### PR TITLE
chore: update the codebase for the newer `golangci-lint` configuration

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-package tasks
-
-const customCallFunctionActivity = "activity"
+package cmd
 
 const (
-	constKeyInput             = "input"
-	constKeyState             = "state"
-	constDefaultItemVar       = "item"
-	constDefaultNamespace     = "default"
-	constScriptLanguagePython = "python"
+	errMsgUnableToLoadWorkflowFile = "Unable to load workflow file"
+	errMsgUnableToReadTargetFile   = "Unable to read target file"
 )

--- a/cmd/constants_test.go
+++ b/cmd/constants_test.go
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package tasks
-
-const customCallFunctionActivity = "activity"
+package cmd
 
 const (
-	constKeyInput             = "input"
-	constKeyState             = "state"
-	constDefaultItemVar       = "item"
-	constDefaultNamespace     = "default"
-	constScriptLanguagePython = "python"
+	testFlagOutput            = "--output"
+	testFlagWorkflow          = "--workflow"
+	testOutputFlowchartTD     = "flowchart TD"
+	testNameUnsupportedFormat = "unsupported output format"
+	testPlaceholderWorkflow   = "PLACEHOLDER_WORKFLOW"
 )

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -63,7 +63,7 @@ Arguments:
 			if err != nil {
 				return gh.FatalError{
 					Cause: err,
-					Msg:   "Unable to load workflow file",
+					Msg:   errMsgUnableToLoadWorkflowFile,
 				}
 			}
 

--- a/cmd/graph_inject.go
+++ b/cmd/graph_inject.go
@@ -112,7 +112,7 @@ Default markers:
 func execGraphInjectAuto(targetFile, outputFormat, endMarker string) error {
 	data, err := os.ReadFile(targetFile)
 	if err != nil {
-		return gh.FatalError{Cause: err, Msg: "Unable to read target file"}
+		return gh.FatalError{Cause: err, Msg: errMsgUnableToReadTargetFile}
 	}
 
 	workflowPath, startMarker, found := graph.ParseEmbeddedPath(string(data), graph.DefaultWorkflowFile)
@@ -136,7 +136,7 @@ func execGraphInject(workflowFile, targetFile, outputFormat, startMarker, endMar
 
 	wf, err := zigflow.LoadFromFile(workflowFile)
 	if err != nil {
-		return gh.FatalError{Cause: err, Msg: "Unable to load workflow file"}
+		return gh.FatalError{Cause: err, Msg: errMsgUnableToLoadWorkflowFile}
 	}
 
 	gen, err := graph.New(graph.Format(outputFormat))
@@ -154,12 +154,12 @@ func execGraphInject(workflowFile, targetFile, outputFormat, startMarker, endMar
 
 	info, err := os.Stat(absTarget)
 	if err != nil {
-		return gh.FatalError{Cause: err, Msg: "Unable to read target file"}
+		return gh.FatalError{Cause: err, Msg: errMsgUnableToReadTargetFile}
 	}
 
 	fileData, err := os.ReadFile(absTarget)
 	if err != nil {
-		return gh.FatalError{Cause: err, Msg: "Unable to read target file"}
+		return gh.FatalError{Cause: err, Msg: errMsgUnableToReadTargetFile}
 	}
 
 	result, err := graph.InjectGraph(string(fileData), startMarker, endMarker, codeBlock)

--- a/cmd/graph_inject_test.go
+++ b/cmd/graph_inject_test.go
@@ -69,12 +69,12 @@ func TestNewGraphInjectCmd(t *testing.T) {
 			Name:          "explicit workflow injects mermaid graph",
 			WorkflowYAML:  validWorkflowYAML,
 			TargetContent: targetWithMarkers,
-			ExtraArgs:     []string{"--workflow", "PLACEHOLDER_WORKFLOW"},
+			ExtraArgs:     []string{testFlagWorkflow, testPlaceholderWorkflow},
 			OutputContains: []string{
 				"<!-- ZIGFLOW_GRAPH_START -->",
 				"<!-- ZIGFLOW_GRAPH_END -->",
 				"```mermaid",
-				"flowchart TD",
+				testOutputFlowchartTD,
 			},
 		},
 		{
@@ -83,12 +83,12 @@ func TestNewGraphInjectCmd(t *testing.T) {
 			WorkflowYAML:  validWorkflowYAML,
 			TargetContent: targetWithCustomMarkers,
 			ExtraArgs: []string{
-				"--workflow", "PLACEHOLDER_WORKFLOW",
+				testFlagWorkflow, testPlaceholderWorkflow,
 				"--start-marker", "{{GRAPH_START}}",
 				"--end-marker", "{{GRAPH_END}}",
 			},
 			OutputContains: []string{
-				"flowchart TD",
+				testOutputFlowchartTD,
 				"{{GRAPH_START}}",
 				"{{GRAPH_END}}",
 			},
@@ -97,13 +97,13 @@ func TestNewGraphInjectCmd(t *testing.T) {
 			Name:          "non-existent workflow file",
 			WorkflowYAML:  validWorkflowYAML,
 			TargetContent: targetWithMarkers,
-			ExtraArgs:     []string{"--workflow", "/nonexistent/workflow.yaml"},
+			ExtraArgs:     []string{testFlagWorkflow, "/nonexistent/workflow.yaml"},
 			ExpectError:   true,
 		},
 		{
 			Name:                 "non-existent target file",
 			WorkflowYAML:         validWorkflowYAML,
-			ExtraArgs:            []string{"--workflow", "PLACEHOLDER_WORKFLOW"},
+			ExtraArgs:            []string{testFlagWorkflow, testPlaceholderWorkflow},
 			UseNonExistentTarget: true,
 			ExpectError:          true,
 		},
@@ -112,14 +112,14 @@ func TestNewGraphInjectCmd(t *testing.T) {
 			Name:          "markers not found in target",
 			WorkflowYAML:  validWorkflowYAML,
 			TargetContent: targetWithoutMarkers,
-			ExtraArgs:     []string{"--workflow", "PLACEHOLDER_WORKFLOW"},
+			ExtraArgs:     []string{testFlagWorkflow, testPlaceholderWorkflow},
 			ExpectError:   true,
 		},
 		{
-			Name:          "unsupported output format",
+			Name:          testNameUnsupportedFormat,
 			WorkflowYAML:  validWorkflowYAML,
 			TargetContent: targetWithMarkers,
-			ExtraArgs:     []string{"--workflow", "PLACEHOLDER_WORKFLOW", "--output", "unknown"},
+			ExtraArgs:     []string{testFlagWorkflow, testPlaceholderWorkflow, testFlagOutput, "unknown"},
 			ExpectError:   true,
 		},
 		{
@@ -131,7 +131,7 @@ func TestNewGraphInjectCmd(t *testing.T) {
 				"<!-- ZIGFLOW_GRAPH_START ./workflow.yaml -->",
 				"<!-- ZIGFLOW_GRAPH_END -->",
 				"```mermaid",
-				"flowchart TD",
+				testOutputFlowchartTD,
 			},
 		},
 		{
@@ -174,7 +174,7 @@ func TestNewGraphInjectCmd(t *testing.T) {
 			// Resolve PLACEHOLDER_WORKFLOW in extra args.
 			resolvedArgs := make([]string, len(test.ExtraArgs))
 			for i, a := range test.ExtraArgs {
-				if a == "PLACEHOLDER_WORKFLOW" {
+				if a == testPlaceholderWorkflow {
 					resolvedArgs[i] = workflowPath
 				} else {
 					resolvedArgs[i] = a

--- a/cmd/graph_test.go
+++ b/cmd/graph_test.go
@@ -38,19 +38,19 @@ func TestNewGraphCmd(t *testing.T) {
 		{
 			Name:           "valid workflow produces mermaid output",
 			Content:        validWorkflowYAML,
-			OutputContains: []string{"flowchart TD", "step"},
+			OutputContains: []string{testOutputFlowchartTD, "step"},
 		},
 		{
 			Name:           "explicit --output mermaid flag",
 			Content:        validWorkflowYAML,
-			ExtraArgs:      []string{"--output", "mermaid"},
-			OutputContains: []string{"flowchart TD"},
+			ExtraArgs:      []string{testFlagOutput, "mermaid"},
+			OutputContains: []string{testOutputFlowchartTD},
 		},
 		{
 			Name:           "explicit -o shorthand flag",
 			Content:        validWorkflowYAML,
 			ExtraArgs:      []string{"-o", "mermaid"},
-			OutputContains: []string{"flowchart TD"},
+			OutputContains: []string{testOutputFlowchartTD},
 		},
 		{
 			Name:        "non-existent file",
@@ -68,9 +68,9 @@ func TestNewGraphCmd(t *testing.T) {
 			ExpectError: true,
 		},
 		{
-			Name:        "unsupported output format",
+			Name:        testNameUnsupportedFormat,
 			Content:     validWorkflowYAML,
-			ExtraArgs:   []string{"--output", "unknown"},
+			ExtraArgs:   []string{testFlagOutput, "unknown"},
 			ExpectError: true,
 		},
 	}

--- a/cmd/run/command_test.go
+++ b/cmd/run/command_test.go
@@ -38,19 +38,19 @@ func TestPreRunE_VersioningValidation(t *testing.T) {
 	}{
 		{
 			name:             "invalid versioning type returns error when versioning enabled",
-			enableVersioning: "true",
+			enableVersioning: testEnableVersioningTrue,
 			versioningType:   "not-a-valid-type",
 			wantErr:          true,
 			errContains:      "invalid default versioning behaviour type",
 		},
 		{
 			name:             "valid pinned type succeeds",
-			enableVersioning: "true",
+			enableVersioning: testEnableVersioningTrue,
 			versioningType:   "pinned",
 		},
 		{
 			name:             "valid autoupgrade type succeeds",
-			enableVersioning: "true",
+			enableVersioning: testEnableVersioningTrue,
 			versioningType:   "autoupgrade",
 		},
 		{

--- a/cmd/run/constants_test.go
+++ b/cmd/run/constants_test.go
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package tasks
+package run
 
-const customCallFunctionActivity = "activity"
-
+// Test constants shared across the cmd/run test suite to satisfy the goconst
+// linter, which requires string literals appearing 3+ times to be named.
 const (
-	constKeyInput             = "input"
-	constKeyState             = "state"
-	constDefaultItemVar       = "item"
-	constDefaultNamespace     = "default"
-	constScriptLanguagePython = "python"
+	testEnableVersioningTrue = "true"
+	testWorkflowPathA        = "/a/workflow.yaml"
+	testDirectoryGlob        = "*.yaml"
+	testTemporalServerName   = "your-namespace.tmprl.cloud"
+	testSourceFileA          = "a.yaml"
+	testSourceFileB          = "b.yaml"
+	testWorkflowType         = "wf"
 )

--- a/cmd/run/watch_test.go
+++ b/cmd/run/watch_test.go
@@ -85,9 +85,9 @@ func TestChangedFilesDeduplication(t *testing.T) {
 	changedFiles := make(map[string]struct{})
 
 	events := []fsnotify.Event{
-		{Name: "/a/workflow.yaml", Op: fsnotify.Write},
-		{Name: "/a/workflow.yaml", Op: fsnotify.Write},
-		{Name: "/a/workflow.yaml", Op: fsnotify.Rename},
+		{Name: testWorkflowPathA, Op: fsnotify.Write},
+		{Name: testWorkflowPathA, Op: fsnotify.Write},
+		{Name: testWorkflowPathA, Op: fsnotify.Rename},
 		{Name: "/b/other.yaml", Op: fsnotify.Create},
 	}
 
@@ -98,7 +98,7 @@ func TestChangedFilesDeduplication(t *testing.T) {
 	}
 
 	assert.Len(t, changedFiles, 2, "duplicate paths must be deduplicated")
-	assert.Contains(t, changedFiles, "/a/workflow.yaml")
+	assert.Contains(t, changedFiles, testWorkflowPathA)
 	assert.Contains(t, changedFiles, "/b/other.yaml")
 }
 
@@ -106,8 +106,8 @@ func TestChangedFilesNonWatchableEventsIgnored(t *testing.T) {
 	changedFiles := make(map[string]struct{})
 
 	events := []fsnotify.Event{
-		{Name: "/a/workflow.yaml", Op: fsnotify.Remove},
-		{Name: "/a/workflow.yaml", Op: fsnotify.Chmod},
+		{Name: testWorkflowPathA, Op: fsnotify.Remove},
+		{Name: testWorkflowPathA, Op: fsnotify.Chmod},
 	}
 
 	for _, e := range events {
@@ -131,7 +131,7 @@ func TestRefreshWatcher_AddsDiscoveredFiles(t *testing.T) {
 
 	opts := &runOptions{
 		Files:         []string{p},
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	}
 
 	require.NoError(t, refreshWatcher(w, opts))
@@ -157,7 +157,7 @@ func TestRefreshWatcher_RemovesStaleAndReAdds(t *testing.T) {
 	// refreshWatcher should remove p1 and add both p1 and p2.
 	opts := &runOptions{
 		Files:         []string{p1, p2},
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	}
 	require.NoError(t, refreshWatcher(w, opts))
 
@@ -173,7 +173,7 @@ func TestRefreshWatcher_ReturnsErrorWhenNoFiles(t *testing.T) {
 	defer func() { _ = w.Close() }()
 
 	// No files and no directory: discoverWorkflowFiles must fail.
-	opts := &runOptions{DirectoryGlob: "*.yaml"}
+	opts := &runOptions{DirectoryGlob: testDirectoryGlob}
 	err = refreshWatcher(w, opts)
 	assert.Error(t, err)
 }
@@ -206,7 +206,7 @@ func TestRefreshWatcher_PreservesWatchesOnAddFailure(t *testing.T) {
 	nonExistent := filepath.Join(dir, "does-not-exist.yaml")
 	opts := &runOptions{
 		Files:         []string{nonExistent, p},
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	}
 
 	err = refreshWatcher(w, opts)
@@ -234,7 +234,7 @@ func TestRefreshWatcher_RemovesStaleWatch(t *testing.T) {
 	// Target only p1; p2 should be removed.
 	opts := &runOptions{
 		Files:         []string{p1},
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	}
 	require.NoError(t, refreshWatcher(w, opts))
 
@@ -260,7 +260,7 @@ func TestHandleDebounce_EmptyChangedFilesIsNoop(t *testing.T) {
 	current := []worker.Worker(nil)
 	changedFiles := make(map[string]struct{})
 
-	next, remaining := handleDebounce(w, nil, &runOptions{Files: []string{p}, DirectoryGlob: "*.yaml"}, nil, changedFiles, current)
+	next, remaining := handleDebounce(w, nil, &runOptions{Files: []string{p}, DirectoryGlob: testDirectoryGlob}, nil, changedFiles, current)
 
 	assert.Equal(t, current, next, "worker slice must be unchanged when changedFiles is empty")
 	assert.Empty(t, remaining)
@@ -283,7 +283,7 @@ func TestHandleDebounce_KeepsCurrentWorkersOnReloadFailure(t *testing.T) {
 
 	// opts with no files: prepareRegistrations will fail before reaching
 	// buildWorkersByTaskQueue, so no Temporal client is needed.
-	opts := &runOptions{DirectoryGlob: "*.yaml"}
+	opts := &runOptions{DirectoryGlob: testDirectoryGlob}
 	next, remaining := handleDebounce(w, nil, opts, nil, changedFiles, current)
 
 	assert.Empty(t, remaining, "changedFiles must be cleared regardless of reload outcome")

--- a/cmd/run/workers_test.go
+++ b/cmd/run/workers_test.go
@@ -69,9 +69,9 @@ func TestInitTemporalClient_ServerNamePropagation(t *testing.T) {
 		{
 			name:           "server name is propagated when TLS is enabled",
 			tlsEnabled:     true,
-			serverName:     "your-namespace.tmprl.cloud",
+			serverName:     testTemporalServerName,
 			expectTLSBlock: true,
-			expectSNI:      "your-namespace.tmprl.cloud",
+			expectSNI:      testTemporalServerName,
 		},
 		{
 			name:           "empty server name leaves SNI unset when TLS is enabled",
@@ -83,7 +83,7 @@ func TestInitTemporalClient_ServerNamePropagation(t *testing.T) {
 		{
 			name:           "no TLS block when TLS is disabled, even with server name set",
 			tlsEnabled:     false,
-			serverName:     "your-namespace.tmprl.cloud",
+			serverName:     testTemporalServerName,
 			expectTLSBlock: false,
 		},
 	}

--- a/cmd/run/workflows_test.go
+++ b/cmd/run/workflows_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestDiscoverWorkflowFiles_NoFilesError(t *testing.T) {
 	_, err := discoverWorkflowFiles(&runOptions{
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "No workflow files found")
@@ -41,7 +41,7 @@ func TestDiscoverWorkflowFiles_ExplicitFiles(t *testing.T) {
 
 	files, err := discoverWorkflowFiles(&runOptions{
 		Files:         []string{p},
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	})
 	require.NoError(t, err)
 	assert.Len(t, files, 1)
@@ -55,7 +55,7 @@ func TestDiscoverWorkflowFiles_DirectoryGlob(t *testing.T) {
 
 	files, err := discoverWorkflowFiles(&runOptions{
 		DirectoryPath: dir,
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	})
 	require.NoError(t, err)
 	assert.Len(t, files, 2)
@@ -69,7 +69,7 @@ func TestDiscoverWorkflowFiles_MergesFilesAndDirectory(t *testing.T) {
 	files, err := discoverWorkflowFiles(&runOptions{
 		Files:         []string{p1},
 		DirectoryPath: dir,
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	})
 	require.NoError(t, err)
 	// p1 discovered by both sources; must appear exactly once.
@@ -85,7 +85,7 @@ func TestDiscoverWorkflowFiles_DeduplicatesRelativeAndAbsolute(t *testing.T) {
 	// Pass both the absolute path and a path that resolves to the same file.
 	files, err := discoverWorkflowFiles(&runOptions{
 		Files:         []string{p, p},
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	})
 	require.NoError(t, err)
 	assert.Len(t, files, 1)
@@ -95,7 +95,7 @@ func TestDiscoverWorkflowFiles_InvalidGlobError(t *testing.T) {
 	// An invalid directory causes the glob to fail.
 	_, err := discoverWorkflowFiles(&runOptions{
 		DirectoryPath: string([]byte{0}), // NUL in path is rejected by the OS
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 	})
 	assert.Error(t, err)
 }
@@ -168,8 +168,8 @@ do:
 
 func TestValidateWorkflowConflicts_DuplicateNameSameQueue(t *testing.T) {
 	regs := []*workflowRegistration{
-		{SourceFile: "a.yaml", TaskQueue: "q", WorkflowType: "wf"},
-		{SourceFile: "b.yaml", TaskQueue: "q", WorkflowType: "wf"},
+		{SourceFile: testSourceFileA, TaskQueue: "q", WorkflowType: testWorkflowType},
+		{SourceFile: testSourceFileB, TaskQueue: "q", WorkflowType: testWorkflowType},
 	}
 	err := validateWorkflowConflicts(regs)
 	assert.Error(t, err)
@@ -178,16 +178,16 @@ func TestValidateWorkflowConflicts_DuplicateNameSameQueue(t *testing.T) {
 
 func TestValidateWorkflowConflicts_SameNameDifferentQueues(t *testing.T) {
 	regs := []*workflowRegistration{
-		{SourceFile: "a.yaml", TaskQueue: "q1", WorkflowType: "wf"},
-		{SourceFile: "b.yaml", TaskQueue: "q2", WorkflowType: "wf"},
+		{SourceFile: testSourceFileA, TaskQueue: "q1", WorkflowType: testWorkflowType},
+		{SourceFile: testSourceFileB, TaskQueue: "q2", WorkflowType: testWorkflowType},
 	}
 	assert.NoError(t, validateWorkflowConflicts(regs))
 }
 
 func TestValidateWorkflowConflicts_DifferentNamesSameQueue(t *testing.T) {
 	regs := []*workflowRegistration{
-		{SourceFile: "a.yaml", TaskQueue: "q", WorkflowType: "wf1"},
-		{SourceFile: "b.yaml", TaskQueue: "q", WorkflowType: "wf2"},
+		{SourceFile: testSourceFileA, TaskQueue: "q", WorkflowType: "wf1"},
+		{SourceFile: testSourceFileB, TaskQueue: "q", WorkflowType: "wf2"},
 	}
 	assert.NoError(t, validateWorkflowConflicts(regs))
 }
@@ -201,7 +201,7 @@ func TestPrepareRegistrations_HappyPath(t *testing.T) {
 
 	opts := &runOptions{
 		DirectoryPath: dir,
-		DirectoryGlob: "*.yaml",
+		DirectoryGlob: testDirectoryGlob,
 		Validate:      false,
 	}
 

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -30,15 +30,15 @@ func TestNewSchemaCmd(t *testing.T) {
 	}{
 		{
 			Name: "JSON output",
-			Args: []string{"--output", "json"},
+			Args: []string{testFlagOutput, "json"},
 		},
 		{
 			Name: "YAML output",
-			Args: []string{"--output", "yaml"},
+			Args: []string{testFlagOutput, "yaml"},
 		},
 		{
-			Name:        "unsupported output format",
-			Args:        []string{"--output", "toml"},
+			Name:        testNameUnsupportedFormat,
+			Args:        []string{testFlagOutput, "toml"},
 			ExpectError: true,
 		},
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -69,7 +69,7 @@ Arguments:
 			if err != nil {
 				return gh.FatalError{
 					Cause: err,
-					Msg:   "Unable to load workflow file",
+					Msg:   errMsgUnableToLoadWorkflowFile,
 				}
 			}
 

--- a/examples/for-loop/main.go
+++ b/examples/for-loop/main.go
@@ -28,6 +28,8 @@ import (
 	"go.temporal.io/sdk/client"
 )
 
+const keyUserID = "userId"
+
 func exec() error {
 	// The client is a heavyweight object that should be created once per process.
 	c, err := temporal.NewConnectionWithEnvvars(
@@ -54,13 +56,13 @@ func exec() error {
 		},
 		"data": []any{
 			map[string]any{
-				"userId": 3,
+				keyUserID: 3,
 			},
 			map[string]any{
-				"userId": 4,
+				keyUserID: 4,
 			},
 			map[string]any{
-				"userId": 5,
+				keyUserID: 5,
 			},
 		},
 	})

--- a/pkg/graph/mermaid_test.go
+++ b/pkg/graph/mermaid_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/zigflow/zigflow/pkg/graph"
 )
 
+const (
+	callHTTP  = "http"
+	methodGet = "get"
+)
+
 // makeWF is a helper that constructs a minimal Workflow for testing.
 func makeWF(name string, tasks ...*model.TaskItem) *model.Workflow {
 	tl := model.TaskList(make([]*model.TaskItem, len(tasks)))
@@ -110,8 +115,8 @@ func TestMermaid_HTTPLabel(t *testing.T) {
 	ep := model.NewEndpoint("https://example.com/api")
 	wf := makeWF("mywf",
 		taskItem("fetch", &model.CallHTTP{
-			Call: "http",
-			With: model.HTTPArguments{Method: "get", Endpoint: ep},
+			Call: callHTTP,
+			With: model.HTTPArguments{Method: methodGet, Endpoint: ep},
 		}),
 	)
 	out, err := gen.Generate(wf)
@@ -233,7 +238,7 @@ func TestMermaid_TryNode(t *testing.T) {
 	gen, _ := graph.New(graph.FormatMermaid)
 	tryTasks := model.TaskList([]*model.TaskItem{
 		taskItem("risky", &model.CallHTTP{
-			Call: "http",
+			Call: callHTTP,
 			With: model.HTTPArguments{
 				Method:   "get",
 				Endpoint: model.NewEndpoint("https://example.com"),
@@ -347,8 +352,8 @@ func TestMermaid_LabelTruncation(t *testing.T) {
 	ep := model.NewEndpoint(longURL)
 	wf := makeWF("mywf",
 		taskItem("fetch", &model.CallHTTP{
-			Call: "http",
-			With: model.HTTPArguments{Method: "get", Endpoint: ep},
+			Call: callHTTP,
+			With: model.HTTPArguments{Method: methodGet, Endpoint: ep},
 		}),
 	)
 	out, err := gen.Generate(wf)

--- a/pkg/mcp/get_example.go
+++ b/pkg/mcp/get_example.go
@@ -51,7 +51,7 @@ func getExampleFromFS(fsys fs.FS, name string) (GetExampleOutput, error) {
 		return GetExampleOutput{
 			Errors: []GetExampleError{
 				{
-					Stage:   "input",
+					Stage:   stageInput,
 					Message: "name is required",
 				},
 			},
@@ -78,7 +78,7 @@ func getExampleFromFS(fsys fs.FS, name string) (GetExampleOutput, error) {
 		}
 
 		return GetExampleOutput{Errors: []GetExampleError{{
-			Stage:   "input",
+			Stage:   stageInput,
 			Message: fmt.Sprintf("example %q not found; available: %s", name, strings.Join(available, ", ")),
 		}}}, nil
 	}

--- a/pkg/mcp/get_example_test.go
+++ b/pkg/mcp/get_example_test.go
@@ -29,7 +29,7 @@ import (
 // signalFS builds a minimal embedded FS containing the "signal" example.
 func signalFS() fstest.MapFS {
 	return exampleFS(map[string]string{
-		"signal/workflow.yaml": "document:\n  title: Signal\n  summary: Signal example\ndo: []\n",
+		signalWorkflowYAML: "document:\n  title: Signal\n  summary: Signal example\ndo: []\n",
 	})
 }
 

--- a/pkg/mcp/get_schema.go
+++ b/pkg/mcp/get_schema.go
@@ -57,7 +57,7 @@ func (m *MCP) GetSchema(
 
 	if format != outputFormatJSON && format != outputFormatYAML {
 		return nil, GetSchemaOutput{Errors: []GetSchemaError{{
-			Stage:   "input",
+			Stage:   stageInput,
 			Message: `output must be "json" or "yaml"`,
 		}}}, nil
 	}

--- a/pkg/mcp/list_examples_test.go
+++ b/pkg/mcp/list_examples_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const signalWorkflowYAML = "signal/workflow.yaml"
+
 func exampleFS(entries map[string]string) fstest.MapFS {
 	fsys := fstest.MapFS{}
 	for path, content := range entries {
@@ -40,8 +42,8 @@ func workflowFile(title, summary string) string {
 
 func TestListExamples_ReturnsExamples(t *testing.T) {
 	fsys := exampleFS(map[string]string{
-		"signal/workflow.yaml": workflowFile("Signal Listeners", "Listen for Temporal signal events"),
-		"query/workflow.yaml":  workflowFile("Query Listeners", "Listen for Temporal query events"),
+		signalWorkflowYAML:    workflowFile("Signal Listeners", "Listen for Temporal signal events"),
+		"query/workflow.yaml": workflowFile("Query Listeners", "Listen for Temporal query events"),
 	})
 
 	out, err := listExamplesFromFS(fsys)
@@ -70,7 +72,7 @@ func TestListExamples_StableOrder(t *testing.T) {
 func TestListExamples_NamesNonEmpty(t *testing.T) {
 	fsys := exampleFS(map[string]string{
 		"hello-world/workflow.yaml": workflowFile("Hello World", "Hello world with Zigflow"),
-		"signal/workflow.yaml":      workflowFile("Signal Listeners", "Listen for Temporal signal events"),
+		signalWorkflowYAML:          workflowFile("Signal Listeners", "Listen for Temporal signal events"),
 	})
 
 	out, err := listExamplesFromFS(fsys)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -20,6 +20,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const stageInput = "input"
+
 type MCP struct {
 	version string
 }

--- a/pkg/mcp/validate_workflow.go
+++ b/pkg/mcp/validate_workflow.go
@@ -52,7 +52,7 @@ func (m *MCP) ValidateWorkflow(
 	if strings.TrimSpace(input.YAML) == "" {
 		return nil, ValidateWorkflowOutput{
 			Errors: []ValidateWorkflowError{{
-				Stage:   "input",
+				Stage:   stageInput,
 				Message: "yaml is required",
 			}},
 		}, nil

--- a/pkg/observability/prometheus.go
+++ b/pkg/observability/prometheus.go
@@ -20,36 +20,42 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	metricNamespace = "zigflow"
+	metricSubsystem = "events"
+	labelEmitter    = "emitter"
+)
+
 var (
 	EventsEmittedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "zigflow",
-			Subsystem: "events",
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
 			Name:      "emitted_total",
 			Help:      "Total number of CloudEvents emitted",
 		},
-		[]string{"emitter", "type"},
+		[]string{labelEmitter, "type"},
 	)
 
 	EventsUndeliveredTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "zigflow",
-			Subsystem: "events",
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
 			Name:      "undelivered_total",
 			Help:      "Total number of CloudEvents that failed delivery",
 		},
-		[]string{"emitter", "type"},
+		[]string{labelEmitter, "type"},
 	)
 
 	EventEmitDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "zigflow",
-			Subsystem: "events",
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
 			Name:      "emit_duration_seconds",
 			Help:      "Time taken to emit CloudEvents",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"emitter"},
+		[]string{labelEmitter},
 	)
 )
 

--- a/pkg/schema/constants.go
+++ b/pkg/schema/constants.go
@@ -50,4 +50,66 @@ const (
 	urlPattern = `^[A-Za-z][A-Za-z0-9+\-.]*://.*`
 
 	ref = "#/$defs/%s"
+
+	// Definition keys used in buildDefinitions() and SchemaRef().
+	defCommonMetadata   = "commonMetadata"
+	defDocumentMetadata = "documentMetadata"
+
+	// Schema property names used across schema definitions and tests.
+	propDo              = "do"
+	propDocument        = "document"
+	propCall            = "call"
+	propArguments       = "arguments"
+	propActivityOptions = "activityOptions"
+	propDisableEager    = "disableEagerExecution"
+	propCanMaxHistory   = "canMaxHistoryLength"
+	propZigflowID       = "__zigflow_id"
+	propCommand         = "command"
+	propCron            = "cron"
+
+	// JSON Schema type values.
+	typeArray   = "array"
+	typeBoolean = "boolean"
+	typeInteger = "integer"
+	typeObject  = "object"
+	typeString  = "string"
+
+	// Definition keys used in buildDefinitions() and SchemaRef().
+	defOutput       = "output"
+	defSchema       = "schema"
+	defTaskMetadata = "taskMetadata"
+	defTimeout      = "timeout"
+
+	// Additional schema property names.
+	propEndpoint             = "endpoint"
+	propError                = "error"
+	propExport               = "export"
+	propInput                = "input"
+	propMethod               = "method"
+	propMetadata             = "metadata"
+	propHeartbeatTimeout     = "heartbeatTimeout"
+	propMaximumAttempts      = "maximumAttempts"
+	propHeartbeat            = "heartbeat"
+	propEnvironment          = "environment"
+	propDSL                  = "dsl"
+	propMinutes              = "minutes"
+	propWith                 = "with"
+	propName                 = "name"
+	propOutput               = "output"
+	propSchema               = "schema"
+	propRetryPolicy          = "retryPolicy"
+	propTaskQueue            = "taskQueue"
+	propType                 = "type"
+	propScheduleWorkflowName = "scheduleWorkflowName"
+	propScheduleID           = "scheduleId"
+	propScheduleInput        = "scheduleInput"
+	propSeconds              = "seconds"
+	propStartToCloseTimeout  = "startToCloseTimeout"
+	propSummary              = "summary"
+	propURI                  = "uri"
+	propSource               = "source"
+	propSet                  = "set"
+	propThen                 = "then"
+	propWorkflowType         = "workflowType"
+	propVersion              = "version"
 )

--- a/pkg/schema/definitions.go
+++ b/pkg/schema/definitions.go
@@ -26,36 +26,36 @@ import (
 func buildDefinitions() map[string]*jsonschema.Schema {
 	return map[string]*jsonschema.Schema{
 		"callTask":                 callTaskDefinition,
-		"commonMetadata":           commonMetadataDefinition,
+		defCommonMetadata:          commonMetadataDefinition,
 		"containerLifetime":        containerLifetimeDefinition,
 		"doTask":                   doTaskDefinition,
-		"documentMetadata":         documentMetadataDefinition,
+		defDocumentMetadata:        documentMetadataDefinition,
 		"duration":                 durationDefinition,
-		"endpoint":                 endpointDefinition,
-		"error":                    errorDefinition,
+		propEndpoint:               endpointDefinition,
+		propError:                  errorDefinition,
 		"eventConsumptionStrategy": eventConsumptionStrategyDefinition,
 		"eventFilter":              eventFilterDefinition,
 		"eventProperties":          eventPropertiesDefinition,
-		"export":                   exportDefinition,
+		propExport:                 exportDefinition,
 		"externalResource":         externalResourceDefinition,
 		"flowDirective":            flowDirectiveDefinition,
 		"forkTask":                 forkTaskDefinition,
 		"forTask":                  forTaskDefinition,
-		"input":                    inputDefinition,
+		propInput:                  inputDefinition,
 		"listenTask":               listenTaskDefinition,
-		"output":                   outputDefinition,
+		defOutput:                  outputDefinition,
 		"raiseTask":                raiseTaskDefinition,
 		"runTask":                  runTaskDefinition,
 		"runtimeExpression":        runtimeExpressionDefinition,
-		"schema":                   schemaDefinition,
+		defSchema:                  schemaDefinition,
 		"setTask":                  setTaskDefinition,
 		"subscriptionIterator":     subscriptionIteratorDefinition,
 		"switchTask":               switchTaskDefinition,
 		"task":                     taskDefinition,
 		"taskBase":                 taskBaseDefinition,
 		"taskList":                 taskListDefinition,
-		"taskMetadata":             taskMetadataDefinition,
-		"timeout":                  timeoutDefinition,
+		defTaskMetadata:            taskMetadataDefinition,
+		defTimeout:                 timeoutDefinition,
 		"tryTask":                  tryTaskDefinition,
 		"uriTemplate":              uriTemplateDefinition,
 		"waitTask":                 waitTaskDefinition,
@@ -67,38 +67,38 @@ var callTaskDefinition = &jsonschema.Schema{
 	Description: "Defines the call to perform.",
 	OneOf: []*jsonschema.Schema{
 		{
-			Type:                  "object",
+			Type:                  typeObject,
 			Title:                 "CallActivity",
 			Description:           "Defines the external Temporal activity call to perform.",
 			UnevaluatedProperties: falseSchema(),
-			Required:              []string{"call", "with"},
+			Required:              []string{propCall, propWith},
 			AllOf: []*jsonschema.Schema{
 				{Ref: SchemaRef("taskBase")},
 				{
 					Properties: map[string]*jsonschema.Schema{
-						"call": {
-							Type:  "string",
+						propCall: {
+							Type:  typeString,
 							Const: utils.Ptr[any]("activity"),
 						},
-						"with": {
-							Type:                  "object",
+						propWith: {
+							Type:                  typeObject,
 							Title:                 "ActivityArguments",
 							Description:           "The activity call arguments.",
 							UnevaluatedProperties: falseSchema(),
-							Required:              []string{"name", "taskQueue"},
+							Required:              []string{propName, "taskQueue"},
 							Properties: map[string]*jsonschema.Schema{
-								"name": {
-									Type:        "string",
+								propName: {
+									Type:        typeString,
 									Title:       "WithActivityName",
 									Description: "The name of the activity to call on the defined Activity service.",
 								},
 								"taskQueue": {
-									Type:        "string",
+									Type:        typeString,
 									Title:       "WithActivityTaskQueue",
 									Description: "The name of the task queue to call on the defined Activity service.",
 								},
-								"arguments": {
-									Type: "array",
+								propArguments: {
+									Type: typeArray,
 								},
 							},
 						},
@@ -107,34 +107,34 @@ var callTaskDefinition = &jsonschema.Schema{
 			},
 		},
 		{
-			Type:                  "object",
+			Type:                  typeObject,
 			Title:                 "CallGRPC",
 			Description:           "Defines the GRPC call to perform.",
 			UnevaluatedProperties: falseSchema(),
-			Required:              []string{"call", "with"},
+			Required:              []string{propCall, propWith},
 			AllOf: []*jsonschema.Schema{
 				{Ref: SchemaRef("taskBase")},
 				{
 					Properties: map[string]*jsonschema.Schema{
-						"call": {
-							Type:  "string",
+						propCall: {
+							Type:  typeString,
 							Const: utils.Ptr[any]("grpc"),
 						},
-						"with": {
-							Type:                  "object",
+						propWith: {
+							Type:                  typeObject,
 							Title:                 "GRPCArguments",
 							Description:           "The GRPC call arguments.",
 							UnevaluatedProperties: falseSchema(),
-							Required:              []string{"proto", "service", "method"},
+							Required:              []string{"proto", "service", propMethod},
 							Properties: map[string]*jsonschema.Schema{
-								"arguments": {
-									Type:                 "object",
+								propArguments: {
+									Type:                 typeObject,
 									Title:                "WithGRPCArguments",
 									Description:          "The arguments, if any, to call the method with.",
 									AdditionalProperties: trueSchema(),
 								},
-								"method": {
-									Type:        "string",
+								propMethod: {
+									Type:        typeString,
 									Title:       "WithGRPCMethod",
 									Description: "The name of the method to call on the defined GRPC service.",
 								},
@@ -144,24 +144,24 @@ var callTaskDefinition = &jsonschema.Schema{
 									Description: "The proto resource that describes the GRPC service to call.",
 								},
 								"service": {
-									Type:                  "object",
+									Type:                  typeObject,
 									Title:                 "WithGRPCService",
 									UnevaluatedProperties: falseSchema(),
-									Required:              []string{"name", "host"},
+									Required:              []string{propName, "host"},
 									Properties: map[string]*jsonschema.Schema{
 										"host": {
-											Type:        "string",
+											Type:        typeString,
 											Title:       "WithGRPCServiceHost",
 											Description: "The hostname of the GRPC service to call.",
 											Pattern:     domainNamePattern,
 										},
-										"name": {
-											Type:        "string",
+										propName: {
+											Type:        typeString,
 											Title:       "WithGRPCServiceName",
 											Description: "The name of the GRPC service to call.",
 										},
 										"port": {
-											Type:        "integer",
+											Type:        typeInteger,
 											Title:       "WithGRPCServicePort",
 											Description: "The port number of the GRPC service to call.",
 											Minimum:     utils.Ptr(float64(0)),
@@ -176,32 +176,32 @@ var callTaskDefinition = &jsonschema.Schema{
 			},
 		},
 		{
-			Type:                  "object",
+			Type:                  typeObject,
 			Title:                 "CallHTTP",
 			Description:           "Defines the HTTP call to perform.",
 			UnevaluatedProperties: falseSchema(),
-			Required:              []string{"call", "with"},
+			Required:              []string{propCall, propWith},
 			AllOf: []*jsonschema.Schema{
 				{Ref: SchemaRef("taskBase")},
 				{
 					Properties: map[string]*jsonschema.Schema{
-						"call": {
-							Type:  "string",
+						propCall: {
+							Type:  typeString,
 							Const: utils.Ptr[any]("http"),
 						},
-						"with": {
-							Type:                  "object",
+						propWith: {
+							Type:                  typeObject,
 							Title:                 "HTTPArguments",
 							Description:           "The HTTP call arguments.",
 							UnevaluatedProperties: falseSchema(),
-							Required:              []string{"method", "endpoint"},
+							Required:              []string{propMethod, propEndpoint},
 							Properties: map[string]*jsonschema.Schema{
 								"body": {
 									Title:       "HTTPBody",
 									Description: "The body, if any, of the HTTP request to perform.",
 								},
-								"endpoint": {
-									Ref:         SchemaRef("endpoint"),
+								propEndpoint: {
+									Ref:         SchemaRef(propEndpoint),
 									Title:       "HTTPEndpoint",
 									Description: "The HTTP endpoint to send the request to.",
 								},
@@ -210,21 +210,21 @@ var callTaskDefinition = &jsonschema.Schema{
 									Description: "A name/value mapping of the headers, if any, of the HTTP request to perform.",
 									OneOf: []*jsonschema.Schema{
 										{
-											Type: "object",
+											Type: typeObject,
 											AdditionalProperties: &jsonschema.Schema{
-												Type: "string",
+												Type: typeString,
 											},
 										},
 										{Ref: SchemaRef("runtimeExpression")},
 									},
 								},
-								"method": {
-									Type:        "string",
+								propMethod: {
+									Type:        typeString,
 									Title:       "HTTPMethod",
 									Description: "The HTTP method of the HTTP request to perform.",
 								},
-								"output": {
-									Type:        "string",
+								propOutput: {
+									Type:        typeString,
 									Title:       "HTTPOutput",
 									Description: "The http call output format. Defaults to 'content'.",
 									Enum:        []any{"raw", "content", "response"},
@@ -235,16 +235,16 @@ var callTaskDefinition = &jsonschema.Schema{
 									AdditionalProperties: trueSchema(),
 									OneOf: []*jsonschema.Schema{
 										{
-											Type: "object",
+											Type: typeObject,
 											AdditionalProperties: &jsonschema.Schema{
-												Type: "string",
+												Type: typeString,
 											},
 										},
 										{Ref: SchemaRef("runtimeExpression")},
 									},
 								},
 								"redirect": {
-									Type:        "boolean",
+									Type:        typeBoolean,
 									Title:       "HttpRedirect",
 									Description: "Specifies whether redirection status codes (`300-399`) should be treated as errors.",
 								},
@@ -258,33 +258,33 @@ var callTaskDefinition = &jsonschema.Schema{
 }
 
 var commonMetadataDefinition = &jsonschema.Schema{
-	Type:                 "object",
+	Type:                 typeObject,
 	Title:                "CommonMetadata",
 	AdditionalProperties: trueSchema(),
 	Properties: map[string]*jsonschema.Schema{
-		"activityOptions": {
-			Type:                 "object",
+		propActivityOptions: {
+			Type:                 typeObject,
 			Title:                "ActivityOptionsMetadata",
 			AdditionalProperties: trueSchema(),
 			Properties: map[string]*jsonschema.Schema{
-				"disableEagerExecution": {
-					Type: "boolean",
+				propDisableEager: {
+					Type: typeBoolean,
 					Description: "If true, eager execution will not be requested, regardless of worker settings. " +
 						"If false, eager execution may still be disabled at the worker level or may not be requested due to lack of available slots.",
 				},
-				"heartbeatTimeout": {
+				propHeartbeatTimeout: {
 					Ref:         SchemaRef("duration"),
 					Title:       "HeartbeatTimeout",
 					Description: "Heartbeat interval. A heartbeat must be set and be called before the interval passes.",
 				},
 				"priority": {
-					Type:                 "object",
+					Type:                 typeObject,
 					Title:                "Priority",
 					Description:          "Configure an activity's priority and fairness",
 					AdditionalProperties: falseSchema(),
 					Properties: map[string]*jsonschema.Schema{
 						"fairnessKey": {
-							Type:        "string",
+							Type:        typeString,
 							Title:       "FairnessKey",
 							Description: "A short string that's used as a key for a fairness balancing mechanism",
 						},
@@ -294,15 +294,15 @@ var commonMetadataDefinition = &jsonschema.Schema{
 							Description: "Weight of a task can come from multiple sources for flexibility",
 						},
 						"priorityKey": {
-							Type:        "integer",
+							Type:        typeInteger,
 							Title:       "PriorityKey",
 							Description: "A positive integer from 1 to n, where smaller integers correspond to higher priorities (tasks run sooner)",
 							Minimum:     utils.Ptr[float64](1),
 						},
 					},
 				},
-				"retryPolicy": {
-					Type:                 "object",
+				propRetryPolicy: {
+					Type:                 typeObject,
 					Title:                "RetryPolicy",
 					Description:          "Specifies how to retry an Activity if an error occurs",
 					AdditionalProperties: falseSchema(),
@@ -318,8 +318,8 @@ var commonMetadataDefinition = &jsonschema.Schema{
 							Title:       "InitialInterval",
 							Description: "Backoff interval for the first retry. If BackoffCoefficient is 1.0 then it is used for all retries.",
 						},
-						"maximumAttempts": {
-							Type:        "integer",
+						propMaximumAttempts: {
+							Type:        typeInteger,
 							Title:       "MaximumAttempts",
 							Description: "Maximum number of attempts. When exceeded the retries stop even if not expired yet.",
 							Default:     json.RawMessage("5"),
@@ -330,12 +330,12 @@ var commonMetadataDefinition = &jsonschema.Schema{
 							Description: "Maximum backoff interval between retries.",
 						},
 						"nonRetryableErrorTypes": {
-							Type:        "array",
+							Type:        typeArray,
 							Title:       "NonRetryableErrorTypes",
 							Description: "Temporal server will stop retry if error type matches this list.",
 							Default:     json.RawMessage("[]"),
 							Items: &jsonschema.Schema{
-								Type: "string",
+								Type: typeString,
 							},
 						},
 					},
@@ -351,14 +351,14 @@ var commonMetadataDefinition = &jsonschema.Schema{
 					Description: "Time that the Activity Task can stay in the Task Queue before it is picked up by a Worker. " +
 						"Do not specify this timeout unless using host specific Task Queues for Activity Tasks are being used for routing.",
 				},
-				"startToCloseTimeout": {
+				propStartToCloseTimeout: {
 					Ref:         SchemaRef("duration"),
 					Title:       "StartToCloseTimeout",
 					Description: "Maximum time of a single Activity execution attempt.",
 					Default:     json.RawMessage(`{"seconds": 15}`),
 				},
-				"summary": {
-					Type:        "string",
+				propSummary: {
+					Type:        typeString,
 					Description: "Add a summary to the Temporal workflow UI.",
 				},
 			},
@@ -367,14 +367,14 @@ var commonMetadataDefinition = &jsonschema.Schema{
 }
 
 var containerLifetimeDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "ContainerLifetime",
 	Description:           "The configuration of a container's lifetime",
 	UnevaluatedProperties: falseSchema(),
 	Required:              []string{"cleanup"},
 	Properties: map[string]*jsonschema.Schema{
 		"cleanup": {
-			Type:        "string",
+			Type:        typeString,
 			Title:       "ContainerCleanupPolicy",
 			Description: "The container cleanup policy to use",
 			Enum:        []any{"always", "never"},
@@ -384,16 +384,16 @@ var containerLifetimeDefinition = &jsonschema.Schema{
 }
 
 var doTaskDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "DoTask",
 	Description:           "Allows to execute a list of tasks in sequence.",
 	UnevaluatedProperties: falseSchema(),
-	Required:              []string{"do"},
+	Required:              []string{propDo},
 	AllOf: []*jsonschema.Schema{
 		{Ref: SchemaRef("taskBase")},
 		{
 			Properties: map[string]*jsonschema.Schema{
-				"do": {
+				propDo: {
 					Ref:         SchemaRef("taskList"),
 					Title:       "DoTaskConfiguration",
 					Description: "The configuration of the tasks to perform sequentially.",
@@ -404,28 +404,28 @@ var doTaskDefinition = &jsonschema.Schema{
 }
 
 var documentMetadataDefinition = &jsonschema.Schema{
-	Type:                 "object",
+	Type:                 typeObject,
 	Title:                "DocumentMetadata",
 	AdditionalProperties: trueSchema(),
 	Properties: map[string]*jsonschema.Schema{
-		"canMaxHistoryLength": {
-			Type:        "integer",
+		propCanMaxHistory: {
+			Type:        typeInteger,
 			Title:       "ContinueAsNewMaxHistoryLength",
 			Description: "Allows you to test the Continue-As-New functionality by specifying the max history length before triggering.",
 		},
-		"scheduleWorkflowName": {
-			Type:        "string",
+		propScheduleWorkflowName: {
+			Type:        typeString,
 			Title:       "ScheduleWorkflowName",
 			Description: "Set the workflow name to trigger - this will either be the document.workflowType or the Do task",
 			MinLength:   utils.Ptr(1),
 		},
-		"scheduleId": {
-			Type:        "string",
+		propScheduleID: {
+			Type:        typeString,
 			Title:       "ScheduleID",
 			Description: "Set the schedule ID. If not set, this will to zigflow_<workflow.document.workflowType>",
 		},
-		"scheduleInput": {
-			Type:        "array",
+		propScheduleInput: {
+			Type:        typeArray,
 			Title:       "ScheduleInput",
 			Description: "Set the input.",
 		},
@@ -435,32 +435,32 @@ var documentMetadataDefinition = &jsonschema.Schema{
 var durationDefinition = &jsonschema.Schema{
 	OneOf: []*jsonschema.Schema{
 		{
-			Type:                  "object",
+			Type:                  typeObject,
 			MinProperties:         utils.Ptr(1),
 			UnevaluatedProperties: falseSchema(),
 			Properties: map[string]*jsonschema.Schema{
 				"days": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Title:       "DurationDays",
 					Description: "Number of days, if any.",
 				},
 				"hours": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Title:       "DurationHours",
 					Description: "Number of hours, if any.",
 				},
-				"minutes": {
-					Type:        "integer",
+				propMinutes: {
+					Type:        typeInteger,
 					Title:       "DurationMinutes",
 					Description: "Number of minutes, if any.",
 				},
-				"seconds": {
-					Type:        "integer",
+				propSeconds: {
+					Type:        typeInteger,
 					Title:       "DurationSeconds",
 					Description: "Number of seconds, if any.",
 				},
 				"milliseconds": {
-					Type:        "integer",
+					Type:        typeInteger,
 					Title:       "DurationMilliseconds",
 					Description: "Number of milliseconds, if any.",
 				},
@@ -476,12 +476,12 @@ var endpointDefinition = &jsonschema.Schema{
 		{Ref: SchemaRef("runtimeExpression")},
 		{Ref: SchemaRef("uriTemplate")},
 		{
-			Type:                  "object",
+			Type:                  typeObject,
 			Title:                 "EndpointConfiguration",
 			UnevaluatedProperties: falseSchema(),
-			Required:              []string{"uri"},
+			Required:              []string{propURI},
 			Properties: map[string]*jsonschema.Schema{
-				"uri": {
+				propURI: {
 					Title:       "EndpointUri",
 					Description: "The endpoint's URI.",
 					OneOf: []*jsonschema.Schema{
@@ -503,11 +503,11 @@ var endpointDefinition = &jsonschema.Schema{
 }
 
 var errorDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "Error",
 	Description:           "Represents an error.",
 	UnevaluatedProperties: falseSchema(),
-	Required:              []string{"type", "status"},
+	Required:              []string{propType, "status"},
 	Properties: map[string]*jsonschema.Schema{
 		"detail": {
 			Title:       "ErrorDetails",
@@ -518,7 +518,7 @@ var errorDefinition = &jsonschema.Schema{
 					Title: "ExpressionErrorDetails",
 				},
 				{
-					Type:  "string",
+					Type:  typeString,
 					Title: "LiteralErrorDetails",
 				},
 			},
@@ -528,7 +528,7 @@ var errorDefinition = &jsonschema.Schema{
 			Description: "A JSON Pointer used to reference the component the error originates from.",
 			OneOf: []*jsonschema.Schema{
 				{
-					Type:        "string",
+					Type:        typeString,
 					Title:       "LiteralErrorInstance",
 					Description: "The literal error instance.",
 					Format:      "json-pointer",
@@ -541,7 +541,7 @@ var errorDefinition = &jsonschema.Schema{
 			},
 		},
 		"status": {
-			Type:        "integer",
+			Type:        typeInteger,
 			Title:       "ErrorStatus",
 			Description: "The status code generated by the origin for this occurrence of the error.",
 		},
@@ -554,12 +554,12 @@ var errorDefinition = &jsonschema.Schema{
 					Title: "ExpressionErrorTitle",
 				},
 				{
-					Type:  "string",
+					Type:  typeString,
 					Title: "LiteralErrorTitle",
 				},
 			},
 		},
-		"type": {
+		propType: {
 			Title:       "ErrorType",
 			Description: "A URI reference that identifies the error type.",
 			OneOf: []*jsonschema.Schema{
@@ -579,7 +579,7 @@ var errorDefinition = &jsonschema.Schema{
 }
 
 var eventConsumptionStrategyDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "EventConsumptionStrategy",
 	Description:           "Describe the event consumption strategy to adopt.",
 	UnevaluatedProperties: falseSchema(),
@@ -589,7 +589,7 @@ var eventConsumptionStrategyDefinition = &jsonschema.Schema{
 			Required: []string{"all"},
 			Properties: map[string]*jsonschema.Schema{
 				"all": {
-					Type:        "array",
+					Type:        typeArray,
 					Title:       "AllEventConsumptionStrategyConfiguration",
 					Description: "A list containing all the events that must be consumed.",
 					Items: &jsonschema.Schema{
@@ -603,7 +603,7 @@ var eventConsumptionStrategyDefinition = &jsonschema.Schema{
 			Required: []string{"any"},
 			Properties: map[string]*jsonschema.Schema{
 				"any": {
-					Type:        "array",
+					Type:        typeArray,
 					Title:       "AnyEventConsumptionStrategyConfiguration",
 					Description: "A list containing any of the events to consume.",
 					Items: &jsonschema.Schema{
@@ -627,14 +627,14 @@ var eventConsumptionStrategyDefinition = &jsonschema.Schema{
 }
 
 var eventFilterDefinition = &jsonschema.Schema{
-	Type:  "object",
+	Type:  typeObject,
 	Title: "EventFilter",
 	Description: "An event filter is a mechanism used to selectively process or handle events " +
 		"based on predefined criteria, such as event type, source, or specific attributes.",
 	UnevaluatedProperties: falseSchema(),
-	Required:              []string{"with"},
+	Required:              []string{propWith},
 	Properties: map[string]*jsonschema.Schema{
-		"with": {
+		propWith: {
 			Ref:   SchemaRef("eventProperties"),
 			Title: "WithEvent",
 			Description: "An event filter is a mechanism used to selectively process or handle events " +
@@ -645,7 +645,7 @@ var eventFilterDefinition = &jsonschema.Schema{
 }
 
 var eventPropertiesDefinition = &jsonschema.Schema{
-	Type:                 "object",
+	Type:                 typeObject,
 	Title:                "EventProperties",
 	Description:          "Describes the properties of an event.",
 	AdditionalProperties: trueSchema(),
@@ -659,7 +659,7 @@ var eventPropertiesDefinition = &jsonschema.Schema{
 			},
 		},
 		"datacontenttype": {
-			Type:  "string",
+			Type:  typeString,
 			Title: "EventDataContentType",
 			Description: "Content type of data value. This attribute enables data to carry any type of content, " +
 				"whereby format and encoding might differ from that of the chosen event format.",
@@ -681,11 +681,11 @@ var eventPropertiesDefinition = &jsonschema.Schema{
 			},
 		},
 		"id": {
-			Type:        "string",
+			Type:        typeString,
 			Title:       "EventId",
 			Description: "The event's unique identifier.",
 		},
-		"source": {
+		propSource: {
 			Title:       "EventSource",
 			Description: "Identifies the context in which an event happened.",
 			OneOf: []*jsonschema.Schema{
@@ -694,7 +694,7 @@ var eventPropertiesDefinition = &jsonschema.Schema{
 			},
 		},
 		"subject": {
-			Type:        "string",
+			Type:        typeString,
 			Title:       "EventSubject",
 			Description: "The subject of the event.",
 		},
@@ -703,15 +703,15 @@ var eventPropertiesDefinition = &jsonschema.Schema{
 			Description: "When the event occurred.",
 			OneOf: []*jsonschema.Schema{
 				{
-					Type:   "string",
+					Type:   typeString,
 					Title:  "LiteralTime",
 					Format: "date-time",
 				},
 				{Ref: SchemaRef("runtimeExpression")},
 			},
 		},
-		"type": {
-			Type:        "string",
+		propType: {
+			Type:        typeString,
 			Title:       "EventType",
 			Description: "This attribute contains a value describing the type of event related to the originating occurrence.",
 		},
@@ -719,13 +719,13 @@ var eventPropertiesDefinition = &jsonschema.Schema{
 }
 
 var exportDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "Export",
 	Description:           "Set the content of the context.",
 	UnevaluatedProperties: falseSchema(),
 	Properties: map[string]*jsonschema.Schema{
-		"schema": {
-			Ref:         SchemaRef("schema"),
+		propSchema: {
+			Ref:         SchemaRef(defSchema),
 			Title:       "ExportSchema",
 			Description: "The schema used to describe and validate the workflow context.",
 		},
@@ -733,27 +733,27 @@ var exportDefinition = &jsonschema.Schema{
 			Title:       "ExportAs",
 			Description: "A runtime expression, if any, used to export the output data to the context.",
 			OneOf: []*jsonschema.Schema{
-				{Type: "string"},
-				{Type: "object"},
+				{Type: typeString},
+				{Type: typeObject},
 			},
 		},
 	},
 }
 
 var externalResourceDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "ExternalResource",
 	Description:           "Represents an external resource.",
 	UnevaluatedProperties: falseSchema(),
-	Required:              []string{"endpoint"},
+	Required:              []string{propEndpoint},
 	Properties: map[string]*jsonschema.Schema{
-		"endpoint": {
-			Ref:         SchemaRef("endpoint"),
+		propEndpoint: {
+			Ref:         SchemaRef(propEndpoint),
 			Title:       "ExternalResourceEndpoint",
 			Description: "The endpoint of the external resource.",
 		},
-		"name": {
-			Type:        "string",
+		propName: {
+			Type:        typeString,
 			Title:       "ExternalResourceName",
 			Description: "The name of the external resource, if any.",
 		},
@@ -766,18 +766,18 @@ var flowDirectiveDefinition = &jsonschema.Schema{
 	AnyOf: []*jsonschema.Schema{
 		{
 			Title:   "FlowDirectiveEnum",
-			Type:    "string",
+			Type:    typeString,
 			Enum:    []any{"continue", "exit", "end"},
 			Default: json.RawMessage(`"continue"`),
 		},
 		{
-			Type: "string",
+			Type: typeString,
 		},
 	},
 }
 
 var forkTaskDefinition = &jsonschema.Schema{
-	Type:  "object",
+	Type:  typeObject,
 	Title: "ForkTask",
 	Description: "Allows workflows to execute multiple tasks concurrently and optionally race them against each other, " +
 		"with a single possible winner, which sets the task's output.",
@@ -788,7 +788,7 @@ var forkTaskDefinition = &jsonschema.Schema{
 		{
 			Properties: map[string]*jsonschema.Schema{
 				"fork": {
-					Type:                  "object",
+					Type:                  typeObject,
 					Title:                 "ForkTaskConfiguration",
 					Description:           "The configuration of the branches to perform concurrently.",
 					UnevaluatedProperties: falseSchema(),
@@ -799,7 +799,7 @@ var forkTaskDefinition = &jsonschema.Schema{
 							Title: "ForkBranches",
 						},
 						"compete": {
-							Type:  "boolean",
+							Type:  typeBoolean,
 							Title: "ForkCompete",
 							Description: "Indicates whether or not the concurrent tasks are racing against each other, " +
 								"with a single possible winner, which sets the composite task's output.",
@@ -813,49 +813,49 @@ var forkTaskDefinition = &jsonschema.Schema{
 }
 
 var forTaskDefinition = &jsonschema.Schema{
-	Type:  "object",
+	Type:  typeObject,
 	Title: "ForTask",
 	Description: "Allows workflows to iterate over a collection of items, executing a defined set of subtasks for each item " +
 		"in the collection. This task type is instrumental in handling scenarios such as batch processing, " +
 		"data transformation, and repetitive operations across datasets.",
 	UnevaluatedProperties: falseSchema(),
-	Required:              []string{"for", "do"},
+	Required:              []string{"for", propDo},
 	AllOf: []*jsonschema.Schema{
 		{Ref: SchemaRef("taskBase")},
 		{
 			Properties: map[string]*jsonschema.Schema{
-				"do": {
+				propDo: {
 					Ref:   SchemaRef("taskList"),
 					Title: "ForTaskDo",
 				},
 				"for": {
-					Type:                  "object",
+					Type:                  typeObject,
 					Title:                 "ForTaskConfiguration",
 					Description:           "The definition of the loop that iterates over a range of values.",
 					UnevaluatedProperties: falseSchema(),
 					Required:              []string{"in"},
 					Properties: map[string]*jsonschema.Schema{
 						"at": {
-							Type:        "string",
+							Type:        typeString,
 							Title:       "ForAt",
 							Description: "The name of the variable used to store the index of the current item being enumerated.",
 							Default:     json.RawMessage(`"index"`),
 						},
 						"each": {
-							Type:        "string",
+							Type:        typeString,
 							Title:       "ForEach",
 							Description: "The name of the variable used to store the current item being enumerated.",
 							Default:     json.RawMessage(`"item"`),
 						},
 						"in": {
-							Type:        "string",
+							Type:        typeString,
 							Title:       "ForIn",
 							Description: "A runtime expression used to get the collection to enumerate.",
 						},
 					},
 				},
 				"while": {
-					Type:        "string",
+					Type:        typeString,
 					Title:       "While",
 					Description: "A runtime expression that represents the condition, if any, that must be met for the iteration to continue.",
 				},
@@ -865,13 +865,13 @@ var forTaskDefinition = &jsonschema.Schema{
 }
 
 var inputDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "Input",
 	Description:           "Configures the input of a workflow or task.",
 	UnevaluatedProperties: falseSchema(),
 	Properties: map[string]*jsonschema.Schema{
-		"schema": {
-			Ref:         SchemaRef("schema"),
+		propSchema: {
+			Ref:         SchemaRef(defSchema),
 			Title:       "InputSchema",
 			Description: "The schema used to describe and validate the input of the workflow or task.",
 		},
@@ -879,7 +879,7 @@ var inputDefinition = &jsonschema.Schema{
 }
 
 var listenTaskDefinition = &jsonschema.Schema{
-	Type:  "object",
+	Type:  typeObject,
 	Title: "ListenTask",
 	Description: "Provides a mechanism for workflows to await and react to external events, " +
 		"enabling event-driven behaviour within workflow systems.",
@@ -890,14 +890,14 @@ var listenTaskDefinition = &jsonschema.Schema{
 		{
 			Properties: map[string]*jsonschema.Schema{
 				"listen": {
-					Type:                  "object",
+					Type:                  typeObject,
 					Title:                 "ListenTaskConfiguration",
 					Description:           "The configuration of the listener to use.",
 					UnevaluatedProperties: falseSchema(),
 					Required:              []string{"to"},
 					Properties: map[string]*jsonschema.Schema{
 						"read": {
-							Type:        "string",
+							Type:        typeString,
 							Title:       "ListenAndReadAs",
 							Description: "Specifies how events are read during the listen operation.",
 							Enum:        []any{"data", "envelope", "raw"},
@@ -916,13 +916,13 @@ var listenTaskDefinition = &jsonschema.Schema{
 }
 
 var outputDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "Output",
 	Description:           "Configures the output of a workflow or task.",
 	UnevaluatedProperties: falseSchema(),
 	Properties: map[string]*jsonschema.Schema{
-		"schema": {
-			Ref:         SchemaRef("schema"),
+		propSchema: {
+			Ref:         SchemaRef(defSchema),
 			Title:       "OutputSchema",
 			Description: "The schema used to describe and validate the output of the workflow or task.",
 		},
@@ -930,15 +930,15 @@ var outputDefinition = &jsonschema.Schema{
 			Title:       "OutputAs",
 			Description: "A runtime expression, if any, used to mutate and/or filter the output of the workflow or task.",
 			OneOf: []*jsonschema.Schema{
-				{Type: "string"},
-				{Type: "object"},
+				{Type: typeString},
+				{Type: typeObject},
 			},
 		},
 	},
 }
 
 var raiseTaskDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "RaiseTask",
 	Description:           "Intentionally triggers and propagates errors.",
 	UnevaluatedProperties: falseSchema(),
@@ -948,22 +948,22 @@ var raiseTaskDefinition = &jsonschema.Schema{
 		{
 			Properties: map[string]*jsonschema.Schema{
 				"raise": {
-					Type:                  "object",
+					Type:                  typeObject,
 					Title:                 "RaiseTaskConfiguration",
 					Description:           "The definition of the error to raise.",
 					UnevaluatedProperties: falseSchema(),
-					Required:              []string{"error"},
+					Required:              []string{propError},
 					Properties: map[string]*jsonschema.Schema{
-						"error": {
+						propError: {
 							Title: "RaiseTaskError",
 							OneOf: []*jsonschema.Schema{
 								{
-									Ref:         SchemaRef("error"),
+									Ref:         SchemaRef(propError),
 									Title:       "RaiseErrorDefinition",
 									Description: "Defines the error to raise.",
 								},
 								{
-									Type:        "string",
+									Type:        typeString,
 									Title:       "RaiseErrorReference",
 									Description: "The name of the error to raise",
 								},
@@ -977,7 +977,7 @@ var raiseTaskDefinition = &jsonschema.Schema{
 }
 
 var runTaskDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "RunTask",
 	Description:           "Provides the capability to execute external containers, shell commands, scripts, or workflows.",
 	UnevaluatedProperties: falseSchema(),
@@ -987,13 +987,13 @@ var runTaskDefinition = &jsonschema.Schema{
 		{
 			Properties: map[string]*jsonschema.Schema{
 				"run": {
-					Type:                  "object",
+					Type:                  typeObject,
 					Title:                 "RunTaskConfiguration",
 					Description:           "The configuration of the process to execute.",
 					UnevaluatedProperties: falseSchema(),
 					Properties: map[string]*jsonschema.Schema{
 						"await": {
-							Type:        "boolean",
+							Type:        typeBoolean,
 							Title:       "AwaitProcessCompletion",
 							Description: "Whether to await the process completion before continuing.",
 							Default:     json.RawMessage(`true`),
@@ -1006,30 +1006,30 @@ var runTaskDefinition = &jsonschema.Schema{
 							Required:    []string{"container"},
 							Properties: map[string]*jsonschema.Schema{
 								"container": {
-									Type:                  "object",
+									Type:                  typeObject,
 									Title:                 "Container",
 									Description:           "The configuration of the container to run.",
 									UnevaluatedProperties: falseSchema(),
 									Required:              []string{"image"},
 									Properties: map[string]*jsonschema.Schema{
-										"arguments": {
-											Type:        "array",
+										propArguments: {
+											Type:        typeArray,
 											Title:       "ContainerArguments",
 											Description: "A list of the arguments, if any, passed as argv to the command or default container CMD",
-											Items:       &jsonschema.Schema{Type: "string"},
+											Items:       &jsonschema.Schema{Type: typeString},
 										},
-										"command": {
-											Type:        "string",
+										propCommand: {
+											Type:        typeString,
 											Title:       "ContainerCommand",
 											Description: "The command, if any, to execute on the container.",
 										},
-										"environment": {
-											Type:        "object",
+										propEnvironment: {
+											Type:        typeObject,
 											Title:       "ContainerEnvironment",
 											Description: "A key/value mapping of the environment variables, if any, to use when running the configured process.",
 										},
 										"image": {
-											Type:        "string",
+											Type:        typeString,
 											Title:       "ContainerImage",
 											Description: "The name of the container image to run.",
 										},
@@ -1038,13 +1038,13 @@ var runTaskDefinition = &jsonschema.Schema{
 											Title:       "ContainerLifetime",
 											Description: "An object, if any, used to configure the container's lifetime",
 										},
-										"name": {
-											Type:        "string",
+										propName: {
+											Type:        typeString,
 											Title:       "ContainerName",
 											Description: "A runtime expression, if any, used to give specific name to the container.",
 										},
 										"volumes": {
-											Type:        "object",
+											Type:        typeObject,
 											Title:       "ContainerVolumes",
 											Description: "The container's volume mappings, if any.",
 										},
@@ -1060,7 +1060,7 @@ var runTaskDefinition = &jsonschema.Schema{
 							Required: []string{"script"},
 							Properties: map[string]*jsonschema.Schema{
 								"script": {
-									Type:                  "object",
+									Type:                  typeObject,
 									Title:                 "Script",
 									Description:           "The configuration of the script to run.",
 									UnevaluatedProperties: falseSchema(),
@@ -1068,23 +1068,23 @@ var runTaskDefinition = &jsonschema.Schema{
 									OneOf: []*jsonschema.Schema{
 										{
 											Title:       "InlineScript",
-											Type:        "object",
+											Type:        typeObject,
 											Description: "The script's code.",
 											Required:    []string{"code"},
 											Properties: map[string]*jsonschema.Schema{
 												"code": {
-													Type:  "string",
+													Type:  typeString,
 													Title: "InlineScriptCode",
 												},
 											},
 										},
 										{
 											Title:       "ExternalScript",
-											Type:        "object",
+											Type:        typeObject,
 											Description: "The script's resource.",
-											Required:    []string{"source"},
+											Required:    []string{propSource},
 											Properties: map[string]*jsonschema.Schema{
-												"source": {
+												propSource: {
 													Ref:   SchemaRef("externalResource"),
 													Title: "ExternalScriptResource",
 												},
@@ -1092,21 +1092,21 @@ var runTaskDefinition = &jsonschema.Schema{
 										},
 									},
 									Properties: map[string]*jsonschema.Schema{
-										"arguments": {
-											Type:        "array",
+										propArguments: {
+											Type:        typeArray,
 											Title:       "ScriptArguments",
 											Description: "A list of the arguments, if any, to the script as argv",
-											Items:       &jsonschema.Schema{Type: "string"},
+											Items:       &jsonschema.Schema{Type: typeString},
 										},
-										"environment": {
-											Type:  "object",
+										propEnvironment: {
+											Type:  typeObject,
 											Title: "ScriptEnvironment",
 											Description: "A key/value mapping of the environment variables, if any, " +
 												"to use when running the configured script process.",
 											AdditionalProperties: trueSchema(),
 										},
 										"language": {
-											Type:        "string",
+											Type:        typeString,
 											Title:       "ScriptLanguage",
 											Description: "The language of the script to run.",
 											Enum:        []any{"js", "python"},
@@ -1123,25 +1123,25 @@ var runTaskDefinition = &jsonschema.Schema{
 							Required: []string{"shell"},
 							Properties: map[string]*jsonschema.Schema{
 								"shell": {
-									Type:                  "object",
+									Type:                  typeObject,
 									Title:                 "Shell",
 									Description:           "The configuration of the shell command to run.",
 									UnevaluatedProperties: falseSchema(),
-									Required:              []string{"command"},
+									Required:              []string{propCommand},
 									Properties: map[string]*jsonschema.Schema{
-										"arguments": {
-											Type:        "array",
+										propArguments: {
+											Type:        typeArray,
 											Title:       "ShellArguments",
 											Description: "A list of the arguments, if any, to the shell command as argv",
-											Items:       &jsonschema.Schema{Type: "string"},
+											Items:       &jsonschema.Schema{Type: typeString},
 										},
-										"command": {
-											Type:        "string",
+										propCommand: {
+											Type:        typeString,
 											Title:       "ShellCommand",
 											Description: "The shell command to run.",
 										},
-										"environment": {
-											Type:                 "object",
+										propEnvironment: {
+											Type:                 typeObject,
 											Title:                "ShellEnvironment",
 											Description:          "A key/value mapping of the environment variables, if any, to use when running the configured process.",
 											AdditionalProperties: trueSchema(),
@@ -1158,21 +1158,21 @@ var runTaskDefinition = &jsonschema.Schema{
 							Required: []string{"workflow"},
 							Properties: map[string]*jsonschema.Schema{
 								"workflow": {
-									Type:                  "object",
+									Type:                  typeObject,
 									Title:                 "SubflowConfiguration",
 									Description:           "The configuration of the workflow to run.",
 									UnevaluatedProperties: falseSchema(),
-									Required:              []string{"type"},
+									Required:              []string{propType},
 									Properties: map[string]*jsonschema.Schema{
-										"input": {
-											Type:  "object",
+										propInput: {
+											Type:  typeObject,
 											Title: "SubflowInput",
 											Description: "The data, if any, to pass as input to the workflow to execute. " +
 												"The value should be validated against the target workflow's input schema, if specified.",
 											AdditionalProperties: trueSchema(),
 										},
-										"type": {
-											Type:        "string",
+										propType: {
+											Type:        typeString,
 											Title:       "SubflowType",
 											Description: "The workflow type to run.",
 										},
@@ -1188,20 +1188,20 @@ var runTaskDefinition = &jsonschema.Schema{
 }
 
 var runtimeExpressionDefinition = &jsonschema.Schema{
-	Type:        "string",
+	Type:        typeString,
 	Title:       "RuntimeExpression",
 	Description: "A runtime expression.",
 	Pattern:     runtimeExpressionString,
 }
 
 var schemaDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "Schema",
 	Description:           "Represents the definition of a schema.",
 	UnevaluatedProperties: falseSchema(),
 	Properties: map[string]*jsonschema.Schema{
 		"format": {
-			Type:        "string",
+			Type:        typeString,
 			Title:       "SchemaFormat",
 			Default:     json.RawMessage(`"json"`),
 			Description: "The schema's format. Defaults to 'json'. The (optional) version of the format can be set using `{format}:{version}`.",
@@ -1210,9 +1210,9 @@ var schemaDefinition = &jsonschema.Schema{
 	OneOf: []*jsonschema.Schema{
 		{
 			Title:    "SchemaInline",
-			Required: []string{"document"},
+			Required: []string{propDocument},
 			Properties: map[string]*jsonschema.Schema{
-				"document": {
+				propDocument: {
 					Description: "The schema's inline definition.",
 				},
 			},
@@ -1221,25 +1221,25 @@ var schemaDefinition = &jsonschema.Schema{
 }
 
 var setTaskDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "SetTask",
 	Description:           "A task used to set data.",
 	UnevaluatedProperties: falseSchema(),
-	Required:              []string{"set"},
+	Required:              []string{propSet},
 	AllOf: []*jsonschema.Schema{
 		{Ref: SchemaRef("taskBase")},
 		{
 			Properties: map[string]*jsonschema.Schema{
-				"set": {
+				propSet: {
 					Title:       "SetTaskConfiguration",
 					Description: "The data to set.",
 					OneOf: []*jsonschema.Schema{
 						{
-							Type:                 "object",
+							Type:                 typeObject,
 							MinProperties:        utils.Ptr(1),
 							AdditionalProperties: trueSchema(),
 						},
-						{Type: "string"},
+						{Type: typeString},
 					},
 				},
 			},
@@ -1248,35 +1248,35 @@ var setTaskDefinition = &jsonschema.Schema{
 }
 
 var subscriptionIteratorDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "SubscriptionIterator",
 	Description:           "Configures the iteration over each item (event or message) consumed by a subscription.",
 	UnevaluatedProperties: falseSchema(),
 	Properties: map[string]*jsonschema.Schema{
 		"at": {
-			Type:        "string",
+			Type:        typeString,
 			Title:       "SubscriptionIteratorIndex",
 			Description: "The name of the variable used to store the index of the current item being enumerated.",
 			Default:     json.RawMessage(`"index"`),
 		},
-		"do": {
+		propDo: {
 			Ref:         SchemaRef("taskList"),
 			Title:       "SubscriptionIteratorTasks",
 			Description: "The tasks to perform for each consumed item.",
 		},
-		"export": {
-			Ref:         SchemaRef("export"),
+		propExport: {
+			Ref:         SchemaRef(propExport),
 			Title:       "SubscriptionIteratorExport",
 			Description: "An object, if any, used to customise the content of the workflow context.",
 		},
 		"item": {
-			Type:        "string",
+			Type:        typeString,
 			Title:       "SubscriptionIteratorItem",
 			Description: "The name of the variable used to store the current item being enumerated.",
 			Default:     json.RawMessage(`"item"`),
 		},
-		"output": {
-			Ref:         SchemaRef("output"),
+		propOutput: {
+			Ref:         SchemaRef(defOutput),
 			Title:       "SubscriptionIteratorOutput",
 			Description: "An object, if any, used to customise the item's output and to document its schema.",
 		},
@@ -1284,7 +1284,7 @@ var subscriptionIteratorDefinition = &jsonschema.Schema{
 }
 
 var switchTaskDefinition = &jsonschema.Schema{
-	Type:  "object",
+	Type:  typeObject,
 	Title: "SwitchTask",
 	Description: "Enables conditional branching within workflows, allowing them to dynamically select " +
 		"different paths based on specified conditions or criteria.",
@@ -1295,30 +1295,30 @@ var switchTaskDefinition = &jsonschema.Schema{
 		{
 			Properties: map[string]*jsonschema.Schema{
 				"switch": {
-					Type:        "array",
+					Type:        typeArray,
 					Title:       "SwitchTaskConfiguration",
 					Description: "The definition of the switch to use.",
 					MinItems:    utils.Ptr(1),
 					Items: &jsonschema.Schema{
-						Type:          "object",
+						Type:          typeObject,
 						Title:         "SwitchItem",
 						MinProperties: utils.Ptr(1),
 						MaxProperties: utils.Ptr(1),
 						AdditionalProperties: &jsonschema.Schema{
-							Type:  "object",
+							Type:  typeObject,
 							Title: "SwitchCase",
 							Description: "The definition of a case within a switch task, defining a condition " +
 								"and corresponding tasks to execute if the condition is met.",
 							UnevaluatedProperties: falseSchema(),
-							Required:              []string{"then"},
+							Required:              []string{propThen},
 							Properties: map[string]*jsonschema.Schema{
-								"then": {
+								propThen: {
 									Ref:         SchemaRef("flowDirective"),
 									Title:       "SwitchCaseOutcome",
 									Description: "The flow directive to execute when the case matches.",
 								},
 								"when": {
-									Type:        "string",
+									Type:        typeString,
 									Title:       "SwitchCaseCondition",
 									Description: "A runtime expression used to determine whether or not the case matches.",
 								},
@@ -1351,54 +1351,54 @@ var taskDefinition = &jsonschema.Schema{
 }
 
 var taskBaseDefinition = &jsonschema.Schema{
-	Type:        "object",
+	Type:        typeObject,
 	Title:       "TaskBase",
 	Description: "An object inherited by all tasks.",
 	Properties: map[string]*jsonschema.Schema{
 		"if": {
-			Type:        "string",
+			Type:        typeString,
 			Title:       "TaskBaseIf",
 			Description: "A runtime expression, if any, used to determine whether or not the task should be run.",
 		},
-		"input": {
-			Ref:         SchemaRef("input"),
+		propInput: {
+			Ref:         SchemaRef(propInput),
 			Title:       "TaskBaseInput",
 			Description: "Configure the task's input.",
 		},
-		"output": {
-			Ref:         SchemaRef("output"),
+		propOutput: {
+			Ref:         SchemaRef(defOutput),
 			Title:       "TaskBaseOutput",
 			Description: "Configure the task's output.",
 		},
-		"export": {
-			Ref:         SchemaRef("export"),
+		propExport: {
+			Ref:         SchemaRef(propExport),
 			Title:       "TaskBaseExport",
 			Description: "Export task output to context.",
 		},
-		"then": {
+		propThen: {
 			Ref:         SchemaRef("flowDirective"),
 			Title:       "TaskBaseThen",
 			Description: "The flow directive to be performed upon completion of the task.",
 		},
-		"metadata": {
-			Type:                 "object",
+		propMetadata: {
+			Type:                 typeObject,
 			Title:                "TaskBaseMetadata",
 			Description:          "Holds additional information about the task.",
 			AdditionalProperties: trueSchema(),
 			AllOf: []*jsonschema.Schema{
-				{Ref: SchemaRef("commonMetadata")},
-				{Ref: SchemaRef("taskMetadata")},
+				{Ref: SchemaRef(defCommonMetadata)},
+				{Ref: SchemaRef(defTaskMetadata)},
 			},
 		},
 	},
 }
 
 var taskListDefinition = &jsonschema.Schema{
-	Type:        "array",
+	Type:        typeArray,
 	Title:       "TaskList",
 	Description: "List of named tasks to perform.",
 	Items: &jsonschema.Schema{
-		Type:          "object",
+		Type:          typeObject,
 		Title:         "TaskItem",
 		MinProperties: utils.Ptr(1),
 		MaxProperties: utils.Ptr(1),
@@ -1409,17 +1409,17 @@ var taskListDefinition = &jsonschema.Schema{
 }
 
 var taskMetadataDefinition = &jsonschema.Schema{
-	Type:                 "object",
+	Type:                 typeObject,
 	Title:                "TaskMetadata",
 	AdditionalProperties: trueSchema(),
 	Properties: map[string]*jsonschema.Schema{
-		"__zigflow_id": {
-			Type:  "string",
+		propZigflowID: {
+			Type:  typeString,
 			Title: "ZigflowID",
 			Description: "A system-generated unique identifier for the task. " +
 				"This value is assigned automatically and should not be modified by users.",
 		},
-		"heartbeat": {
+		propHeartbeat: {
 			Ref:         SchemaRef("duration"),
 			Title:       "Heartbeat",
 			Description: "Heartbeats will be triggered after this time period.",
@@ -1428,7 +1428,7 @@ var taskMetadataDefinition = &jsonschema.Schema{
 }
 
 var timeoutDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "Timeout",
 	Description:           "The definition of a timeout.",
 	UnevaluatedProperties: falseSchema(),
@@ -1443,7 +1443,7 @@ var timeoutDefinition = &jsonschema.Schema{
 }
 
 var tryTaskDefinition = &jsonschema.Schema{
-	Type:  "object",
+	Type:  typeObject,
 	Title: "TryTask",
 	Description: "Serves as a mechanism within workflows to handle errors gracefully, " +
 		"potentially retrying failed tasks before proceeding with alternate ones.",
@@ -1454,13 +1454,13 @@ var tryTaskDefinition = &jsonschema.Schema{
 		{
 			Properties: map[string]*jsonschema.Schema{
 				"catch": {
-					Type:                  "object",
+					Type:                  typeObject,
 					Title:                 "TryTaskCatch",
 					Description:           "The object used to define the errors to catch.",
 					UnevaluatedProperties: falseSchema(),
-					Required:              []string{"do"},
+					Required:              []string{propDo},
 					Properties: map[string]*jsonschema.Schema{
-						"do": {
+						propDo: {
 							Ref:         SchemaRef("taskList"),
 							Title:       "TryTaskCatchDo",
 							Description: "The definition of the task(s) to run when catching an error.",
@@ -1481,13 +1481,13 @@ var uriTemplateDefinition = &jsonschema.Schema{
 	Title: "UriTemplate",
 	AnyOf: []*jsonschema.Schema{
 		{
-			Type:    "string",
+			Type:    typeString,
 			Title:   "LiteralUriTemplate",
 			Format:  "uri-template",
 			Pattern: urlPattern,
 		},
 		{
-			Type:    "string",
+			Type:    typeString,
 			Title:   "LiteralUri",
 			Format:  "uri",
 			Pattern: urlPattern,
@@ -1496,7 +1496,7 @@ var uriTemplateDefinition = &jsonschema.Schema{
 }
 
 var waitTaskDefinition = &jsonschema.Schema{
-	Type:                  "object",
+	Type:                  typeObject,
 	Title:                 "WaitTask",
 	Description:           "Allows workflows to pause or delay their execution for a specified period of time.",
 	UnevaluatedProperties: falseSchema(),

--- a/pkg/schema/definitions_test.go
+++ b/pkg/schema/definitions_test.go
@@ -96,36 +96,36 @@ func TestBuildDefinitionsKeys(t *testing.T) {
 
 	expected := []string{
 		"callTask",
-		"commonMetadata",
+		defCommonMetadata,
 		"containerLifetime",
 		"doTask",
-		"documentMetadata",
+		defDocumentMetadata,
 		"duration",
-		"endpoint",
-		"error",
+		propEndpoint,
+		propError,
 		"eventConsumptionStrategy",
 		"eventFilter",
 		"eventProperties",
-		"export",
+		propExport,
 		"externalResource",
 		"flowDirective",
 		"forkTask",
 		"forTask",
-		"input",
+		propInput,
 		"listenTask",
-		"output",
+		defOutput,
 		"raiseTask",
 		"runTask",
 		"runtimeExpression",
-		"schema",
+		defSchema,
 		"setTask",
 		"subscriptionIterator",
 		"switchTask",
 		"task",
 		"taskBase",
 		"taskList",
-		"taskMetadata",
-		"timeout",
+		defTaskMetadata,
+		defTimeout,
 		"tryTask",
 		"uriTemplate",
 		"waitTask",
@@ -174,9 +174,9 @@ func TestDurationDefinitionShape(t *testing.T) {
 	assert.Len(t, d.OneOf, 1, "duration must have exactly one OneOf branch (object form only)")
 
 	branch := d.OneOf[0]
-	assert.Equal(t, "object", branch.Type, "the single duration branch must be an object")
+	assert.Equal(t, typeObject, branch.Type, "the single duration branch must be an object")
 
-	for _, prop := range []string{"days", "hours", "minutes", "seconds", "milliseconds"} {
+	for _, prop := range []string{"days", "hours", propMinutes, propSeconds, "milliseconds"} {
 		assert.Contains(t, branch.Properties, prop, "duration object must have property %q", prop)
 	}
 
@@ -196,7 +196,7 @@ func TestTryTaskDefinitionCatch(t *testing.T) {
 	catch := tryTaskDefinition.AllOf[1].Properties["catch"]
 	require.NotNil(t, catch, "catch property must be present")
 
-	assert.Equal(t, "object", catch.Type)
+	assert.Equal(t, typeObject, catch.Type)
 	assert.Contains(t, catch.Required, "do")
 
 	doField := catchProperty("do")

--- a/pkg/schema/metadata_test.go
+++ b/pkg/schema/metadata_test.go
@@ -72,7 +72,7 @@ func withTaskMetadata(meta map[string]any) map[string]any {
 func TestMetadataDefinitionsPresent(t *testing.T) {
 	defs := buildDefinitions()
 
-	for _, key := range []string{"commonMetadata", "documentMetadata", "taskMetadata"} {
+	for _, key := range []string{defCommonMetadata, defDocumentMetadata, defTaskMetadata} {
 		assert.Contains(t, defs, key, "buildDefinitions() must contain %q", key)
 	}
 }
@@ -83,33 +83,33 @@ func TestMetadataDefinitionsPresent(t *testing.T) {
 func TestCommonMetadataDefinitionShape(t *testing.T) {
 	def := commonMetadataDefinition
 
-	assert.Equal(t, "object", def.Type)
+	assert.Equal(t, typeObject, def.Type)
 	assert.True(t, isOpenSchema(def.AdditionalProperties),
 		"commonMetadata must be open (additionalProperties: true)")
 
-	require.Contains(t, def.Properties, "activityOptions")
-	actOpts := def.Properties["activityOptions"]
+	require.Contains(t, def.Properties, propActivityOptions)
+	actOpts := def.Properties[propActivityOptions]
 
 	// All expected activity-options sub-keys must be present.
 	for _, key := range []string{
-		"disableEagerExecution",
-		"heartbeatTimeout",
-		"retryPolicy",
+		propDisableEager,
+		propHeartbeatTimeout,
+		propRetryPolicy,
 		"scheduleToCloseTimeout",
 		"scheduleToStartTimeout",
-		"startToCloseTimeout",
-		"summary",
+		propStartToCloseTimeout,
+		propSummary,
 	} {
 		assert.Contains(t, actOpts.Properties, key,
 			"activityOptions must have property %q", key)
 	}
 
-	assert.Equal(t, "boolean", actOpts.Properties["disableEagerExecution"].Type)
-	assert.Equal(t, SchemaRef("duration"), actOpts.Properties["heartbeatTimeout"].Ref)
+	assert.Equal(t, typeBoolean, actOpts.Properties[propDisableEager].Type)
+	assert.Equal(t, SchemaRef("duration"), actOpts.Properties[propHeartbeatTimeout].Ref)
 	assert.Equal(t, SchemaRef("duration"), actOpts.Properties["scheduleToCloseTimeout"].Ref)
 	assert.Equal(t, SchemaRef("duration"), actOpts.Properties["scheduleToStartTimeout"].Ref)
-	assert.Equal(t, SchemaRef("duration"), actOpts.Properties["startToCloseTimeout"].Ref)
-	assert.Equal(t, "string", actOpts.Properties["summary"].Type)
+	assert.Equal(t, SchemaRef("duration"), actOpts.Properties[propStartToCloseTimeout].Ref)
+	assert.Equal(t, typeString, actOpts.Properties[propSummary].Type)
 }
 
 // TestRetryPolicyDefinitionShape verifies that retryPolicy inside
@@ -117,18 +117,18 @@ func TestCommonMetadataDefinitionShape(t *testing.T) {
 // closed (additionalProperties: false) so that unknown retry keys are
 // rejected.
 func TestRetryPolicyDefinitionShape(t *testing.T) {
-	actOpts := commonMetadataDefinition.Properties["activityOptions"]
-	require.Contains(t, actOpts.Properties, "retryPolicy")
-	rp := actOpts.Properties["retryPolicy"]
+	actOpts := commonMetadataDefinition.Properties[propActivityOptions]
+	require.Contains(t, actOpts.Properties, propRetryPolicy)
+	rp := actOpts.Properties[propRetryPolicy]
 
-	assert.Equal(t, "object", rp.Type)
+	assert.Equal(t, typeObject, rp.Type)
 	assert.False(t, isOpenSchema(rp.AdditionalProperties),
 		"retryPolicy must be closed (additionalProperties: false)")
 
 	for _, key := range []string{
 		"backoffCoefficient",
 		"initialInterval",
-		"maximumAttempts",
+		propMaximumAttempts,
 		"maximumInterval",
 		"nonRetryableErrorTypes",
 	} {
@@ -136,14 +136,14 @@ func TestRetryPolicyDefinitionShape(t *testing.T) {
 	}
 
 	assert.Equal(t, "number", rp.Properties["backoffCoefficient"].Type)
-	assert.Equal(t, "integer", rp.Properties["maximumAttempts"].Type)
+	assert.Equal(t, typeInteger, rp.Properties[propMaximumAttempts].Type)
 	assert.Equal(t, SchemaRef("duration"), rp.Properties["initialInterval"].Ref)
 	assert.Equal(t, SchemaRef("duration"), rp.Properties["maximumInterval"].Ref)
 
 	nonRetryable := rp.Properties["nonRetryableErrorTypes"]
-	assert.Equal(t, "array", nonRetryable.Type)
+	assert.Equal(t, typeArray, nonRetryable.Type)
 	require.NotNil(t, nonRetryable.Items)
-	assert.Equal(t, "string", nonRetryable.Items.Type)
+	assert.Equal(t, typeString, nonRetryable.Items.Type)
 }
 
 // TestDocumentMetadataDefinitionShape verifies that documentMetadataDefinition
@@ -152,24 +152,24 @@ func TestRetryPolicyDefinitionShape(t *testing.T) {
 func TestDocumentMetadataDefinitionShape(t *testing.T) {
 	def := documentMetadataDefinition
 
-	assert.Equal(t, "object", def.Type)
+	assert.Equal(t, typeObject, def.Type)
 	assert.True(t, isOpenSchema(def.AdditionalProperties),
 		"documentMetadata must be open (additionalProperties: true)")
 
 	for _, key := range []string{
-		"canMaxHistoryLength",
-		"scheduleWorkflowName",
-		"scheduleId",
-		"scheduleInput",
+		propCanMaxHistory,
+		propScheduleWorkflowName,
+		propScheduleID,
+		propScheduleInput,
 	} {
 		assert.Contains(t, def.Properties, key,
 			"documentMetadata must have property %q", key)
 	}
 
-	assert.Equal(t, "integer", def.Properties["canMaxHistoryLength"].Type)
-	assert.Equal(t, "string", def.Properties["scheduleWorkflowName"].Type)
-	assert.Equal(t, "string", def.Properties["scheduleId"].Type)
-	assert.Equal(t, "array", def.Properties["scheduleInput"].Type)
+	assert.Equal(t, typeInteger, def.Properties[propCanMaxHistory].Type)
+	assert.Equal(t, typeString, def.Properties[propScheduleWorkflowName].Type)
+	assert.Equal(t, typeString, def.Properties[propScheduleID].Type)
+	assert.Equal(t, typeArray, def.Properties[propScheduleInput].Type)
 }
 
 // TestTaskMetadataDefinitionShape verifies that taskMetadataDefinition
@@ -177,37 +177,37 @@ func TestDocumentMetadataDefinitionShape(t *testing.T) {
 func TestTaskMetadataDefinitionShape(t *testing.T) {
 	def := taskMetadataDefinition
 
-	assert.Equal(t, "object", def.Type)
+	assert.Equal(t, typeObject, def.Type)
 	assert.True(t, isOpenSchema(def.AdditionalProperties),
 		"taskMetadata must be open (additionalProperties: true)")
 
-	require.Contains(t, def.Properties, "__zigflow_id")
-	assert.Equal(t, "string", def.Properties["__zigflow_id"].Type)
+	require.Contains(t, def.Properties, propZigflowID)
+	assert.Equal(t, typeString, def.Properties[propZigflowID].Type)
 
-	require.Contains(t, def.Properties, "heartbeat")
-	assert.Equal(t, SchemaRef("duration"), def.Properties["heartbeat"].Ref)
+	require.Contains(t, def.Properties, propHeartbeat)
+	assert.Equal(t, SchemaRef("duration"), def.Properties[propHeartbeat].Ref)
 }
 
 // TestTaskBaseMetadataAllOf verifies that taskBase wires metadata through
 // both commonMetadata and taskMetadata.
 func TestTaskBaseMetadataAllOf(t *testing.T) {
-	meta := taskBaseDefinition.Properties["metadata"]
+	meta := taskBaseDefinition.Properties[propMetadata]
 	require.NotNil(t, meta, "taskBase must have a metadata property")
 
 	refs := schemaRefs(meta.AllOf)
-	assert.Contains(t, refs, SchemaRef("commonMetadata"))
+	assert.Contains(t, refs, SchemaRef(defCommonMetadata))
 	assert.Contains(t, refs, SchemaRef("taskMetadata"))
 }
 
 // TestDocumentMetadataAllOf verifies that the document.metadata property in
 // the root schema wires through both commonMetadata and documentMetadata.
 func TestDocumentMetadataAllOf(t *testing.T) {
-	meta := schemaProperties["document"].Properties["metadata"]
+	meta := schemaProperties[propDocument].Properties[propMetadata]
 	require.NotNil(t, meta, "document must have a metadata property")
 
 	refs := schemaRefs(meta.AllOf)
-	assert.Contains(t, refs, SchemaRef("commonMetadata"))
-	assert.Contains(t, refs, SchemaRef("documentMetadata"))
+	assert.Contains(t, refs, SchemaRef(defCommonMetadata))
+	assert.Contains(t, refs, SchemaRef(defDocumentMetadata))
 }
 
 // --- validation tests ---------------------------------------------------------
@@ -237,7 +237,7 @@ func TestDocumentMetadata_Validation(t *testing.T) {
 		},
 		{
 			name: "canMaxHistoryLength integer is accepted",
-			meta: map[string]any{"canMaxHistoryLength": 100},
+			meta: map[string]any{propCanMaxHistory: 100},
 		},
 		{
 			name: "unknown metadata key is accepted (open schema)",
@@ -246,16 +246,16 @@ func TestDocumentMetadata_Validation(t *testing.T) {
 		{
 			name: "activityOptions with valid startToCloseTimeout is accepted",
 			meta: map[string]any{
-				"activityOptions": map[string]any{
-					"startToCloseTimeout": map[string]any{"seconds": 30},
+				propActivityOptions: map[string]any{
+					"startToCloseTimeout": map[string]any{propSeconds: 30},
 				},
 			},
 		},
 		{
 			name: "activityOptions with valid retryPolicy is accepted",
 			meta: map[string]any{
-				"activityOptions": map[string]any{
-					"retryPolicy": map[string]any{"maximumAttempts": 3},
+				propActivityOptions: map[string]any{
+					propRetryPolicy: map[string]any{"maximumAttempts": 3},
 				},
 			},
 		},
@@ -268,19 +268,19 @@ func TestDocumentMetadata_Validation(t *testing.T) {
 		},
 		{
 			name:        "canMaxHistoryLength as string is rejected",
-			meta:        map[string]any{"canMaxHistoryLength": "not-an-int"},
+			meta:        map[string]any{propCanMaxHistory: "not-an-int"},
 			expectError: true,
 		},
 		{
 			name:        "activityOptions.disableEagerExecution as string is rejected",
-			meta:        map[string]any{"activityOptions": map[string]any{"disableEagerExecution": "yes"}},
+			meta:        map[string]any{propActivityOptions: map[string]any{propDisableEager: "yes"}},
 			expectError: true,
 		},
 		{
 			name: "unknown key in retryPolicy is rejected (closed schema)",
 			meta: map[string]any{
-				"activityOptions": map[string]any{
-					"retryPolicy": map[string]any{"unknownRetryKey": "val"},
+				propActivityOptions: map[string]any{
+					propRetryPolicy: map[string]any{"unknownRetryKey": "val"},
 				},
 			},
 			expectError: true,
@@ -313,11 +313,11 @@ func TestTaskMetadata_Validation(t *testing.T) {
 		// ---- valid cases ----
 		{
 			name: "__zigflow_id string is accepted",
-			meta: map[string]any{"__zigflow_id": "abc-123"},
+			meta: map[string]any{propZigflowID: "abc-123"},
 		},
 		{
 			name: "heartbeat duration object is accepted",
-			meta: map[string]any{"heartbeat": map[string]any{"seconds": 30}},
+			meta: map[string]any{propHeartbeat: map[string]any{propSeconds: 30}},
 		},
 		{
 			name: "unknown task metadata key is accepted (open schema)",
@@ -326,8 +326,8 @@ func TestTaskMetadata_Validation(t *testing.T) {
 		{
 			name: "activityOptions with valid heartbeatTimeout is accepted",
 			meta: map[string]any{
-				"activityOptions": map[string]any{
-					"heartbeatTimeout": map[string]any{"minutes": 1},
+				propActivityOptions: map[string]any{
+					propHeartbeatTimeout: map[string]any{propMinutes: 1},
 				},
 			},
 		},
@@ -335,26 +335,26 @@ func TestTaskMetadata_Validation(t *testing.T) {
 		// ---- invalid cases ----
 		{
 			name:        "__zigflow_id as integer is rejected",
-			meta:        map[string]any{"__zigflow_id": 99},
+			meta:        map[string]any{propZigflowID: 99},
 			expectError: true,
 		},
 		{
 			name:        "heartbeat as plain string is rejected",
-			meta:        map[string]any{"heartbeat": "30s"},
+			meta:        map[string]any{propHeartbeat: "30s"},
 			expectError: true,
 		},
 		{
 			name: "unknown key in retryPolicy is rejected (closed schema)",
 			meta: map[string]any{
-				"activityOptions": map[string]any{
-					"retryPolicy": map[string]any{"bogusKey": true},
+				propActivityOptions: map[string]any{
+					propRetryPolicy: map[string]any{"bogusKey": true},
 				},
 			},
 			expectError: true,
 		},
 		{
 			name:        "activityOptions.disableEagerExecution as string is rejected",
-			meta:        map[string]any{"activityOptions": map[string]any{"disableEagerExecution": "true"}},
+			meta:        map[string]any{propActivityOptions: map[string]any{propDisableEager: "true"}},
 			expectError: true,
 		},
 	}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -32,21 +32,21 @@ func BuildSchema(version, format string) (*jsonschema.Schema, error) {
 		Schema:      SchemaVersion,
 		Title:       SchemaTitle,
 		Description: SchemaDescription,
-		Type:        "object",
-		Required:    []string{"do", "document"},
+		Type:        typeObject,
+		Required:    []string{propDo, propDocument},
 		Properties:  schemaProperties,
 		Defs:        buildDefinitions(),
 		If: &jsonschema.Schema{
 			Required: []string{"schedule"},
 		},
 		Then: &jsonschema.Schema{
-			Required: []string{"document"},
+			Required: []string{propDocument},
 			Properties: map[string]*jsonschema.Schema{
-				"document": {
-					Required: []string{"metadata"},
+				propDocument: {
+					Required: []string{propMetadata},
 					Properties: map[string]*jsonschema.Schema{
-						"metadata": {
-							Required: []string{"scheduleWorkflowName"},
+						propMetadata: {
+							Required: []string{propScheduleWorkflowName},
 						},
 					},
 				},
@@ -63,88 +63,88 @@ func BuildSchema(version, format string) (*jsonschema.Schema, error) {
 }
 
 var schemaProperties = map[string]*jsonschema.Schema{
-	"do": {
+	propDo: {
 		Ref:         SchemaRef("taskList"),
 		Title:       "Do",
 		Description: "Defines the task(s) the workflow must perform.",
 	},
-	"document": {
-		Type:                  "object",
+	propDocument: {
+		Type:                  typeObject,
 		Title:                 "Document",
 		Description:           "Documents the workflow",
-		Required:              []string{"dsl", "taskQueue", "workflowType", "version"},
+		Required:              []string{propDSL, propTaskQueue, propWorkflowType, propVersion},
 		UnevaluatedProperties: falseSchema(),
 		Properties: map[string]*jsonschema.Schema{
-			"dsl": {
-				Type:        "string",
+			propDSL: {
+				Type:        typeString,
 				Title:       "WorkflowDSL",
 				Pattern:     semVerPattern,
 				Description: "The version of the DSL used by the workflow.",
 			},
-			"metadata": {
-				Type:                 "object",
+			propMetadata: {
+				Type:                 typeObject,
 				Title:                "WorkflowMetadata",
 				Description:          "Holds additional information about the workflow.",
 				AdditionalProperties: trueSchema(),
 				AllOf: []*jsonschema.Schema{
-					{Ref: SchemaRef("commonMetadata")},
-					{Ref: SchemaRef("documentMetadata")},
+					{Ref: SchemaRef(defCommonMetadata)},
+					{Ref: SchemaRef(defDocumentMetadata)},
 				},
 			},
-			"taskQueue": {
-				Type:        "string",
+			propTaskQueue: {
+				Type:        typeString,
 				Title:       "WorkflowTaskQueue",
 				Pattern:     dnsLabelPattern,
 				Description: "The Temporal task queue the workflow runs on.",
 			},
-			"workflowType": {
-				Type:        "string",
+			propWorkflowType: {
+				Type:        typeString,
 				Title:       "WorkflowType",
 				Pattern:     dnsLabelPattern,
 				Description: "The Temporal workflow type name.",
 			},
-			"summary": {
-				Type:        "string",
+			propSummary: {
+				Type:        typeString,
 				Title:       "WorkflowSummary",
 				Description: "The workflow's Markdown summary.",
 			},
 			"tags": {
-				Type:                 "object",
+				Type:                 typeObject,
 				Title:                "WorkflowTags",
 				Description:          "A key/value mapping of the workflow's tags, if any.",
 				AdditionalProperties: &jsonschema.Schema{},
 			},
 			"title": {
-				Type:        "string",
+				Type:        typeString,
 				Title:       "WorkflowTitle",
 				Description: "The workflow's title.",
 			},
-			"version": {
-				Type:        "string",
+			propVersion: {
+				Type:        typeString,
 				Title:       "WorkflowVersion",
 				Pattern:     semVerPattern,
 				Description: "The workflow's semantic version.",
 			},
 		},
 	},
-	"input": {
-		Ref:         SchemaRef("input"),
+	propInput: {
+		Ref:         SchemaRef(propInput),
 		Title:       "Input",
 		Description: "Configures the workflow's input.",
 	},
-	"output": {
-		Ref:         SchemaRef("output"),
+	propOutput: {
+		Ref:         SchemaRef(defOutput),
 		Title:       "Output",
 		Description: "Configures the workflow's output.",
 	},
 	"schedule": {
-		Type:                  "object",
+		Type:                  typeObject,
 		Title:                 "Schedule",
 		Description:           "Schedules the workflow.",
 		UnevaluatedProperties: falseSchema(),
 		Properties: map[string]*jsonschema.Schema{
-			"cron": {
-				Type:        "string",
+			propCron: {
+				Type:        typeString,
 				Title:       "ScheduleCron",
 				Description: "Specifies the schedule using a cron expression, e.g., '0 0 * * *' for daily at midnight.",
 			},
@@ -155,12 +155,12 @@ var schemaProperties = map[string]*jsonschema.Schema{
 			},
 		},
 	},
-	"timeout": {
+	defTimeout: {
 		Title:      "DoTimeout",
 		Deprecated: true,
 		OneOf: []*jsonschema.Schema{
 			{
-				Ref:         SchemaRef("timeout"),
+				Ref:         SchemaRef(defTimeout),
 				Title:       "TimeoutDefinition",
 				Description: "The workflow's timeout configuration, if any.",
 			},

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -23,21 +23,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testCronExpr = "0 0 * * *"
+
 // minimalWorkflow returns a minimal structurally valid workflow document.
 // It is used as a baseline for validation tests so that each test only
 // introduces one deviation from a known-good state.
 func minimalWorkflow() map[string]any {
 	return map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"taskQueue":    "default",
-			"workflowType": "test",
-			"version":      "1.0.0",
+		propDocument: map[string]any{
+			propDSL:          "1.0.0",
+			propTaskQueue:    "default",
+			propWorkflowType: "test",
+			propVersion:      "1.0.0",
 		},
-		"do": []any{
+		propDo: []any{
 			map[string]any{
 				"step1": map[string]any{
-					"set": map[string]any{"x": "y"},
+					propSet: map[string]any{"x": "y"},
 				},
 			},
 		},
@@ -61,7 +63,7 @@ func TestSchema_DocumentFields(t *testing.T) {
 	t.Run("old name field is rejected", func(t *testing.T) {
 		doc := minimalWorkflow()
 		document := doc["document"].(map[string]any)
-		delete(document, "workflowType")
+		delete(document, propWorkflowType)
 		document["name"] = "test"
 
 		err := resolved.Validate(doc)
@@ -71,7 +73,7 @@ func TestSchema_DocumentFields(t *testing.T) {
 	t.Run("old namespace field is rejected", func(t *testing.T) {
 		doc := minimalWorkflow()
 		document := doc["document"].(map[string]any)
-		delete(document, "taskQueue")
+		delete(document, propTaskQueue)
 		document["namespace"] = "default"
 
 		err := resolved.Validate(doc)
@@ -80,7 +82,7 @@ func TestSchema_DocumentFields(t *testing.T) {
 
 	t.Run("missing workflowType is rejected", func(t *testing.T) {
 		doc := minimalWorkflow()
-		delete(doc["document"].(map[string]any), "workflowType")
+		delete(doc["document"].(map[string]any), propWorkflowType)
 
 		err := resolved.Validate(doc)
 		assert.Error(t, err, "document without workflowType must fail validation")
@@ -88,7 +90,7 @@ func TestSchema_DocumentFields(t *testing.T) {
 
 	t.Run("missing taskQueue is rejected", func(t *testing.T) {
 		doc := minimalWorkflow()
-		delete(doc["document"].(map[string]any), "taskQueue")
+		delete(doc["document"].(map[string]any), propTaskQueue)
 
 		err := resolved.Validate(doc)
 		assert.Error(t, err, "document without taskQueue must fail validation")
@@ -103,7 +105,7 @@ func TestSchema_ScheduleRequiresScheduleWorkflowName(t *testing.T) {
 
 	t.Run("schedule present without document.metadata is rejected", func(t *testing.T) {
 		doc := minimalWorkflow()
-		doc["schedule"] = map[string]any{"cron": "0 0 * * *"}
+		doc["schedule"] = map[string]any{propCron: testCronExpr}
 
 		err := resolved.Validate(doc)
 		assert.Error(t, err, "schedule without document.metadata must fail validation")
@@ -111,9 +113,9 @@ func TestSchema_ScheduleRequiresScheduleWorkflowName(t *testing.T) {
 
 	t.Run("schedule present with document.metadata but missing scheduleWorkflowName is rejected", func(t *testing.T) {
 		doc := minimalWorkflow()
-		doc["schedule"] = map[string]any{"cron": "0 0 * * *"}
+		doc["schedule"] = map[string]any{propCron: testCronExpr}
 		doc["document"].(map[string]any)["metadata"] = map[string]any{
-			"scheduleId": "my-schedule",
+			propScheduleID: "my-schedule",
 		}
 
 		err := resolved.Validate(doc)
@@ -122,9 +124,9 @@ func TestSchema_ScheduleRequiresScheduleWorkflowName(t *testing.T) {
 
 	t.Run("schedule present with valid document.metadata.scheduleWorkflowName is accepted", func(t *testing.T) {
 		doc := minimalWorkflow()
-		doc["schedule"] = map[string]any{"cron": "0 0 * * *"}
+		doc["schedule"] = map[string]any{propCron: testCronExpr}
 		doc["document"].(map[string]any)["metadata"] = map[string]any{
-			"scheduleWorkflowName": "my-workflow",
+			propScheduleWorkflowName: "my-workflow",
 		}
 
 		err := resolved.Validate(doc)

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const expectedCountryGB = "GB"
+
 func TestParseCloudflareTrace(t *testing.T) {
 	tests := []struct {
 		Name     string
@@ -36,7 +38,7 @@ func TestParseCloudflareTrace(t *testing.T) {
 			Body: "fl=123abc\nh=www.cloudflare.com\nip=1.2.3.4\nts=1234567890.123\n" +
 				"visit_scheme=https\nuag=Go-http-client/1.1\ncolo=LHR\nsliver=none\n" +
 				"http=http/1.1\nloc=GB\ntls=TLSv1.3\nsni=plaintext\nwarp=off",
-			Expected: "GB",
+			Expected: expectedCountryGB,
 		},
 		{
 			Name:     "lowercase country code",
@@ -152,7 +154,7 @@ func TestFetchCountry(t *testing.T) {
 			Name:     "200 with valid loc",
 			Status:   http.StatusOK,
 			Body:     validBody,
-			Expected: "GB",
+			Expected: expectedCountryGB,
 		},
 		{
 			Name:     "500 response returns empty",
@@ -177,7 +179,7 @@ func TestFetchCountry(t *testing.T) {
 			Status: http.StatusOK,
 			// loc=GB within the first 4KB, padded well beyond the limit
 			Body:     "fl=123abc\nloc=GB\npadding=" + strings.Repeat("x", 12*1024),
-			Expected: "GB",
+			Expected: expectedCountryGB,
 		},
 		{
 			Name:   "200 with oversized body where loc is beyond limit",

--- a/pkg/utils/runtime_expressions.go
+++ b/pkg/utils/runtime_expressions.go
@@ -29,7 +29,13 @@ import (
 	"go.temporal.io/sdk/temporal"
 )
 
-const ndeDocsURL = "https://zigflow.dev/docs/concepts/data-and-expressions/#why-must-generated-values-be-in-a-set-task"
+const (
+	ndeDocsURL = "https://zigflow.dev/docs/concepts/data-and-expressions/#why-must-generated-values-be-in-a-set-task"
+
+	jqFuncUUID         = "uuid"
+	jqFuncTimestamp    = "timestamp"
+	jqFuncTimestampISO = "timestamp_iso8601"
+)
 
 type ExpressionWrapperFunc func(func() (any, error)) (any, error)
 
@@ -45,20 +51,20 @@ type jqFunc struct {
 // when used outside of a set task (i.e. without a side-effect wrapper).
 var jqFuncs []jqFunc = []jqFunc{
 	{
-		Name: "uuid",
+		Name: jqFuncUUID,
 		Func: func(_ any, _ []any) any {
 			return uuid.New().String()
 		},
 	},
 	{
-		Name: "timestamp",
+		Name: jqFuncTimestamp,
 		Func: func(_ any, _ []any) any {
 			// Convert to int so it can be formatted by strftime
 			return int(time.Now().Unix())
 		},
 	},
 	{
-		Name: "timestamp_iso8601",
+		Name: jqFuncTimestampISO,
 		Func: func(_ any, _ []any) any {
 			return time.Now().UTC().Format(time.RFC3339)
 		},

--- a/pkg/utils/runtime_expressions_test.go
+++ b/pkg/utils/runtime_expressions_test.go
@@ -27,6 +27,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testKeyName     = "name"
+	testKeyValue    = "value"
+	testKeyStatic   = "static"
+	testKeyItems    = "items"
+	testKeyEnv      = "env"
+	testKeyNested   = "nested"
+	testKeyHOST     = "HOST"
+	testKeyPORT     = "PORT"
+	testValHi       = "hi"
+	testValPlain    = "plain"
+	testValHost     = "localhost"
+	testExprInvalid = "${ @@@ }"
+	testExprMsg     = "${ .msg }"
+	testExprA       = "${ .a }"
+	testKeyGreeting = "greeting"
+)
+
 func newState(input, output, ctx any, data map[string]any) *State {
 	s := NewState()
 	s.Input = input
@@ -68,7 +86,7 @@ func TestEvaluateString(t *testing.T) {
 		{
 			Name:     "simple field access on context",
 			Str:      "${ .name }",
-			Ctx:      map[string]any{"name": "zigflow"},
+			Ctx:      map[string]any{testKeyName: "zigflow"},
 			State:    NewState(),
 			Expected: "zigflow",
 		},
@@ -125,18 +143,18 @@ func TestEvaluateString(t *testing.T) {
 			Name:     "jq string literal expression",
 			Str:      `${ "static" }`,
 			State:    NewState(),
-			Expected: "static",
+			Expected: testKeyStatic,
 		},
 		{
 			Name:     "expression without spaces inside braces",
 			Str:      "${.name}",
-			Ctx:      map[string]any{"name": "compact"},
+			Ctx:      map[string]any{testKeyName: "compact"},
 			State:    NewState(),
 			Expected: "compact",
 		},
 		{
 			Name:      "invalid jq expression returns error",
-			Str:       "${ @@@ }",
+			Str:       testExprInvalid,
 			State:     NewState(),
 			ExpectErr: true,
 		},
@@ -282,15 +300,15 @@ func TestLeadingNonDeterministicFunc(t *testing.T) {
 		Expected string
 	}{
 		// Registered non-deterministic functions
-		{Name: "uuid is detected", Expr: "uuid", Expected: "uuid"},
-		{Name: "timestamp is detected", Expr: "timestamp", Expected: "timestamp"},
-		{Name: "timestamp_iso8601 is detected", Expr: "timestamp_iso8601", Expected: "timestamp_iso8601"},
+		{Name: "uuid is detected", Expr: jqFuncUUID, Expected: jqFuncUUID},
+		{Name: "timestamp is detected", Expr: jqFuncTimestamp, Expected: jqFuncTimestamp},
+		{Name: "timestamp_iso8601 is detected", Expr: jqFuncTimestampISO, Expected: jqFuncTimestampISO},
 
 		// Leading whitespace is trimmed
-		{Name: "uuid with leading spaces", Expr: "  uuid", Expected: "uuid"},
+		{Name: "uuid with leading spaces", Expr: "  uuid", Expected: jqFuncUUID},
 
 		// Only the leading identifier matters; a pipe still makes it non-det
-		{Name: "uuid piped to length", Expr: "uuid | length", Expected: "uuid"},
+		{Name: "uuid piped to length", Expr: "uuid | length", Expected: jqFuncUUID},
 
 		// Field accesses and variable references are NOT function calls
 		{Name: "field access .uuid is not a function", Expr: ".uuid", Expected: ""},
@@ -382,39 +400,39 @@ func TestTraverseAndEvaluateObj(t *testing.T) {
 		},
 		{
 			Name:  "map with expression value",
-			Obj:   model.NewObjectOrRuntimeExpr(map[string]any{"greeting": "${ .msg }"}),
-			Ctx:   map[string]any{"msg": "hi"},
+			Obj:   model.NewObjectOrRuntimeExpr(map[string]any{testKeyGreeting: testExprMsg}),
+			Ctx:   map[string]any{"msg": testValHi},
 			State: NewState(),
 			Expected: map[string]any{
-				"greeting": "hi",
+				testKeyGreeting: testValHi,
 			},
 		},
 		{
 			Name: "map with mixed plain and expression values",
 			Obj: model.NewObjectOrRuntimeExpr(map[string]any{
-				"static":  "constant",
-				"dynamic": "${ .value }",
+				testKeyStatic: "constant",
+				"dynamic":     "${ .value }",
 			}),
-			Ctx:   map[string]any{"value": "evaluated"},
+			Ctx:   map[string]any{testKeyValue: "evaluated"},
 			State: NewState(),
 			Expected: map[string]any{
-				"static":  "constant",
-				"dynamic": "evaluated",
+				testKeyStatic: "constant",
+				"dynamic":     "evaluated",
 			},
 		},
 		{
 			Name: "map containing an array of expressions",
 			Obj: model.NewObjectOrRuntimeExpr(map[string]any{
-				"items": []any{
-					"${ .a }",
+				testKeyItems: []any{
+					testExprA,
 					"${ .b }",
-					"plain",
+					testValPlain,
 				},
 			}),
 			Ctx:   map[string]any{"a": 1, "b": 2},
 			State: NewState(),
 			Expected: map[string]any{
-				"items": []any{1, 2, "plain"},
+				testKeyItems: []any{1, 2, testValPlain},
 			},
 		},
 		{
@@ -432,7 +450,7 @@ func TestTraverseAndEvaluateObj(t *testing.T) {
 			Obj: model.NewObjectOrRuntimeExpr(map[string]any{
 				"inputVal": "${ $input.name }",
 			}),
-			State: newState(map[string]any{"name": "from-input"}, nil, nil, nil),
+			State: newState(map[string]any{testKeyName: "from-input"}, nil, nil, nil),
 			Expected: map[string]any{
 				"inputVal": "from-input",
 			},
@@ -440,7 +458,7 @@ func TestTraverseAndEvaluateObj(t *testing.T) {
 		{
 			Name: "map with invalid expression returns error",
 			Obj: model.NewObjectOrRuntimeExpr(map[string]any{
-				"bad": "${ @@@ }",
+				"bad": testExprInvalid,
 			}),
 			State:     NewState(),
 			ExpectErr: true,
@@ -448,7 +466,7 @@ func TestTraverseAndEvaluateObj(t *testing.T) {
 		{
 			Name: "map containing array with invalid expression returns error",
 			Obj: model.NewObjectOrRuntimeExpr(map[string]any{
-				"items": []any{"${ @@@ }"},
+				testKeyItems: []any{testExprInvalid},
 			}),
 			State:     NewState(),
 			ExpectErr: true,
@@ -470,9 +488,9 @@ func TestTraverseAndEvaluateObj(t *testing.T) {
 
 func TestTraverseAndEvaluateObjMapStringStringNilCoercedToEmpty(t *testing.T) {
 	obj := model.NewObjectOrRuntimeExpr(map[string]any{
-		"env": map[string]string{
+		testKeyEnv: map[string]string{
 			"NULLABLE": "${ null }",
-			"PLAIN":    "value",
+			"PLAIN":    testKeyValue,
 		},
 	})
 
@@ -480,9 +498,9 @@ func TestTraverseAndEvaluateObjMapStringStringNilCoercedToEmpty(t *testing.T) {
 	require.NoError(t, err)
 	// A null result must become "" not "<nil>".
 	assert.Equal(t, map[string]any{
-		"env": map[string]string{
+		testKeyEnv: map[string]string{
 			"NULLABLE": "",
-			"PLAIN":    "value",
+			"PLAIN":    testKeyValue,
 		},
 	}, result)
 }
@@ -492,7 +510,7 @@ func TestTraverseAndEvaluateObjMapStringString(t *testing.T) {
 	state.Env["OPENAI_API_KEY"] = "secret-key"
 
 	obj := model.NewObjectOrRuntimeExpr(map[string]any{
-		"env": map[string]string{
+		testKeyEnv: map[string]string{
 			"OPENAI_API_KEY": "${ $env.OPENAI_API_KEY }",
 		},
 	})
@@ -500,7 +518,7 @@ func TestTraverseAndEvaluateObjMapStringString(t *testing.T) {
 	result, err := TraverseAndEvaluateObj(obj, nil, state)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
-		"env": map[string]string{
+		testKeyEnv: map[string]string{
 			"OPENAI_API_KEY": "secret-key",
 		},
 	}, result)
@@ -508,25 +526,25 @@ func TestTraverseAndEvaluateObjMapStringString(t *testing.T) {
 
 func TestTraverseAndEvaluateObjDoesNotMutateMapStringString(t *testing.T) {
 	env := map[string]string{
-		"HOST": "${ .host }",
-		"PORT": "8080",
+		testKeyHOST: "${ .host }",
+		testKeyPORT: "8080",
 	}
-	obj := model.NewObjectOrRuntimeExpr(map[string]any{"env": env})
+	obj := model.NewObjectOrRuntimeExpr(map[string]any{testKeyEnv: env})
 
-	result, err := TraverseAndEvaluateObj(obj, map[string]any{"host": "localhost"}, NewState())
+	result, err := TraverseAndEvaluateObj(obj, map[string]any{"host": testValHost}, NewState())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
-		"env": map[string]string{
-			"HOST": "localhost",
-			"PORT": "8080",
+		testKeyEnv: map[string]string{
+			testKeyHOST: testValHost,
+			testKeyPORT: "8080",
 		},
 	}, result)
 
 	// Original map[string]string must not be mutated.
 	// DeepCloneValue does not clone map[string]string, so traverseAndEvaluate
 	// must allocate its own copy before writing evaluated values.
-	assert.Equal(t, "${ .host }", env["HOST"], "original map[string]string was mutated")
-	assert.Equal(t, "8080", env["PORT"])
+	assert.Equal(t, "${ .host }", env[testKeyHOST], "original map[string]string was mutated")
+	assert.Equal(t, "8080", env[testKeyPORT])
 }
 
 func TestTraverseAndEvaluateObjMapStringStringConcurrent(t *testing.T) {
@@ -534,10 +552,10 @@ func TestTraverseAndEvaluateObjMapStringStringConcurrent(t *testing.T) {
 	// a map[string]string. The race detector will catch any concurrent writes to
 	// the original map if the clone is missing.
 	env := map[string]string{
-		"HOST": "${ .host }",
-		"PORT": "8080",
+		testKeyHOST: "${ .host }",
+		testKeyPORT: "8080",
 	}
-	obj := model.NewObjectOrRuntimeExpr(map[string]any{"env": env})
+	obj := model.NewObjectOrRuntimeExpr(map[string]any{testKeyEnv: env})
 
 	const goroutines = 200
 	var wg sync.WaitGroup
@@ -545,40 +563,40 @@ func TestTraverseAndEvaluateObjMapStringStringConcurrent(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			_, _ = TraverseAndEvaluateObj(obj, map[string]any{"host": "localhost"}, NewState())
+			_, _ = TraverseAndEvaluateObj(obj, map[string]any{"host": testValHost}, NewState())
 		}()
 	}
 	wg.Wait()
 
-	assert.Equal(t, "${ .host }", env["HOST"], "original map[string]string was mutated")
+	assert.Equal(t, "${ .host }", env[testKeyHOST], "original map[string]string was mutated")
 }
 
 func TestTraverseAndEvaluateObjDoesNotMutateOriginal(t *testing.T) {
 	obj := model.NewObjectOrRuntimeExpr(map[string]any{
-		"greeting": "${ .msg }",
-		"nested": map[string]any{
-			"items": []any{"${ .a }", "plain"},
+		testKeyGreeting: testExprMsg,
+		testKeyNested: map[string]any{
+			testKeyItems: []any{testExprA, testValPlain},
 		},
 	})
 
 	result, err := TraverseAndEvaluateObj(obj, map[string]any{
-		"msg": "hi",
+		"msg": testValHi,
 		"a":   1,
 	}, NewState())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
-		"greeting": "hi",
-		"nested": map[string]any{
-			"items": []any{1, "plain"},
+		testKeyGreeting: testValHi,
+		testKeyNested: map[string]any{
+			testKeyItems: []any{1, testValPlain},
 		},
 	}, result)
 
 	// The original workflow definition object should be unchanged so it can be
 	// safely reused by concurrent workflow executions.
 	assert.Equal(t, map[string]any{
-		"greeting": "${ .msg }",
-		"nested": map[string]any{
-			"items": []any{"${ .a }", "plain"},
+		testKeyGreeting: testExprMsg,
+		testKeyNested: map[string]any{
+			testKeyItems: []any{testExprA, testValPlain},
 		},
 	}, obj.AsStringOrMap())
 }
@@ -593,11 +611,11 @@ func TestTraverseAndEvaluateObjWithWrapper(t *testing.T) {
 
 		obj := model.NewObjectOrRuntimeExpr(map[string]any{
 			"a": "${ .x }",
-			"b": "plain",
+			"b": testValPlain,
 		})
 		result, err := TraverseAndEvaluateObj(obj, map[string]any{"x": 1}, NewState(), wrapper)
 		require.NoError(t, err)
-		assert.Equal(t, map[string]any{"a": 1, "b": "plain"}, result)
+		assert.Equal(t, map[string]any{"a": 1, "b": testValPlain}, result)
 		assert.Equal(t, 1, callCount, "wrapper should be called once for the single expression value")
 	})
 
@@ -609,11 +627,11 @@ func TestTraverseAndEvaluateObjWithWrapper(t *testing.T) {
 		})
 
 		obj := model.NewObjectOrRuntimeExpr(map[string]any{
-			"items": []any{"${ .a }", "${ .b }", "plain"},
+			testKeyItems: []any{testExprA, "${ .b }", testValPlain},
 		})
 		result, err := TraverseAndEvaluateObj(obj, map[string]any{"a": 10, "b": 20}, NewState(), wrapper)
 		require.NoError(t, err)
-		assert.Equal(t, map[string]any{"items": []any{10, 20, "plain"}}, result)
+		assert.Equal(t, map[string]any{testKeyItems: []any{10, 20, testValPlain}}, result)
 		assert.Equal(t, 2, callCount, "wrapper should be called once per expression in the array")
 	})
 
@@ -729,7 +747,7 @@ func TestCheckIfStatement(t *testing.T) {
 		},
 		{
 			Name:        "invalid jq expression returns non-retryable error",
-			Expression:  model.NewExpr("${ @@@ }"),
+			Expression:  model.NewExpr(testExprInvalid),
 			State:       NewState(),
 			ExpectErr:   true,
 			ErrContains: "Error parsing if statement",

--- a/pkg/zigflow/activities/run.go
+++ b/pkg/zigflow/activities/run.go
@@ -35,6 +35,12 @@ import (
 	"go.temporal.io/sdk/temporal"
 )
 
+const (
+	scriptLangJS     = "js"
+	scriptLangPython = "python"
+	scriptCmdNode    = "node"
+)
+
 func init() {
 	Registry = append(Registry, &Run{})
 }
@@ -79,11 +85,11 @@ func (r *Run) CallScriptActivity(ctx context.Context, task *model.RunTask, input
 	lang := script.Language
 	logger.Debug("Detecting script language", "language", lang)
 	switch lang {
-	case "js":
-		command = append(command, "node")
+	case scriptLangJS:
+		command = append(command, scriptCmdNode)
 		file = "script.js"
-	case "python":
-		command = append(command, "python")
+	case scriptLangPython:
+		command = append(command, scriptLangPython)
 		file = "script.py"
 	default:
 		logger.Error("Unknown script language", "language", lang)

--- a/pkg/zigflow/activities/run_test.go
+++ b/pkg/zigflow/activities/run_test.go
@@ -33,12 +33,19 @@ import (
 	"go.temporal.io/sdk/testsuite"
 )
 
+const (
+	testHello           = "hello"
+	testShellCmd        = "sh"
+	testShellFlag       = "-c"
+	testImageNeverExist = "zigflow-test-does-not-exist:never"
+)
+
 func TestStdToString(t *testing.T) {
 	r := &Run{}
 	cases := []struct{ input, want string }{
 		{"", ""},
-		{"hello", "hello"},
-		{"\nhello\n", "hello"},
+		{testHello, testHello},
+		{"\nhello\n", testHello},
 		{"  hello world  ", "hello world"},
 	}
 	for _, c := range cases {
@@ -59,11 +66,11 @@ func TestCallShellActivity(t *testing.T) {
 		{
 			name: "stdout is returned trimmed",
 			task: &model.RunTask{Run: model.RunTaskConfiguration{Shell: &model.Shell{
-				Command:   "sh",
-				Arguments: &model.RunArguments{Value: []string{"-c", "echo hello"}},
+				Command:   testShellCmd,
+				Arguments: &model.RunArguments{Value: []string{testShellFlag, "echo hello"}},
 			}}},
 			state: utils.NewState(),
-			want:  "hello",
+			want:  testHello,
 		},
 		{
 			name: "nil args are tolerated",
@@ -77,8 +84,8 @@ func TestCallShellActivity(t *testing.T) {
 		{
 			name: "environment variables are passed through",
 			task: &model.RunTask{Run: model.RunTaskConfiguration{Shell: &model.Shell{
-				Command:     "sh",
-				Arguments:   &model.RunArguments{Value: []string{"-c", `printf "%s" "$MY_VAR"`}},
+				Command:     testShellCmd,
+				Arguments:   &model.RunArguments{Value: []string{testShellFlag, `printf "%s" "$MY_VAR"`}},
 				Environment: map[string]string{"MY_VAR": "my-value"},
 			}}},
 			state: utils.NewState(),
@@ -87,8 +94,8 @@ func TestCallShellActivity(t *testing.T) {
 		{
 			name: "state expressions in environment are interpolated",
 			task: &model.RunTask{Run: model.RunTaskConfiguration{Shell: &model.Shell{
-				Command:     "sh",
-				Arguments:   &model.RunArguments{Value: []string{"-c", `printf "%s" "$OPENAI_API_KEY"`}},
+				Command:     testShellCmd,
+				Arguments:   &model.RunArguments{Value: []string{testShellFlag, `printf "%s" "$OPENAI_API_KEY"`}},
 				Environment: map[string]string{"OPENAI_API_KEY": "${ $env.OPENAI_API_KEY }"},
 			}}},
 			state: func() *utils.State {
@@ -102,16 +109,16 @@ func TestCallShellActivity(t *testing.T) {
 			name: "command field is used as the executable with arguments forwarded",
 			task: &model.RunTask{Run: model.RunTaskConfiguration{Shell: &model.Shell{
 				Command:   "echo",
-				Arguments: &model.RunArguments{Value: []string{"hello"}},
+				Arguments: &model.RunArguments{Value: []string{testHello}},
 			}}},
 			state: utils.NewState(),
-			want:  "hello",
+			want:  testHello,
 		},
 		{
 			name: "non-zero exit code is surfaced as error",
 			task: &model.RunTask{Run: model.RunTaskConfiguration{Shell: &model.Shell{
-				Command:   "sh",
-				Arguments: &model.RunArguments{Value: []string{"-c", "exit 1"}},
+				Command:   testShellCmd,
+				Arguments: &model.RunArguments{Value: []string{testShellFlag, "exit 1"}},
 			}}},
 			state:   utils.NewState(),
 			wantErr: true,
@@ -158,7 +165,7 @@ func TestCallContainerActivityEnvExpressionsUseActivityEnrichedState(t *testing.
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
 			Container: &model.Container{
-				Image: "zigflow-test-does-not-exist:never",
+				Image: testImageNeverExist,
 				Environment: map[string]string{
 					// Raises a jq error when $data.activity is absent (raw state).
 					// Resolves cleanly when state is enriched with activity info.
@@ -192,7 +199,7 @@ func TestCallContainerActivityNonStringEnvVarFormattedCorrectly(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
 			Container: &model.Container{
-				Image: "zigflow-test-does-not-exist:never",
+				Image: testImageNeverExist,
 				Environment: map[string]string{
 					"INT_VAR":  "${ 1 }",
 					"BOOL_VAR": "${ true }",
@@ -225,7 +232,7 @@ func TestCallContainerActivityNilEnvVarCoercedToEmpty(t *testing.T) {
 		Run: model.RunTaskConfiguration{
 			Container: &model.Container{
 				// Deliberately nonexistent image — docker fails fast without running anything.
-				Image: "zigflow-test-does-not-exist:never",
+				Image: testImageNeverExist,
 				Environment: map[string]string{
 					"MY_VAR": "${ null }", // jq null evaluates to nil in Go
 				},
@@ -253,7 +260,7 @@ func TestRunExecCommandRespectsWorkingDirectory(t *testing.T) {
 	testActivity := func(ctx context.Context) (any, error) {
 		return run.runExecCommand(
 			ctx,
-			[]string{"sh"}, &model.RunArguments{Value: []string{"-c", "pwd"}},
+			[]string{testShellCmd}, &model.RunArguments{Value: []string{testShellFlag, "pwd"}},
 			nil, utils.NewState(), dir, &model.TaskBase{},
 		)
 	}
@@ -279,7 +286,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 	}{
 		{
 			name:   "external file source is fetched and executed",
-			binary: "node",
+			binary: scriptCmdNode,
 			want:   "hello from file",
 			makeTask: func(t *testing.T) (*model.RunTask, *utils.State) {
 				f, err := os.CreateTemp("", "*.js")
@@ -291,7 +298,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 				return &model.RunTask{
 					Run: model.RunTaskConfiguration{
 						Script: &model.Script{
-							Language: "js",
+							Language: scriptLangJS,
 							External: &model.ExternalResource{
 								Endpoint: model.NewEndpoint("file://" + f.Name()),
 							},
@@ -302,7 +309,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 		},
 		{
 			name:   "external HTTP source is fetched and executed",
-			binary: "node",
+			binary: scriptCmdNode,
 			want:   "hello from http",
 			makeTask: func(t *testing.T) (*model.RunTask, *utils.State) {
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -312,7 +319,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 				return &model.RunTask{
 					Run: model.RunTaskConfiguration{
 						Script: &model.Script{
-							Language: "js",
+							Language: scriptLangJS,
 							External: &model.ExternalResource{
 								Endpoint: model.NewEndpoint(srv.URL + "/script.js"),
 							},
@@ -329,7 +336,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 				return &model.RunTask{
 					Run: model.RunTaskConfiguration{
 						Script: &model.Script{
-							Language: "js",
+							Language: scriptLangJS,
 							External: &model.ExternalResource{
 								Endpoint: &model.Endpoint{
 									URITemplate: &model.LiteralUri{Value: "ftp://example.com/script.js"},
@@ -344,7 +351,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 			// The endpoint is a runtime expression that resolves to the test server URL
 			// via $env.SCRIPT_URL. Verifies EvaluateString is called before ReadURLContents.
 			name:   "runtime-expression endpoint is evaluated before fetching",
-			binary: "node",
+			binary: scriptCmdNode,
 			want:   "hello from expression",
 			makeTask: func(t *testing.T) (*model.RunTask, *utils.State) {
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -356,7 +363,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 				return &model.RunTask{
 					Run: model.RunTaskConfiguration{
 						Script: &model.Script{
-							Language: "js",
+							Language: scriptLangJS,
 							External: &model.ExternalResource{
 								Endpoint: &model.Endpoint{
 									RuntimeExpression: model.NewExpr("${ $env.SCRIPT_URL }"),
@@ -375,7 +382,7 @@ func TestCallScriptActivityExternalSource(t *testing.T) {
 				return &model.RunTask{
 					Run: model.RunTaskConfiguration{
 						Script: &model.Script{
-							Language: "js",
+							Language: scriptLangJS,
 							External: &model.ExternalResource{
 								// Endpoint intentionally nil
 							},
@@ -436,24 +443,24 @@ func TestCallScriptActivity(t *testing.T) {
 		},
 		{
 			name:   "js script is executed and stdout is captured",
-			lang:   "js",
+			lang:   scriptLangJS,
 			code:   `process.stdout.write("hello from js")`,
-			binary: "node",
+			binary: scriptCmdNode,
 			want:   "hello from js",
 		},
 		{
 			name:   "python script is executed and stdout is captured",
-			lang:   "python",
+			lang:   scriptLangPython,
 			code:   `import sys; sys.stdout.write("hello from python")`,
-			binary: "python",
+			binary: scriptLangPython,
 			want:   "hello from python",
 		},
 		{
 			name:   "script arguments are forwarded after the script file",
-			lang:   "js",
+			lang:   scriptLangJS,
 			code:   `process.stdout.write(process.argv.slice(2).join(","))`,
 			args:   &model.RunArguments{Value: []string{"x", "y"}},
-			binary: "node",
+			binary: scriptCmdNode,
 			want:   "x,y",
 		},
 	}

--- a/pkg/zigflow/metadata/activity_options_test.go
+++ b/pkg/zigflow/metadata/activity_options_test.go
@@ -125,12 +125,14 @@ func TestSetActivityOptionsWorkflowTimeoutOverride(t *testing.T) {
 	assert.Equal(t, 2*time.Minute, opts.StartToCloseTimeout)
 }
 
+const testKeyStartToCloseTimeout = "startToCloseTimeout"
+
 func TestSetActivityOptionsGlobalMetadataOverride(t *testing.T) {
 	wf := &model.Workflow{
 		Document: model.Document{
 			Metadata: map[string]any{
 				metadata.MetadataActivityOptions: map[string]any{
-					"startToCloseTimeout": map[string]any{"minutes": 3},
+					testKeyStartToCloseTimeout: map[string]any{"minutes": 3},
 				},
 			},
 		},
@@ -149,7 +151,7 @@ func TestSetActivityOptionsTaskMetadataOverridePrecedence(t *testing.T) {
 		Document: model.Document{
 			Metadata: map[string]any{
 				metadata.MetadataActivityOptions: map[string]any{
-					"startToCloseTimeout": map[string]any{"minutes": 3},
+					testKeyStartToCloseTimeout: map[string]any{"minutes": 3},
 				},
 			},
 		},
@@ -162,7 +164,7 @@ func TestSetActivityOptionsTaskMetadataOverridePrecedence(t *testing.T) {
 	task := &model.TaskBase{
 		Metadata: map[string]any{
 			metadata.MetadataActivityOptions: map[string]any{
-				"startToCloseTimeout": map[string]any{"seconds": 30},
+				testKeyStartToCloseTimeout: map[string]any{"seconds": 30},
 			},
 		},
 	}

--- a/pkg/zigflow/normalise_test.go
+++ b/pkg/zigflow/normalise_test.go
@@ -26,6 +26,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// String constants used across normalise_test.go to satisfy goconst requirements.
+const (
+	testKeyDocument     = "document"
+	testKeyDo           = "do"
+	testKeyDSL          = "dsl"
+	testKeyRun          = "run"
+	testKeySet          = "set"
+	testKeyType         = "type"
+	testKeyWorkflow     = "workflow"
+	testKeyWorkflowType = "workflowType"
+	testKeyTaskQueue    = "taskQueue"
+	testKeyVersion      = "version"
+	testDSLVersion      = "1.0.0"
+	testWFName          = "wf"
+	testChildWorkflow   = "child-workflow"
+	testHello           = "hello"
+	testParent          = "parent"
+)
+
 // cloneMap returns a deep copy of m so that mutations in the function under
 // test do not affect the original test-case literal.
 func cloneMap(t *testing.T, m map[string]any) map[string]any {
@@ -40,7 +59,7 @@ func cloneMap(t *testing.T, m map[string]any) map[string]any {
 // docOf extracts the "document" sub-map from a top-level workflow map.
 func docOf(t *testing.T, m map[string]any) map[string]any {
 	t.Helper()
-	raw, ok := m["document"]
+	raw, ok := m[testKeyDocument]
 	require.True(t, ok, "expected a 'document' key")
 	doc, ok := raw.(map[string]any)
 	require.True(t, ok, "expected document to be a map")
@@ -50,11 +69,11 @@ func docOf(t *testing.T, m map[string]any) map[string]any {
 // workflowOf extracts run.workflow from a single task-body map.
 func workflowOf(t *testing.T, task map[string]any) map[string]any {
 	t.Helper()
-	raw, ok := task["run"]
+	raw, ok := task[testKeyRun]
 	require.True(t, ok, "expected a 'run' key in task")
 	run, ok := raw.(map[string]any)
 	require.True(t, ok, "expected run to be a map")
-	raw, ok = run["workflow"]
+	raw, ok = run[testKeyWorkflow]
 	require.True(t, ok, "expected a 'workflow' key in run")
 	wf, ok := raw.(map[string]any)
 	require.True(t, ok, "expected run.workflow to be a map")
@@ -66,11 +85,11 @@ func workflowOf(t *testing.T, task map[string]any) map[string]any {
 func TestNormaliseTopLevelDocument_WorkflowTypeRenamedToName(t *testing.T) {
 	// workflowType must become name.
 	input := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "my-workflow",
-			"taskQueue":    "my-queue",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: "my-workflow",
+			testKeyTaskQueue:    "my-queue",
+			testKeyVersion:      testDSLVersion,
 		},
 	})
 
@@ -84,38 +103,38 @@ func TestNormaliseTopLevelDocument_WorkflowTypeRenamedToName(t *testing.T) {
 func TestNormaliseTopLevelDocument_ZigflowKeysRemoved(t *testing.T) {
 	// After normalisation the original Zigflow field names must not remain.
 	input := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "wf",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testWFName,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
 		},
 	})
 
 	require.NoError(t, normaliseTopLevelDocument(input))
 
 	doc := docOf(t, input)
-	assert.NotContains(t, doc, "workflowType", "workflowType must be removed after normalisation")
-	assert.NotContains(t, doc, "taskQueue", "taskQueue must be removed after normalisation")
+	assert.NotContains(t, doc, testKeyWorkflowType, "workflowType must be removed after normalisation")
+	assert.NotContains(t, doc, testKeyTaskQueue, "taskQueue must be removed after normalisation")
 }
 
 func TestNormaliseTopLevelDocument_UnrelatedFieldsPreserved(t *testing.T) {
 	// Fields unrelated to the Zigflow rename must survive unchanged.
 	input := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "wf",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
-			"summary":      "A workflow summary",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testWFName,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
+			"summary":           "A workflow summary",
 		},
 	})
 
 	require.NoError(t, normaliseTopLevelDocument(input))
 
 	doc := docOf(t, input)
-	assert.Equal(t, "1.0.0", doc["dsl"])
-	assert.Equal(t, "1.0.0", doc["version"])
+	assert.Equal(t, testDSLVersion, doc[testKeyDSL])
+	assert.Equal(t, testDSLVersion, doc[testKeyVersion])
 	assert.Equal(t, "A workflow summary", doc["summary"])
 }
 
@@ -123,17 +142,17 @@ func TestNormaliseTopLevelDocument_OnlyWorkflowType(t *testing.T) {
 	// If only workflowType is present, name is added but namespace is not
 	// introduced from thin air.
 	input := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "wf",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testWFName,
+			testKeyVersion:      testDSLVersion,
 		},
 	})
 
 	require.NoError(t, normaliseTopLevelDocument(input))
 
 	doc := docOf(t, input)
-	assert.Equal(t, "wf", doc["name"])
+	assert.Equal(t, testWFName, doc["name"])
 	assert.NotContains(t, doc, "namespace", "namespace must not be introduced when taskQueue is absent")
 }
 
@@ -141,10 +160,10 @@ func TestNormaliseTopLevelDocument_OnlyTaskQueue(t *testing.T) {
 	// If only taskQueue is present, namespace is added but name is not
 	// introduced from thin air.
 	input := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":       "1.0.0",
-			"taskQueue": "q",
-			"version":   "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:       testDSLVersion,
+			testKeyTaskQueue: "q",
+			testKeyVersion:   testDSLVersion,
 		},
 	})
 
@@ -159,9 +178,9 @@ func TestNormaliseTopLevelDocument_NoZigflowFields(t *testing.T) {
 	// When neither workflowType nor taskQueue are present the document must
 	// not gain name or namespace keys.
 	input := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":     "1.0.0",
-			"version": "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:     testDSLVersion,
+			testKeyVersion: testDSLVersion,
 		},
 	})
 
@@ -175,7 +194,7 @@ func TestNormaliseTopLevelDocument_NoZigflowFields(t *testing.T) {
 func TestNormaliseTopLevelDocument_NoDocumentKey(t *testing.T) {
 	// A map without a "document" key is a no-op and must not error.
 	input := cloneMap(t, map[string]any{
-		"do": []any{},
+		testKeyDo: []any{},
 	})
 
 	require.NoError(t, normaliseTopLevelDocument(input))
@@ -186,9 +205,9 @@ func TestNormaliseTopLevelDocument_NoDocumentKey(t *testing.T) {
 func TestNormaliseRunTask_TypeRenamedToName(t *testing.T) {
 	// run.workflow.type must become run.workflow.name.
 	task := cloneMap(t, map[string]any{
-		"run": map[string]any{
-			"workflow": map[string]any{
-				"type": "child-workflow",
+		testKeyRun: map[string]any{
+			testKeyWorkflow: map[string]any{
+				testKeyType: testChildWorkflow,
 			},
 		},
 	})
@@ -196,16 +215,16 @@ func TestNormaliseRunTask_TypeRenamedToName(t *testing.T) {
 	require.NoError(t, normaliseRunTask(task))
 
 	wf := workflowOf(t, task)
-	assert.Equal(t, "child-workflow", wf["name"], "type must be mapped to name")
+	assert.Equal(t, testChildWorkflow, wf["name"], "type must be mapped to name")
 }
 
 func TestNormaliseRunTask_TypeKeyRemoved(t *testing.T) {
 	// The original "type" key must not remain after normalisation.
 	task := cloneMap(t, map[string]any{
-		"run": map[string]any{
-			"workflow": map[string]any{
-				"type":  "child-workflow",
-				"input": map[string]any{"foo": "bar"},
+		testKeyRun: map[string]any{
+			testKeyWorkflow: map[string]any{
+				testKeyType: testChildWorkflow,
+				"input":     map[string]any{"foo": "bar"},
 			},
 		},
 	})
@@ -213,16 +232,16 @@ func TestNormaliseRunTask_TypeKeyRemoved(t *testing.T) {
 	require.NoError(t, normaliseRunTask(task))
 
 	wf := workflowOf(t, task)
-	assert.NotContains(t, wf, "type", "type must be removed after normalisation")
+	assert.NotContains(t, wf, testKeyType, "type must be removed after normalisation")
 }
 
 func TestNormaliseRunTask_OtherWorkflowFieldsPreserved(t *testing.T) {
 	// Fields alongside "type" in run.workflow must survive unchanged.
 	task := cloneMap(t, map[string]any{
-		"run": map[string]any{
-			"workflow": map[string]any{
-				"type":  "child-workflow",
-				"input": map[string]any{"key": "value"},
+		testKeyRun: map[string]any{
+			testKeyWorkflow: map[string]any{
+				testKeyType: testChildWorkflow,
+				"input":     map[string]any{"key": "value"},
 			},
 		},
 	})
@@ -237,7 +256,7 @@ func TestNormaliseRunTask_NoWorkflowKey(t *testing.T) {
 	// A run task without a workflow key (e.g. container run) must not be
 	// modified and must not error.
 	task := cloneMap(t, map[string]any{
-		"run": map[string]any{
+		testKeyRun: map[string]any{
 			"container": map[string]any{
 				"image": "alpine",
 			},
@@ -247,31 +266,31 @@ func TestNormaliseRunTask_NoWorkflowKey(t *testing.T) {
 	require.NoError(t, normaliseRunTask(task))
 
 	// run.container must survive unchanged.
-	run := task["run"].(map[string]any)
+	run := task[testKeyRun].(map[string]any)
 	assert.Equal(t, map[string]any{"image": "alpine"}, run["container"])
-	assert.NotContains(t, run, "workflow")
+	assert.NotContains(t, run, testKeyWorkflow)
 }
 
 func TestNormaliseRunTask_NoRunKey(t *testing.T) {
 	// A task without a "run" key at all (e.g. a set task) must be left
 	// completely unchanged and must not error.
 	task := cloneMap(t, map[string]any{
-		"set": map[string]any{
-			"greeting": "hello",
+		testKeySet: map[string]any{
+			"greeting": testHello,
 		},
 	})
 
 	require.NoError(t, normaliseRunTask(task))
 
-	assert.Equal(t, map[string]any{"greeting": "hello"}, task["set"])
+	assert.Equal(t, map[string]any{"greeting": testHello}, task[testKeySet])
 }
 
 func TestNormaliseRunTask_NormalisationIsIdempotentAfterRename(t *testing.T) {
 	// If the task already uses the SDK field name (name instead of type),
 	// the existing name must not be overwritten by a second rename attempt.
 	task := cloneMap(t, map[string]any{
-		"run": map[string]any{
-			"workflow": map[string]any{
+		testKeyRun: map[string]any{
+			testKeyWorkflow: map[string]any{
 				"name": "already-normalised",
 			},
 		},
@@ -290,18 +309,18 @@ func TestNormaliseWorkflowDocument_TopLevelDoRunTask(t *testing.T) {
 	// A run.workflow task nested directly in the top-level do list must be
 	// normalised.
 	doc := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "parent",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testParent,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
 		},
-		"do": []any{
+		testKeyDo: []any{
 			map[string]any{
 				"callChild": map[string]any{
-					"run": map[string]any{
-						"workflow": map[string]any{
-							"type": "child-workflow",
+					testKeyRun: map[string]any{
+						testKeyWorkflow: map[string]any{
+							testKeyType: testChildWorkflow,
 						},
 					},
 				},
@@ -313,35 +332,35 @@ func TestNormaliseWorkflowDocument_TopLevelDoRunTask(t *testing.T) {
 
 	// Top-level document mapping.
 	d := docOf(t, doc)
-	assert.Equal(t, "parent", d["name"])
+	assert.Equal(t, testParent, d["name"])
 	assert.Equal(t, "q", d["namespace"])
 
 	// Nested run.workflow normalisation.
-	tasks := doc["do"].([]any)
+	tasks := doc[testKeyDo].([]any)
 	callChild := tasks[0].(map[string]any)["callChild"].(map[string]any)
-	wf := callChild["run"].(map[string]any)["workflow"].(map[string]any)
-	assert.Equal(t, "child-workflow", wf["name"])
-	assert.NotContains(t, wf, "type")
+	wf := callChild[testKeyRun].(map[string]any)[testKeyWorkflow].(map[string]any)
+	assert.Equal(t, testChildWorkflow, wf["name"])
+	assert.NotContains(t, wf, testKeyType)
 }
 
 func TestNormaliseWorkflowDocument_RunTaskInsideTry(t *testing.T) {
 	// A run.workflow task inside a try block's task list must be normalised.
 	doc := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "parent",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testParent,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
 		},
-		"do": []any{
+		testKeyDo: []any{
 			map[string]any{
 				"tryBlock": map[string]any{
 					"try": []any{
 						map[string]any{
 							"callChild": map[string]any{
-								"run": map[string]any{
-									"workflow": map[string]any{
-										"type": "child-in-try",
+								testKeyRun: map[string]any{
+									testKeyWorkflow: map[string]any{
+										testKeyType: "child-in-try",
 									},
 								},
 							},
@@ -357,41 +376,41 @@ func TestNormaliseWorkflowDocument_RunTaskInsideTry(t *testing.T) {
 
 	require.NoError(t, normaliseWorkflowDocument(doc))
 
-	tasks := doc["do"].([]any)
+	tasks := doc[testKeyDo].([]any)
 	tryBlock := tasks[0].(map[string]any)["tryBlock"].(map[string]any)
 	tryList := tryBlock["try"].([]any)
-	wf := tryList[0].(map[string]any)["callChild"].(map[string]any)["run"].(map[string]any)["workflow"].(map[string]any)
+	wf := tryList[0].(map[string]any)["callChild"].(map[string]any)[testKeyRun].(map[string]any)[testKeyWorkflow].(map[string]any)
 	assert.Equal(t, "child-in-try", wf["name"])
-	assert.NotContains(t, wf, "type")
+	assert.NotContains(t, wf, testKeyType)
 }
 
 func TestNormaliseWorkflowDocument_RunTaskInsideCatchDo(t *testing.T) {
 	// A run.workflow task inside a catch.do list must be normalised.
 	doc := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "parent",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testParent,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
 		},
-		"do": []any{
+		testKeyDo: []any{
 			map[string]any{
 				"tryBlock": map[string]any{
 					"try": []any{
 						map[string]any{
 							"noop": map[string]any{
-								"set": map[string]any{"x": "1"},
+								testKeySet: map[string]any{"x": "1"},
 							},
 						},
 					},
 					"catch": map[string]any{
 						"errors": map[string]any{"with": map[string]any{}},
-						"do": []any{
+						testKeyDo: []any{
 							map[string]any{
 								"recover": map[string]any{
-									"run": map[string]any{
-										"workflow": map[string]any{
-											"type": "recovery-workflow",
+									testKeyRun: map[string]any{
+										testKeyWorkflow: map[string]any{
+											testKeyType: "recovery-workflow",
 										},
 									},
 								},
@@ -405,24 +424,24 @@ func TestNormaliseWorkflowDocument_RunTaskInsideCatchDo(t *testing.T) {
 
 	require.NoError(t, normaliseWorkflowDocument(doc))
 
-	tasks := doc["do"].([]any)
+	tasks := doc[testKeyDo].([]any)
 	tryBlock := tasks[0].(map[string]any)["tryBlock"].(map[string]any)
-	catchDo := tryBlock["catch"].(map[string]any)["do"].([]any)
-	wf := catchDo[0].(map[string]any)["recover"].(map[string]any)["run"].(map[string]any)["workflow"].(map[string]any)
+	catchDo := tryBlock["catch"].(map[string]any)[testKeyDo].([]any)
+	wf := catchDo[0].(map[string]any)["recover"].(map[string]any)[testKeyRun].(map[string]any)[testKeyWorkflow].(map[string]any)
 	assert.Equal(t, "recovery-workflow", wf["name"])
-	assert.NotContains(t, wf, "type")
+	assert.NotContains(t, wf, testKeyType)
 }
 
 func TestNormaliseWorkflowDocument_RunTaskInsideForkBranch(t *testing.T) {
 	// A run.workflow task inside a fork branch must be normalised.
 	doc := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "parent",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testParent,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
 		},
-		"do": []any{
+		testKeyDo: []any{
 			map[string]any{
 				"fanOut": map[string]any{
 					"fork": map[string]any{
@@ -430,18 +449,18 @@ func TestNormaliseWorkflowDocument_RunTaskInsideForkBranch(t *testing.T) {
 						"branches": []any{
 							map[string]any{
 								"branch1": map[string]any{
-									"run": map[string]any{
-										"workflow": map[string]any{
-											"type": "child-a",
+									testKeyRun: map[string]any{
+										testKeyWorkflow: map[string]any{
+											testKeyType: "child-a",
 										},
 									},
 								},
 							},
 							map[string]any{
 								"branch2": map[string]any{
-									"run": map[string]any{
-										"workflow": map[string]any{
-											"type": "child-b",
+									testKeyRun: map[string]any{
+										testKeyWorkflow: map[string]any{
+											testKeyType: "child-b",
 										},
 									},
 								},
@@ -455,17 +474,17 @@ func TestNormaliseWorkflowDocument_RunTaskInsideForkBranch(t *testing.T) {
 
 	require.NoError(t, normaliseWorkflowDocument(doc))
 
-	tasks := doc["do"].([]any)
+	tasks := doc[testKeyDo].([]any)
 	fanOut := tasks[0].(map[string]any)["fanOut"].(map[string]any)
 	branches := fanOut["fork"].(map[string]any)["branches"].([]any)
 
-	wf1 := branches[0].(map[string]any)["branch1"].(map[string]any)["run"].(map[string]any)["workflow"].(map[string]any)
+	wf1 := branches[0].(map[string]any)["branch1"].(map[string]any)[testKeyRun].(map[string]any)[testKeyWorkflow].(map[string]any)
 	assert.Equal(t, "child-a", wf1["name"])
-	assert.NotContains(t, wf1, "type")
+	assert.NotContains(t, wf1, testKeyType)
 
-	wf2 := branches[1].(map[string]any)["branch2"].(map[string]any)["run"].(map[string]any)["workflow"].(map[string]any)
+	wf2 := branches[1].(map[string]any)["branch2"].(map[string]any)[testKeyRun].(map[string]any)[testKeyWorkflow].(map[string]any)
 	assert.Equal(t, "child-b", wf2["name"])
-	assert.NotContains(t, wf2, "type")
+	assert.NotContains(t, wf2, testKeyType)
 }
 
 // --- no-op behaviour ---
@@ -473,17 +492,17 @@ func TestNormaliseWorkflowDocument_RunTaskInsideForkBranch(t *testing.T) {
 func TestNormaliseWorkflowDocument_SetTaskUntouched(t *testing.T) {
 	// A set task must pass through normalisation without any modification.
 	original := map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "wf",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testWFName,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
 		},
-		"do": []any{
+		testKeyDo: []any{
 			map[string]any{
 				"greet": map[string]any{
-					"set": map[string]any{
-						"hello": "world",
+					testKeySet: map[string]any{
+						testHello: "world",
 					},
 				},
 			},
@@ -493,9 +512,9 @@ func TestNormaliseWorkflowDocument_SetTaskUntouched(t *testing.T) {
 
 	require.NoError(t, normaliseWorkflowDocument(doc))
 
-	tasks := doc["do"].([]any)
+	tasks := doc[testKeyDo].([]any)
 	greet := tasks[0].(map[string]any)["greet"].(map[string]any)
-	assert.Equal(t, map[string]any{"hello": "world"}, greet["set"],
+	assert.Equal(t, map[string]any{testHello: "world"}, greet[testKeySet],
 		"set task body must be unchanged after normalisation")
 }
 
@@ -503,20 +522,20 @@ func TestNormaliseWorkflowDocument_NoDo(t *testing.T) {
 	// A document without a do key must have only the top-level field mapping
 	// applied and must not error.
 	doc := cloneMap(t, map[string]any{
-		"document": map[string]any{
-			"dsl":          "1.0.0",
-			"workflowType": "wf",
-			"taskQueue":    "q",
-			"version":      "1.0.0",
+		testKeyDocument: map[string]any{
+			testKeyDSL:          testDSLVersion,
+			testKeyWorkflowType: testWFName,
+			testKeyTaskQueue:    "q",
+			testKeyVersion:      testDSLVersion,
 		},
 	})
 
 	require.NoError(t, normaliseWorkflowDocument(doc))
 
 	d := docOf(t, doc)
-	assert.Equal(t, "wf", d["name"])
+	assert.Equal(t, testWFName, d["name"])
 	assert.Equal(t, "q", d["namespace"])
-	assert.NotContains(t, doc, "do")
+	assert.NotContains(t, doc, testKeyDo)
 }
 
 // --- normaliser boundary: defaults are not the normaliser's responsibility ---

--- a/pkg/zigflow/tasks/task_builder_call_activity_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_activity_test.go
@@ -55,7 +55,7 @@ func TestCallActivityTaskBuilderExecute(t *testing.T) {
 
 	workflowFunc := func(ctx workflow.Context) (string, error) {
 		state := utils.NewState().AddWorkflowInfo(ctx)
-		input := map[string]any{"message": "ping"}
+		input := map[string]any{testConstMessage: "ping"}
 		state.Input = input
 		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: time.Minute})
 		result, err := fn(ctx, input, state)

--- a/pkg/zigflow/tasks/task_builder_call_http_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_http_test.go
@@ -41,7 +41,7 @@ func TestParseHTTPArguments(t *testing.T) {
 				"X-Token": "${ $env.token }",
 			},
 			Query: map[string]any{
-				"debug": "${ $data.flag }",
+				"debug": testConstDataFlag,
 			},
 		},
 	}
@@ -58,7 +58,7 @@ func TestParseOutput(t *testing.T) {
 	httpResp := activities.HTTPResponse{
 		StatusCode: 200,
 		Content: map[string]any{
-			"message": "ok",
+			testConstMessage: "ok",
 		},
 	}
 	raw := []byte("payload")

--- a/pkg/zigflow/tasks/task_builder_do.go
+++ b/pkg/zigflow/tasks/task_builder_do.go
@@ -207,8 +207,8 @@ func (t *DoTaskBuilder) workflowExecutor(tasks []workflowFunc) TemporalWorkflowF
 		t.eventEmitter.Emit(context.Background(), "workflow.started", func(e *ceSDK.Event) {
 			e.SetID(workflow.GetInfo(ctx).WorkflowExecution.ID)
 			_ = e.SetData(ceSDK.ApplicationJSON, map[string]any{
-				"input": input,
-				"state": state,
+				constKeyInput: input,
+				constKeyState: state,
 			})
 		})
 
@@ -407,9 +407,9 @@ func (t *DoTaskBuilder) runTask(ctx workflow.Context, task workflowFunc, input a
 		e.SetID(workflowID)
 		e.SetSubject(task.Name)
 		_ = e.SetData(ceSDK.ApplicationJSON, map[string]any{
-			"attempt": info.Attempt,
-			"input":   input,
-			"state":   state,
+			"attempt":     info.Attempt,
+			constKeyInput: input,
+			constKeyState: state,
 		})
 	})
 
@@ -461,9 +461,9 @@ func (t *DoTaskBuilder) runTask(ctx workflow.Context, task workflowFunc, input a
 		e.SetID(workflowID)
 		e.SetSubject(task.Name)
 		_ = e.SetData(ceSDK.ApplicationJSON, map[string]any{
-			"input":  input,
-			"output": output,
-			"state":  state,
+			constKeyInput: input,
+			"output":      output,
+			constKeyState: state,
 		})
 	})
 

--- a/pkg/zigflow/tasks/task_builder_do_test.go
+++ b/pkg/zigflow/tasks/task_builder_do_test.go
@@ -79,7 +79,7 @@ func TestDoTaskBuilderWorkflowExecutor(t *testing.T) {
 			var capturedState *utils.State
 			runOrder := make([]string, 0, 2)
 			expectedOutput := map[string]any{
-				"value": "two",
+				testConstValue: "two",
 			}
 
 			tasks := newOutputWorkflowFuncs(&runOrder, &capturedState)
@@ -89,7 +89,7 @@ func TestDoTaskBuilderWorkflowExecutor(t *testing.T) {
 			env := s.NewTestWorkflowEnvironment()
 
 			inputPayload := map[string]any{
-				"request_id": tc.name,
+				testConstRequestID: tc.name,
 			}
 			workflowName := "workflow-" + tc.name
 
@@ -106,7 +106,7 @@ func TestDoTaskBuilderWorkflowExecutor(t *testing.T) {
 			assert.NoError(t, env.GetWorkflowResult(&workflowResult))
 			assert.Equal(t, expectedOutput, workflowResult)
 
-			assert.Equal(t, []string{"task-one", "task-two"}, runOrder)
+			assert.Equal(t, []string{"task-one", testConstTaskTwo}, runOrder)
 			assert.NotNil(t, capturedState)
 			if tc.initialState != nil {
 				assert.Same(t, tc.initialState, capturedState)
@@ -134,14 +134,14 @@ func TestDoTaskBuilderIterateTasksFlowControl(t *testing.T) {
 				return []workflowFunc{
 					newSimpleWorkflowFunc("task-a", &model.TaskBase{
 						Then: &model.FlowDirective{
-							Value: "task-c",
+							Value: testConstTaskC,
 						},
 					}, runOrder),
 					newSimpleWorkflowFunc("task-b", &model.TaskBase{}, runOrder),
-					newSimpleWorkflowFunc("task-c", &model.TaskBase{}, runOrder),
+					newSimpleWorkflowFunc(testConstTaskC, &model.TaskBase{}, runOrder),
 				}
 			},
-			expectedRun: []string{"task-a", "task-c"},
+			expectedRun: []string{"task-a", testConstTaskC},
 		},
 		{
 			name: "missing target returns descriptive error",
@@ -149,7 +149,7 @@ func TestDoTaskBuilderIterateTasksFlowControl(t *testing.T) {
 				return []workflowFunc{
 					newSimpleWorkflowFunc("task-a", &model.TaskBase{
 						Then: &model.FlowDirective{
-							Value: "task-c",
+							Value: testConstTaskC,
 						},
 					}, runOrder),
 					newSimpleWorkflowFunc("task-b", &model.TaskBase{}, runOrder),
@@ -280,7 +280,7 @@ func TestDoTaskBuilderContinueAsNew(t *testing.T) {
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return nil, builder.continueAsNew(ctx, builder.GetTaskName(), "task-one-0", map[string]any{"request_id": "123"}, state)
+		return nil, builder.continueAsNew(ctx, builder.GetTaskName(), "task-one-0", map[string]any{testConstRequestID: "123"}, state)
 	}, workflow.RegisterOptions{Name: builder.GetTaskName()})
 
 	env.ExecuteWorkflow(builder.GetTaskName())
@@ -333,7 +333,7 @@ func TestDoTaskBuilderIterateTasksSkipsCompletedTasks(t *testing.T) {
 
 	tasks := []workflowFunc{
 		newSimpleWorkflowFunc("task-one", &model.TaskBase{}, &runOrder),
-		newSimpleWorkflowFunc("task-two", &model.TaskBase{}, &runOrder),
+		newSimpleWorkflowFunc(testConstTaskTwo, &model.TaskBase{}, &runOrder),
 	}
 
 	var s testsuite.WorkflowTestSuite
@@ -345,7 +345,7 @@ func TestDoTaskBuilderIterateTasksSkipsCompletedTasks(t *testing.T) {
 	env.ExecuteWorkflow(builder.GetTaskName())
 
 	assert.NoError(t, env.GetWorkflowError())
-	assert.Equal(t, []string{"task-two"}, runOrder)
+	assert.Equal(t, []string{testConstTaskTwo}, runOrder)
 	assert.Nil(t, state.CANStartFrom)
 }
 
@@ -385,8 +385,8 @@ func TestDoTaskBuilderShouldSkip(t *testing.T) {
 			name: "matching task ID resumes execution",
 			task: func() workflowFunc {
 				return workflowFunc{
-					TaskBuilder: newFakeTaskBuilder("task-two", &model.TaskBase{}),
-					Name:        "task-two",
+					TaskBuilder: newFakeTaskBuilder(testConstTaskTwo, &model.TaskBase{}),
+					Name:        testConstTaskTwo,
 				}
 			}(),
 			taskID: "task-two-1",
@@ -526,7 +526,7 @@ func newOutputWorkflowFuncs(runOrder *[]string, capturedState **utils.State) []w
 	}
 
 	taskOneBuilder := newFakeTaskBuilder("task-one", taskOneBase)
-	taskTwoBuilder := newFakeTaskBuilder("task-two", taskTwoBase)
+	taskTwoBuilder := newFakeTaskBuilder(testConstTaskTwo, taskTwoBase)
 
 	return []workflowFunc{
 		{
@@ -536,7 +536,7 @@ func newOutputWorkflowFuncs(runOrder *[]string, capturedState **utils.State) []w
 				*capturedState = state
 				*runOrder = append(*runOrder, "task-one")
 				return map[string]any{
-					"value": "one",
+					testConstValue: "one",
 				}, nil
 			},
 		},
@@ -544,9 +544,9 @@ func newOutputWorkflowFuncs(runOrder *[]string, capturedState **utils.State) []w
 			TaskBuilder: taskTwoBuilder,
 			Name:        taskTwoBuilder.GetTaskName(),
 			Func: func(ctx workflow.Context, input any, state *utils.State) (any, error) {
-				*runOrder = append(*runOrder, "task-two")
+				*runOrder = append(*runOrder, testConstTaskTwo)
 				return map[string]any{
-					"value": "two",
+					testConstValue: "two",
 				}, nil
 			},
 		},

--- a/pkg/zigflow/tasks/task_builder_for.go
+++ b/pkg/zigflow/tasks/task_builder_for.go
@@ -159,8 +159,8 @@ func (t *ForTaskBuilder) addIterationResult(ctx workflow.Context, state *utils.S
 		e.SetID(workflowID)
 		e.SetSubject(taskName)
 		_ = e.SetData(ceSDK.ApplicationJSON, map[string]any{
-			"state": state,
-			"while": t.task.While,
+			constKeyState: state,
+			"while":       t.task.While,
 		})
 	})
 }
@@ -300,7 +300,7 @@ func (t *ForTaskBuilder) iterator(ctx workflow.Context, key, value any, workingS
 	}
 	valueVar := t.task.For.Each
 	if valueVar == "" {
-		valueVar = "item"
+		valueVar = constDefaultItemVar
 	}
 
 	// Build a per-iteration state that adds the loop-local variables.

--- a/pkg/zigflow/tasks/task_builder_for_test.go
+++ b/pkg/zigflow/tasks/task_builder_for_test.go
@@ -42,7 +42,7 @@ func TestForTaskBuilderAddIterationResult(t *testing.T) {
 		{
 			name:     "adds map response to state data",
 			taskName: "map-task",
-			response: map[string]any{"key": "value"},
+			response: map[string]any{"key": testConstValue},
 		},
 		{
 			name:     "adds nil response to state data",
@@ -61,7 +61,7 @@ func TestForTaskBuilderAddIterationResult(t *testing.T) {
 					eventEmitter: testEvents,
 					name:         tc.taskName,
 					task: &model.ForTask{
-						For: model.ForTaskConfiguration{In: "${ .data.items }"},
+						For: model.ForTaskConfiguration{In: testConstForDataItems},
 						Do:  &model.TaskList{},
 					},
 				},
@@ -98,7 +98,7 @@ func TestForTaskBuilderCheckWhile(t *testing.T) {
 		},
 		{
 			name:  "boolean true expression",
-			while: "${ $data.flag }",
+			while: testConstDataFlag,
 			stateData: map[string]any{
 				"flag": true,
 			},
@@ -106,7 +106,7 @@ func TestForTaskBuilderCheckWhile(t *testing.T) {
 		},
 		{
 			name:  "boolean false expression",
-			while: "${ $data.flag }",
+			while: testConstDataFlag,
 			stateData: map[string]any{
 				"flag": false,
 			},
@@ -137,7 +137,7 @@ func TestForTaskBuilderCheckWhile(t *testing.T) {
 					eventEmitter: testEvents,
 					name:         "for-task",
 					task: &model.ForTask{
-						For:   model.ForTaskConfiguration{In: "${ .data.items }"},
+						For:   model.ForTaskConfiguration{In: testConstForDataItems},
 						While: tc.while,
 						Do:    &model.TaskList{},
 					},
@@ -172,7 +172,7 @@ func TestForTaskBuilderCheckWhile(t *testing.T) {
 func TestForTaskBuilderIterator(t *testing.T) {
 	state := utils.NewState()
 	state.Input = map[string]any{
-		"request_id": "abc",
+		testConstRequestID: "abc",
 	}
 
 	builder := &ForTaskBuilder{
@@ -182,9 +182,9 @@ func TestForTaskBuilderIterator(t *testing.T) {
 			name:         "iterate",
 			task: &model.ForTask{
 				For: model.ForTaskConfiguration{
-					Each: "value",
-					At:   "idx",
-					In:   "${ .data.items }",
+					Each: testConstValue,
+					At:   testConstIdx,
+					In:   testConstForDataItems,
 				},
 				Do: &model.TaskList{
 					&model.TaskItem{Key: "first", Task: &model.DoTask{}},
@@ -199,17 +199,17 @@ func TestForTaskBuilderIterator(t *testing.T) {
 
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
 		return forChildResult{
-			Output:  map[string]any{"child_value": st.Data["value"]},
+			Output:  map[string]any{testConstChildValue: st.Data[testConstValue]},
 			Context: nil,
 		}, nil
 	}, workflow.RegisterOptions{Name: builder.childWorkflowName})
 
 	state.AddData(map[string]any{
-		"items": []any{"item-value"},
+		testConstItems: []any{testConstItemValue},
 	})
 
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return builder.iterator(ctx, 0, "item-value", state)
+		return builder.iterator(ctx, 0, testConstItemValue, state)
 	}, workflow.RegisterOptions{Name: "iterator-test"})
 
 	env.ExecuteWorkflow("iterator-test")
@@ -218,14 +218,14 @@ func TestForTaskBuilderIterator(t *testing.T) {
 	var result map[string]any
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
-	assert.Equal(t, map[string]any{"child_value": "item-value"}, result)
+	assert.Equal(t, map[string]any{testConstChildValue: testConstItemValue}, result)
 	// iterator() propagates the child's output back onto the working state (the
 	// state passed as the workingState parameter, which in this test is state itself).
-	assert.Equal(t, map[string]any{"child_value": "item-value"}, state.Output)
+	assert.Equal(t, map[string]any{testConstChildValue: testConstItemValue}, state.Output)
 	// Loop-local variables must not appear on the state passed to iterator()
 	// because they are placed on a per-iteration clone (iterState) inside iterator().
-	assert.Nil(t, state.Data["value"])
-	assert.Nil(t, state.Data["idx"])
+	assert.Nil(t, state.Data[testConstValue])
+	assert.Nil(t, state.Data[testConstIdx])
 }
 
 // TestForIteratorContextPropagates verifies that $context set by an export in
@@ -239,8 +239,8 @@ func TestForIteratorContextPropagates(t *testing.T) {
 			eventEmitter: testEvents,
 			name:         "ctx-prop",
 			task: &model.ForTask{
-				For: model.ForTaskConfiguration{Each: "item", At: "idx", In: "${ .data.items }"},
-				Do:  &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				For: model.ForTaskConfiguration{Each: constDefaultItemVar, At: testConstIdx, In: testConstForDataItems},
+				Do:  &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -256,8 +256,8 @@ func TestForIteratorContextPropagates(t *testing.T) {
 		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
 			receivedContexts = append(receivedContexts, st.Context)
 			return forChildResult{
-				Output:  st.Data["item"],
-				Context: map[string]any{"last": st.Data["item"]},
+				Output:  st.Data[constDefaultItemVar],
+				Context: map[string]any{testConstLast: st.Data[constDefaultItemVar]},
 			}, nil
 		},
 		workflow.RegisterOptions{Name: childWorkflowName},
@@ -282,9 +282,9 @@ func TestForIteratorContextPropagates(t *testing.T) {
 	// First iteration starts with no exported context.
 	assert.Nil(t, receivedContexts[0])
 	// Second iteration sees the context exported by the first iteration.
-	assert.Equal(t, map[string]any{"last": "alpha"}, receivedContexts[1])
+	assert.Equal(t, map[string]any{testConstLast: "alpha"}, receivedContexts[1])
 	// Parent state ends with the context from the final iteration.
-	assert.Equal(t, map[string]any{"last": "beta"}, state.Context)
+	assert.Equal(t, map[string]any{testConstLast: "beta"}, state.Context)
 }
 
 // TestForIteratorWhileSeesOutput verifies that the while condition for iteration
@@ -300,8 +300,8 @@ func TestForIteratorWhileSeesOutput(t *testing.T) {
 			task: &model.ForTask{
 				// Continue while $output.continue is true.
 				While: "${ $output.continue }",
-				For:   model.ForTaskConfiguration{Each: "item", At: "idx", In: "${ .data.items }"},
-				Do:    &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				For:   model.ForTaskConfiguration{Each: constDefaultItemVar, At: testConstIdx, In: testConstForDataItems},
+				Do:    &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -372,11 +372,11 @@ func TestForExecArrayAccumulatesResults(t *testing.T) {
 			name:         "accum",
 			task: &model.ForTask{
 				For: model.ForTaskConfiguration{
-					Each: "item",
-					At:   "idx",
-					In:   "${ $data.items }",
+					Each: constDefaultItemVar,
+					At:   testConstIdx,
+					In:   testConstForRefDataItems,
 				},
-				Do: &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -388,7 +388,7 @@ func TestForExecArrayAccumulatesResults(t *testing.T) {
 	env.RegisterWorkflowWithOptions(
 		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
 			return forChildResult{
-				Output:  map[string]any{"processed": st.Data["item"]},
+				Output:  map[string]any{testConstProcessed: st.Data[constDefaultItemVar]},
 				Context: nil,
 			}, nil
 		},
@@ -396,7 +396,7 @@ func TestForExecArrayAccumulatesResults(t *testing.T) {
 	)
 
 	state := utils.NewState()
-	state.AddData(map[string]any{"items": []any{"x", "y", "z"}})
+	state.AddData(map[string]any{testConstItems: []any{"x", "y", "z"}})
 
 	execFn, err := b.exec()
 	assert.NoError(t, err)
@@ -412,9 +412,9 @@ func TestForExecArrayAccumulatesResults(t *testing.T) {
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
 	assert.Equal(t, []any{
-		map[string]any{"processed": "x"},
-		map[string]any{"processed": "y"},
-		map[string]any{"processed": "z"},
+		map[string]any{testConstProcessed: "x"},
+		map[string]any{testConstProcessed: "y"},
+		map[string]any{testConstProcessed: "z"},
 	}, result)
 }
 
@@ -432,9 +432,9 @@ func TestForExecObjectAccumulatesResults(t *testing.T) {
 				For: model.ForTaskConfiguration{
 					Each: "val",
 					At:   "key",
-					In:   "${ $data.items }",
+					In:   testConstForRefDataItems,
 				},
-				Do: &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -454,7 +454,7 @@ func TestForExecObjectAccumulatesResults(t *testing.T) {
 	)
 
 	state := utils.NewState()
-	state.AddData(map[string]any{"items": map[string]any{"a": 1, "b": 2}})
+	state.AddData(map[string]any{testConstItems: map[string]any{"a": 1, "b": 2}})
 
 	execFn, err := b.exec()
 	assert.NoError(t, err)
@@ -486,10 +486,10 @@ func TestForExecNumericAccumulatesResults(t *testing.T) {
 			task: &model.ForTask{
 				For: model.ForTaskConfiguration{
 					Each: "val",
-					At:   "idx",
+					At:   testConstIdx,
 					In:   "${ $data.count }",
 				},
-				Do: &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -500,7 +500,7 @@ func TestForExecNumericAccumulatesResults(t *testing.T) {
 
 	env.RegisterWorkflowWithOptions(
 		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{Output: st.Data["idx"], Context: nil}, nil
+			return forChildResult{Output: st.Data[testConstIdx], Context: nil}, nil
 		},
 		workflow.RegisterOptions{Name: childWorkflowName},
 	)
@@ -538,11 +538,11 @@ func TestForExecLoopVarsDoNotLeakToParent(t *testing.T) {
 			name:         "leak-check",
 			task: &model.ForTask{
 				For: model.ForTaskConfiguration{
-					Each: "item",
-					At:   "idx",
-					In:   "${ $data.items }",
+					Each: constDefaultItemVar,
+					At:   testConstIdx,
+					In:   testConstForRefDataItems,
 				},
-				Do: &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -553,13 +553,13 @@ func TestForExecLoopVarsDoNotLeakToParent(t *testing.T) {
 
 	env.RegisterWorkflowWithOptions(
 		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{Output: st.Data["item"], Context: nil}, nil
+			return forChildResult{Output: st.Data[constDefaultItemVar], Context: nil}, nil
 		},
 		workflow.RegisterOptions{Name: childWorkflowName},
 	)
 
 	state := utils.NewState()
-	state.AddData(map[string]any{"items": []any{"a", "b"}})
+	state.AddData(map[string]any{testConstItems: []any{"a", "b"}})
 
 	execFn, err := b.exec()
 	assert.NoError(t, err)
@@ -572,10 +572,10 @@ func TestForExecLoopVarsDoNotLeakToParent(t *testing.T) {
 	assert.NoError(t, env.GetWorkflowError())
 
 	// Loop-local variables must not appear in parent state after the loop exits.
-	assert.Nil(t, state.Data["item"], "item must not leak to parent state")
-	assert.Nil(t, state.Data["idx"], "idx must not leak to parent state")
+	assert.Nil(t, state.Data[constDefaultItemVar], "item must not leak to parent state")
+	assert.Nil(t, state.Data[testConstIdx], "idx must not leak to parent state")
 	// The pre-loop data must be unmodified.
-	assert.Equal(t, []any{"a", "b"}, state.Data["items"])
+	assert.Equal(t, []any{"a", "b"}, state.Data[testConstItems])
 }
 
 // TestForExecContextDoesNotLeakToParent verifies that $context updated by an
@@ -592,11 +592,11 @@ func TestForExecContextDoesNotLeakToParent(t *testing.T) {
 			name:         "ctx-leak",
 			task: &model.ForTask{
 				For: model.ForTaskConfiguration{
-					Each: "item",
-					At:   "idx",
-					In:   "${ $data.items }",
+					Each: constDefaultItemVar,
+					At:   testConstIdx,
+					In:   testConstForRefDataItems,
 				},
-				Do: &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -608,15 +608,15 @@ func TestForExecContextDoesNotLeakToParent(t *testing.T) {
 	env.RegisterWorkflowWithOptions(
 		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
 			return forChildResult{
-				Output:  st.Data["item"],
-				Context: map[string]any{"last": st.Data["item"]},
+				Output:  st.Data[constDefaultItemVar],
+				Context: map[string]any{testConstLast: st.Data[constDefaultItemVar]},
 			}, nil
 		},
 		workflow.RegisterOptions{Name: childWorkflowName},
 	)
 
 	state := utils.NewState()
-	state.AddData(map[string]any{"items": []any{"x", "y"}})
+	state.AddData(map[string]any{testConstItems: []any{"x", "y"}})
 
 	execFn, err := b.exec()
 	assert.NoError(t, err)
@@ -649,11 +649,11 @@ func TestForExecOutputIsAggregatedResult(t *testing.T) {
 			name:         "no-out-leak",
 			task: &model.ForTask{
 				For: model.ForTaskConfiguration{
-					Each: "item",
-					At:   "idx",
-					In:   "${ $data.items }",
+					Each: constDefaultItemVar,
+					At:   testConstIdx,
+					In:   testConstForRefDataItems,
 				},
-				Do: &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -670,7 +670,7 @@ func TestForExecOutputIsAggregatedResult(t *testing.T) {
 	)
 
 	state := utils.NewState()
-	state.AddData(map[string]any{"items": []any{"a"}})
+	state.AddData(map[string]any{testConstItems: []any{"a"}})
 
 	execFn, err := b.exec()
 	assert.NoError(t, err)
@@ -703,11 +703,11 @@ func TestForExecErrorLeavesParentStateUnchanged(t *testing.T) {
 			name:         "err-unchanged",
 			task: &model.ForTask{
 				For: model.ForTaskConfiguration{
-					Each: "item",
-					At:   "idx",
-					In:   "${ $data.items }",
+					Each: constDefaultItemVar,
+					At:   testConstIdx,
+					In:   testConstForRefDataItems,
 				},
-				Do: &model.TaskList{&model.TaskItem{Key: "step", Task: &model.DoTask{}}},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
 		childWorkflowName: childWorkflowName,
@@ -726,7 +726,7 @@ func TestForExecErrorLeavesParentStateUnchanged(t *testing.T) {
 	state := utils.NewState()
 	state.Context = map[string]any{"original": true}
 	state.Output = "original-output"
-	state.AddData(map[string]any{"items": []any{"a"}})
+	state.AddData(map[string]any{testConstItems: []any{"a"}})
 
 	execFn, err := b.exec()
 	assert.NoError(t, err)
@@ -744,12 +744,12 @@ func TestForExecErrorLeavesParentStateUnchanged(t *testing.T) {
 		"exec() must not modify state.Context when an iteration fails")
 	assert.Equal(t, "original-output", state.Output,
 		"exec() must not modify state.Output when an iteration fails")
-	assert.Equal(t, []any{"a"}, state.Data["items"],
+	assert.Equal(t, []any{"a"}, state.Data[testConstItems],
 		"pre-loop Data must be unchanged when an iteration fails")
 	assert.Nil(t, state.Data["err-unchanged"],
 		"loop task result must not appear in parent Data when an iteration fails")
-	assert.Nil(t, state.Data["item"],
+	assert.Nil(t, state.Data[constDefaultItemVar],
 		"loop-local variable must not leak into parent Data when an iteration fails")
-	assert.Nil(t, state.Data["idx"],
+	assert.Nil(t, state.Data[testConstIdx],
 		"loop-local variable must not leak into parent Data when an iteration fails")
 }

--- a/pkg/zigflow/tasks/task_builder_listen_test.go
+++ b/pkg/zigflow/tasks/task_builder_listen_test.go
@@ -142,8 +142,8 @@ func TestListenTaskBuilderProcessReply(t *testing.T) {
 			ID:   "evt",
 			Type: string(ListenTaskTypeSignal),
 			Additional: map[string]any{
-				"data": map[string]any{
-					"result": "${ $data.message }",
+				testConstData: map[string]any{
+					testConstResult: "${ $data.message }",
 				},
 			},
 		},
@@ -151,7 +151,7 @@ func TestListenTaskBuilderProcessReply(t *testing.T) {
 
 	state := utils.NewState()
 	state.AddData(map[string]any{
-		"message": "hello",
+		testConstMessage: "hello",
 	})
 
 	var s testsuite.WorkflowTestSuite
@@ -167,5 +167,5 @@ func TestListenTaskBuilderProcessReply(t *testing.T) {
 	var result map[string]any
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
-	assert.Equal(t, map[string]any{"result": "hello"}, result)
+	assert.Equal(t, map[string]any{testConstResult: "hello"}, result)
 }

--- a/pkg/zigflow/tasks/task_builder_run.go
+++ b/pkg/zigflow/tasks/task_builder_run.go
@@ -93,7 +93,7 @@ func (t *RunTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 }
 
 func (t *RunTaskBuilder) validateScriptConfig(s *model.Script) error {
-	if !slices.Contains([]string{"js", "python"}, s.Language) {
+	if !slices.Contains([]string{"js", constScriptLanguagePython}, s.Language) {
 		return fmt.Errorf("unknown script language '%s' for task: %s", s.Language, t.GetTaskName())
 	}
 	if !*t.task.Run.Await {
@@ -127,7 +127,7 @@ func (t *RunTaskBuilder) PostLoad() error {
 	// Default run.workflow fields.
 	if w := t.task.Run.Workflow; w != nil {
 		if w.Namespace == "" {
-			w.Namespace = "default"
+			w.Namespace = constDefaultNamespace
 		}
 		if w.Version == "" {
 			w.Version = "0.0.1"

--- a/pkg/zigflow/tasks/task_builder_run_test.go
+++ b/pkg/zigflow/tasks/task_builder_run_test.go
@@ -33,7 +33,7 @@ func TestRunTaskBuilderPostLoadSetsAwaitDefault(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
 			Workflow: &model.RunWorkflow{
-				Namespace: "default",
+				Namespace: constDefaultNamespace,
 				Name:      "child-runner",
 				Version:   "1.0.0",
 			},
@@ -91,7 +91,7 @@ func TestRunTaskBuilderRunWorkflow(t *testing.T) {
 				Run: model.RunTaskConfiguration{
 					Await: tc.await,
 					Workflow: &model.RunWorkflow{
-						Namespace: "default",
+						Namespace: constDefaultNamespace,
 						Name:      "child-runner",
 						Version:   "1.0.0",
 					},
@@ -109,14 +109,14 @@ func TestRunTaskBuilderRunWorkflow(t *testing.T) {
 
 			env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, state *utils.State) (any, error) {
 				return map[string]any{
-					"child": "done",
+					testConstChild: testConstDone,
 				}, nil
 			}, workflow.RegisterOptions{Name: task.Run.Workflow.Name})
 
 			state := utils.NewState()
 
 			env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-				return fn(ctx, map[string]any{"request": "data"}, state)
+				return fn(ctx, map[string]any{testConstRequest: testConstData}, state)
 			}, workflow.RegisterOptions{Name: "run-" + tc.name})
 
 			env.ExecuteWorkflow("run-" + tc.name)
@@ -130,7 +130,7 @@ func TestRunTaskBuilderRunWorkflow(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, map[string]any{"child": "done"}, result)
+				assert.Equal(t, map[string]any{testConstChild: testConstDone}, result)
 			}
 
 			val, ok := state.Data["run-task"]
@@ -138,7 +138,7 @@ func TestRunTaskBuilderRunWorkflow(t *testing.T) {
 			if tc.expectNilResp {
 				assert.Nil(t, val)
 			} else {
-				assert.Equal(t, map[string]any{"child": "done"}, val)
+				assert.Equal(t, map[string]any{testConstChild: testConstDone}, val)
 			}
 		})
 	}
@@ -170,7 +170,7 @@ func TestRunTaskBuilderRunScriptValidation(t *testing.T) {
 			task: &model.RunTask{
 				Run: model.RunTaskConfiguration{
 					Script: &model.Script{
-						Language: "python",
+						Language: constScriptLanguagePython,
 					},
 				},
 			},
@@ -182,7 +182,7 @@ func TestRunTaskBuilderRunScriptValidation(t *testing.T) {
 				Run: model.RunTaskConfiguration{
 					Await: utils.Ptr(false),
 					Script: &model.Script{
-						Language:   "python",
+						Language:   constScriptLanguagePython,
 						InlineCode: utils.Ptr(inline),
 					},
 				},
@@ -194,7 +194,7 @@ func TestRunTaskBuilderRunScriptValidation(t *testing.T) {
 			task: &model.RunTask{
 				Run: model.RunTaskConfiguration{
 					Script: &model.Script{
-						Language:   "python",
+						Language:   constScriptLanguagePython,
 						InlineCode: utils.Ptr(inline),
 						External: &model.ExternalResource{
 							Endpoint: model.NewEndpoint("file:///scripts/run.py"),
@@ -209,7 +209,7 @@ func TestRunTaskBuilderRunScriptValidation(t *testing.T) {
 			task: &model.RunTask{
 				Run: model.RunTaskConfiguration{
 					Script: &model.Script{
-						Language: "python",
+						Language: constScriptLanguagePython,
 						External: &model.ExternalResource{
 							// Endpoint intentionally nil
 						},
@@ -227,7 +227,7 @@ func TestRunTaskBuilderRunScriptValidation(t *testing.T) {
 		task := &model.RunTask{
 			Run: model.RunTaskConfiguration{
 				Script: &model.Script{
-					Language: "python",
+					Language: constScriptLanguagePython,
 					External: &model.ExternalResource{
 						Endpoint: model.NewEndpoint("file:///scripts/run.py"),
 					},
@@ -267,7 +267,7 @@ func TestRunTaskBuilderRunScriptExecutesActivity(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
 			Script: &model.Script{
-				Language:   "python",
+				Language:   constScriptLanguagePython,
 				InlineCode: utils.Ptr("print('hello')"),
 			},
 		},
@@ -291,7 +291,7 @@ func TestRunTaskBuilderRunScriptExecutesActivity(t *testing.T) {
 
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
 		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: time.Minute})
-		return fn(ctx, map[string]any{"request": "data"}, state)
+		return fn(ctx, map[string]any{testConstRequest: testConstData}, state)
 	}, workflow.RegisterOptions{Name: "script-run"})
 
 	env.ExecuteWorkflow("script-run")
@@ -307,7 +307,7 @@ func TestRunTaskBuilderRunScriptExecutesActivity(t *testing.T) {
 func TestRunTaskBuilderPostLoadSetsAwaitToTrueWhenNil(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
-			Shell: &model.Shell{Command: "echo"},
+			Shell: &model.Shell{Command: testConstEcho},
 			// Await intentionally omitted
 		},
 	}
@@ -323,7 +323,7 @@ func TestRunTaskBuilderPostLoadSetsAwaitToTrueWhenNil(t *testing.T) {
 func TestRunTaskBuilderPostLoadPreservesExplicitAwait(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
-			Shell: &model.Shell{Command: "echo"},
+			Shell: &model.Shell{Command: testConstEcho},
 			Await: utils.Ptr(false),
 		},
 	}
@@ -403,14 +403,14 @@ func TestRunTaskBuilderPostLoadDefaultsEmptyNamespaceAndVersion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, builder.PostLoad())
 
-	assert.Equal(t, "default", task.Run.Workflow.Namespace, "empty namespace should receive default")
+	assert.Equal(t, constDefaultNamespace, task.Run.Workflow.Namespace, "empty namespace should receive default")
 	assert.Equal(t, "0.0.1", task.Run.Workflow.Version, "empty version should receive default")
 }
 
 func TestRunTaskBuilderPostLoadNilWorkflowIsNoop(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
-			Shell: &model.Shell{Command: "echo"},
+			Shell: &model.Shell{Command: testConstEcho},
 			// Workflow is nil — PostLoad must not panic
 		},
 	}
@@ -428,7 +428,7 @@ func TestRunTaskBuilderRunShellExecutesActivity(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
 			Shell: &model.Shell{
-				Command: "echo",
+				Command: testConstEcho,
 			},
 		},
 	}
@@ -451,7 +451,7 @@ func TestRunTaskBuilderRunShellExecutesActivity(t *testing.T) {
 
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
 		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: time.Minute})
-		return fn(ctx, map[string]any{"request": "data"}, state)
+		return fn(ctx, map[string]any{testConstRequest: testConstData}, state)
 	}, workflow.RegisterOptions{Name: "shell-run"})
 
 	env.ExecuteWorkflow("shell-run")

--- a/pkg/zigflow/tasks/task_builder_set_test.go
+++ b/pkg/zigflow/tasks/task_builder_set_test.go
@@ -29,8 +29,8 @@ import (
 func TestSetTaskBuilderBuild(t *testing.T) {
 	task := &model.SetTask{
 		Set: map[string]any{
-			"result": map[string]any{
-				"value": "${ $env.VALUE }",
+			testConstResult: map[string]any{
+				testConstValue: "${ $env.VALUE }",
 			},
 		},
 	}
@@ -42,7 +42,7 @@ func TestSetTaskBuilderBuild(t *testing.T) {
 	assert.NoError(t, err)
 
 	state := utils.NewState()
-	state.Env["VALUE"] = "ok"
+	state.Env["VALUE"] = testConstOK
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
@@ -58,11 +58,11 @@ func TestSetTaskBuilderBuild(t *testing.T) {
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
 	expected := map[string]any{
-		"result": map[string]any{
-			"value": "ok",
+		testConstResult: map[string]any{
+			testConstValue: testConstOK,
 		},
 	}
 
 	assert.Equal(t, expected, result)
-	assert.Equal(t, expected["result"], state.Data["result"])
+	assert.Equal(t, expected[testConstResult], state.Data[testConstResult])
 }

--- a/pkg/zigflow/tasks/test_helpers_test.go
+++ b/pkg/zigflow/tasks/test_helpers_test.go
@@ -21,6 +21,53 @@ import (
 	"github.com/zigflow/zigflow/pkg/cloudevents"
 )
 
+const (
+	// testConstValue is a generic map key used in test payloads.
+	testConstValue = "value"
+	// testConstMessage is a map key used in test payloads that carry a message field.
+	testConstMessage = "message"
+	// testConstRequestID is a map key used for request identifiers in test inputs.
+	testConstRequestID = "request_id"
+	// testConstData is a map key used in event payloads that carry a data field.
+	testConstData = "data"
+	// testConstResult is a map key used in test payloads that carry a result field.
+	testConstResult = "result"
+	// testConstDataFlag is the jq expression used in tests to evaluate a boolean flag from $data.
+	testConstDataFlag = "${ $data.flag }"
+	// testConstTaskTwo is the task name "task-two" used in do-task flow-control tests.
+	testConstTaskTwo = "task-two"
+	// testConstTaskC is the task name "task-c" used in do-task flow-control tests.
+	testConstTaskC = "task-c"
+	// testConstForDataItems is the jq expression used to reference items via .data.items.
+	testConstForDataItems = "${ .data.items }"
+	// testConstForRefDataItems is the jq expression used to reference items via $data.items.
+	testConstForRefDataItems = "${ $data.items }"
+	// testConstIdx is the loop index variable name used in for-task tests.
+	testConstIdx = "idx"
+	// testConstStep is the step task name used in for-task tests.
+	testConstStep = "step"
+	// testConstItemValue is the sample item string used in for-task iterator tests.
+	testConstItemValue = "item-value"
+	// testConstChildValue is the child output key used in for-task iterator tests.
+	testConstChildValue = "child_value"
+	// testConstLast is the key used to store the last-seen item in context propagation tests.
+	testConstLast = "last"
+	// testConstProcessed is the key used for the processed output in accumulator tests.
+	testConstProcessed = "processed"
+	// testConstEcho is the shell command used in run-task shell tests.
+	testConstEcho = "echo"
+	// testConstChild is the map key used in run-task child workflow result tests.
+	testConstChild = "child"
+	// testConstOK is the string value assigned to an env var in set-task tests.
+	testConstOK = "ok"
+	// testConstItems is the map key used for the items slice in for-task tests.
+	testConstItems = "items"
+	// testConstDone is the string value returned by child workflows in run-task tests.
+	testConstDone = "done"
+	// testConstRequest is the map key used for request payloads in run-task tests.
+	testConstRequest = "request"
+)
+
 var (
 	// testWorkflow is a shared workflow instance for testing purposes.
 	testWorkflow = &model.Workflow{

--- a/toodaloo.md
+++ b/toodaloo.md
@@ -4,5 +4,5 @@
 
 | File | Line Number | Author | Message |
 | --- | --- | --- | --- |
-| [pkg/zigflow/activities/run.go](pkg/zigflow/activities/run.go#L46) | 46 | Simon Emms <simon@simonemms.com> | in addition to Docker #181 |
+| [pkg/zigflow/activities/run.go](pkg/zigflow/activities/run.go#L52) | 52 | Simon Emms <simon@simonemms.com> | in addition to Docker #181 |
 | [pkg/zigflow/tasks/task_builder_listen.go](pkg/zigflow/tasks/task_builder_listen.go#L327) | 327 | Simon Emms <simon@simonemms.com> | configure the "until" EventConsumptionUntil for "any" events |


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The main issue was repeated string literals now being reported once they appeared 3+ times. Because golangci-lint caps output at 50 issues per linter, this required several lint/fix cycles as earlier fixes revealed additional issues.

Changes made:

* Added shared constants for repeated schema/type/property strings
* Replaced repeated literals across schema generation, Zigflow task handling, CLI commands and tests
* Added test-only constants where repeated values were limited to test fixtures
* Added package-level constants for repeated script language, shell command, YAML path and MCP values
* Ran `gofmt` to clean up affected formatting

Validation:

* `golangci-lint run ./...` passes
* `go test ./...` passes

No lint suppressions were added.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
