### PR TITLE
feat(tasks): add Validate hook on TaskBuilder

### DIFF
--- a/pkg/zigflow/loader.go
+++ b/pkg/zigflow/loader.go
@@ -66,7 +66,7 @@ func LoadFromBytes(data []byte) (*model.Workflow, error) {
 		return nil, fmt.Errorf("error unmarshaling json to workflow: %w", err)
 	}
 
-	if err := newWorkflowPostLoad(wf); err != nil {
+	if err := newWorkflowPrepare(wf); err != nil {
 		return nil, fmt.Errorf("error preparing workflow: %w", err)
 	}
 

--- a/pkg/zigflow/loader_test.go
+++ b/pkg/zigflow/loader_test.go
@@ -333,3 +333,30 @@ do:
 	require.NotNil(t, task.Wait)
 	assert.Equal(t, "${ $data.cooldownSeconds }", task.Wait.Seconds)
 }
+
+// TestLoadFromBytes_RunsTaskValidate confirms that LoadFromBytes
+// exercises the per-task Validate() hook. A run script with `await:
+// false` passes JSON schema and parses cleanly, but is rejected by
+// RunTaskBuilder.Validate() (scripts must run with await).
+//
+// Every CLI/MCP validate entry point calls LoadFromBytes (directly or
+// via LoadFromFile) after the schema check, so the hook reaches them
+// all through this single integration point.
+func TestLoadFromBytes_RunsTaskValidate(t *testing.T) {
+	content := `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do:
+  - bad:
+      run:
+        await: false
+        script:
+          language: python
+          code: "print(1)"`
+
+	_, err := zigflow.LoadFromBytes([]byte(content))
+	assert.Error(t, err, "await:false on run script must be rejected by Validate()")
+	assert.Contains(t, err.Error(), "run scripts must be run with await")
+}

--- a/pkg/zigflow/tasks/task_builder.go
+++ b/pkg/zigflow/tasks/task_builder.go
@@ -42,6 +42,7 @@ type TaskBuilder interface {
 	GetTaskName() string
 	NeverSkipCAN() bool
 	ParseMetadata(workflow.Context, *utils.State) error
+	Validate() error
 	PostLoad() error
 	ShouldRun(*utils.State) (bool, error)
 }
@@ -125,6 +126,11 @@ func (d builder[T]) ParseMetadata(ctx workflow.Context, state *utils.State) erro
 		}
 	}
 
+	return nil
+}
+
+func (d *builder[T]) Validate() error {
+	log.Trace().Str("task", d.GetTaskName()).Msg("Task has no validate hook")
 	return nil
 }
 

--- a/pkg/zigflow/tasks/task_builder_call_activity.go
+++ b/pkg/zigflow/tasks/task_builder_call_activity.go
@@ -62,6 +62,13 @@ type CallActivityTaskBuilder struct {
 	activity *models.ActivityCallWith
 }
 
+func (t *CallActivityTaskBuilder) Validate() error {
+	// Both in Validate and Build, we need to convert the untyped `with`
+	// field into our typed struct. We do it in Validate so that we can
+	// catch any errors in the shape of the `with` data early.
+	return t.convertToType()
+}
+
 func (t *CallActivityTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 	log.Debug().Str("task", t.GetTaskName()).Msg("Converting call activity data")
 	if err := t.convertToType(); err != nil {

--- a/pkg/zigflow/tasks/task_builder_do.go
+++ b/pkg/zigflow/tasks/task_builder_do.go
@@ -160,6 +160,19 @@ func (t *DoTaskBuilder) PostLoad() error {
 	return nil
 }
 
+func (t *DoTaskBuilder) Validate() error {
+	for _, task := range *t.task.Do {
+		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts)
+		if err != nil {
+			return fmt.Errorf("error creating task validate builder: %w", err)
+		}
+		if err := builder.Validate(); err != nil {
+			return fmt.Errorf("error validating task %q: %w", task.Key, err)
+		}
+	}
+	return nil
+}
+
 // validateInput validates the input if it exists
 func (t *DoTaskBuilder) validateInput(ctx workflow.Context, inputDef *model.Input, state *utils.State) error {
 	logger := workflow.GetLogger(ctx)

--- a/pkg/zigflow/tasks/task_builder_do_test.go
+++ b/pkg/zigflow/tasks/task_builder_do_test.go
@@ -648,6 +648,10 @@ func (f *fakeTaskBuilder) PostLoad() error {
 	return nil
 }
 
+func (f *fakeTaskBuilder) Validate() error {
+	return nil
+}
+
 func (f *fakeTaskBuilder) ShouldRun(*utils.State) (bool, error) {
 	if f.shouldRunErr != nil {
 		return false, f.shouldRunErr

--- a/pkg/zigflow/tasks/task_builder_for.go
+++ b/pkg/zigflow/tasks/task_builder_for.go
@@ -144,6 +144,22 @@ func (t *ForTaskBuilder) PostLoad() error {
 	return nil
 }
 
+func (t *ForTaskBuilder) Validate() error {
+	builder, err := t.createBuilder()
+	if err != nil {
+		return err
+	}
+	if builder == nil {
+		return nil
+	}
+
+	if err := builder.Validate(); err != nil {
+		return fmt.Errorf("error validating for workflow: %w", err)
+	}
+
+	return nil
+}
+
 // addIterationResult adds the latest iteration to the data - this will be overridden
 // with each iteration so should only be relied upon inside the iterator
 func (t *ForTaskBuilder) addIterationResult(ctx workflow.Context, state *utils.State, response any) {

--- a/pkg/zigflow/tasks/task_builder_fork.go
+++ b/pkg/zigflow/tasks/task_builder_fork.go
@@ -93,6 +93,21 @@ func (t *ForkTaskBuilder) PostLoad() error {
 	return nil
 }
 
+func (t *ForkTaskBuilder) Validate() error {
+	_, builders, err := t.buildOrPostLoad()
+	if err != nil {
+		return err
+	}
+
+	for _, builder := range builders {
+		if err := builder.Validate(); err != nil {
+			return fmt.Errorf("error validating forked workflow: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func (t *ForkTaskBuilder) awaitCondition(
 	replyErr error, endSeen bool, isCompeting bool, winningCtx workflow.Context, hasReplied []bool,
 ) func() bool {

--- a/pkg/zigflow/tasks/task_builder_listen.go
+++ b/pkg/zigflow/tasks/task_builder_listen.go
@@ -63,6 +63,24 @@ type ListenTaskBuilder struct {
 	builder[*model.ListenTask]
 }
 
+func (t *ListenTaskBuilder) Validate() error {
+	if _, _, err := t.listEvents(); err != nil {
+		return err
+	}
+	timeoutInterface, ok := t.task.Metadata["timeout"]
+	if !ok {
+		return nil
+	}
+	timeoutStr, ok := timeoutInterface.(string)
+	if !ok {
+		return fmt.Errorf("timeout must be a string")
+	}
+	if _, err := time.ParseDuration(timeoutStr); err != nil {
+		return fmt.Errorf("error parsing timeout to duration: %w", err)
+	}
+	return nil
+}
+
 func (t *ListenTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 	events, isAll, err := t.listEvents()
 	if err != nil {

--- a/pkg/zigflow/tasks/task_builder_run.go
+++ b/pkg/zigflow/tasks/task_builder_run.go
@@ -63,22 +63,16 @@ type RunTaskBuilder struct {
 
 func (t *RunTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 	var factory TemporalWorkflowFunc
-	if t.task.Run.Container != nil {
-		if len(t.task.Run.Container.Ports) > 0 {
-			return nil, fmt.Errorf("ports are not allowed on containers")
-		}
-
+	switch {
+	case t.task.Run.Container != nil:
 		factory = t.runContainer
-	} else if s := t.task.Run.Script; s != nil {
-		if err := t.validateScriptConfig(s); err != nil {
-			return nil, err
-		}
+	case t.task.Run.Script != nil:
 		factory = t.runScript
-	} else if t.task.Run.Shell != nil {
+	case t.task.Run.Shell != nil:
 		factory = t.runShell
-	} else if t.task.Run.Workflow != nil {
+	case t.task.Run.Workflow != nil:
 		factory = t.runWorkflow
-	} else {
+	default:
 		return nil, fmt.Errorf("unsupported run task: %s", t.GetTaskName())
 	}
 
@@ -113,21 +107,26 @@ func (t *RunTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 	}, nil
 }
 
-func (t *RunTaskBuilder) validateScriptConfig(s *model.Script) error {
-	if !slices.Contains([]string{"js", constScriptLanguagePython}, s.Language) {
-		return fmt.Errorf("unknown script language '%s' for task: %s", s.Language, t.GetTaskName())
+func (t *RunTaskBuilder) Validate() error {
+	if t.task.Run.Container != nil && len(t.task.Run.Container.Ports) > 0 {
+		return fmt.Errorf("ports are not allowed on containers")
 	}
-	if !*t.task.Run.Await {
-		return fmt.Errorf("run scripts must be run with await: %s", t.GetTaskName())
-	}
-	if (s.InlineCode == nil || *s.InlineCode == "") && s.External == nil {
-		return fmt.Errorf("run script has no inline or external code defined: %s", t.GetTaskName())
-	}
-	if s.InlineCode != nil && *s.InlineCode != "" && s.External != nil {
-		return fmt.Errorf("run script must not set both inline code and external source: %s", t.GetTaskName())
-	}
-	if s.External != nil && s.External.Endpoint == nil {
-		return fmt.Errorf("run script external source has no endpoint: %s", t.GetTaskName())
+	if s := t.task.Run.Script; s != nil {
+		if !slices.Contains([]string{"js", constScriptLanguagePython}, s.Language) {
+			return fmt.Errorf("unknown script language '%s' for task: %s", s.Language, t.GetTaskName())
+		}
+		if !*t.task.Run.Await {
+			return fmt.Errorf("run scripts must be run with await: %s", t.GetTaskName())
+		}
+		if (s.InlineCode == nil || *s.InlineCode == "") && s.External == nil {
+			return fmt.Errorf("run script has no inline or external code defined: %s", t.GetTaskName())
+		}
+		if s.InlineCode != nil && *s.InlineCode != "" && s.External != nil {
+			return fmt.Errorf("run script must not set both inline code and external source: %s", t.GetTaskName())
+		}
+		if s.External != nil && s.External.Endpoint == nil {
+			return fmt.Errorf("run script external source has no endpoint: %s", t.GetTaskName())
+		}
 	}
 	return nil
 }

--- a/pkg/zigflow/tasks/task_builder_run_test.go
+++ b/pkg/zigflow/tasks/task_builder_run_test.go
@@ -31,6 +31,49 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+// TestRunTaskBuilderValidateNeedsPostLoadAwaitDefault confirms the
+// PostLoad → Validate ordering. Run.Await is a *bool; Validate's script
+// branch contains `if !*t.task.Run.Await {...}`, so the pointer must be
+// non-nil at that point. PostLoad's job is to default a nil Await to
+// true. If the order were inverted, Validate would nil-panic here.
+//
+// The "without PostLoad" subtest is a tripwire: it verifies that
+// Validate currently DOES nil-panic on nil Await. If that ever stops
+// being true (e.g. Validate becomes nil-tolerant), the positive
+// subtest is no longer testing whether the order is correct, and both
+// halves must be re-examined together.
+func TestRunTaskBuilderValidateNeedsPostLoadAwaitDefault(t *testing.T) {
+	makeTask := func() *model.RunTask {
+		return &model.RunTask{
+			Run: model.RunTaskConfiguration{
+				Await: nil, // explicit: PostLoad must populate this before Validate
+				Script: &model.Script{
+					Language:   constScriptLanguagePython,
+					InlineCode: utils.Ptr("print(1)"),
+				},
+			},
+		}
+	}
+
+	t.Run("PostLoad then Validate succeeds", func(t *testing.T) {
+		task := makeTask()
+		builder, err := NewRunTaskBuilder(nil, task, "ordering", nil, testEvents, nil)
+		require.NoError(t, err)
+		require.NoError(t, builder.PostLoad())
+		require.NotNil(t, task.Run.Await, "PostLoad must set Await before Validate runs")
+		assert.NoError(t, builder.Validate(), "Validate must not panic on Await deref once PostLoad has run")
+	})
+
+	t.Run("Validate without PostLoad nil-panics (tripwire)", func(t *testing.T) {
+		task := makeTask()
+		builder, err := NewRunTaskBuilder(nil, task, "ordering", nil, testEvents, nil)
+		require.NoError(t, err)
+		assert.Panics(t, func() {
+			_ = builder.Validate()
+		}, "Validate must currently nil-panic on nil Await; if this stops being true the test is no longer testing if the order is correct")
+	})
+}
+
 func TestRunTaskBuilderPostLoadSetsAwaitDefault(t *testing.T) {
 	task := &model.RunTask{
 		Run: model.RunTaskConfiguration{
@@ -316,11 +359,11 @@ func TestRunTaskBuilderRunScriptValidation(t *testing.T) {
 			builder, err := NewRunTaskBuilder(nil, tc.task, "script-task", nil, testEvents, nil)
 			assert.NoError(t, err)
 
-			// PostLoad must precede Build in the production lifecycle; replicate that here
-			// so Build() can safely dereference Await without a nil-pointer panic.
+			// PostLoad must precede Validate in the production lifecycle so Validate
+			// can dereference Await safely.
 			assert.NoError(t, builder.PostLoad())
 
-			_, err = builder.Build()
+			err = builder.Validate()
 			assert.EqualError(t, err, tc.assertErr)
 		})
 	}

--- a/pkg/zigflow/tasks/task_builder_switch.go
+++ b/pkg/zigflow/tasks/task_builder_switch.go
@@ -52,13 +52,13 @@ type SwitchTaskBuilder struct {
 	builder[*model.SwitchTask]
 }
 
-func (t *SwitchTaskBuilder) Build() (TemporalWorkflowFunc, error) {
+func (t *SwitchTaskBuilder) Validate() error {
 	hasDefault := false
 	for i, switchItem := range t.task.Switch {
 		for name, item := range switchItem {
 			if item.When == nil {
 				if hasDefault {
-					return nil, fmt.Errorf("multiple switch statements without when: %s.%d.%s", t.GetTaskName(), i, name)
+					return fmt.Errorf("multiple switch statements without when: %s.%d.%s", t.GetTaskName(), i, name)
 				}
 				hasDefault = true
 			}
@@ -67,7 +67,10 @@ func (t *SwitchTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 	if !hasDefault {
 		log.Warn().Str("task", t.GetTaskName()).Msg("No default switch task detected")
 	}
+	return nil
+}
 
+func (t *SwitchTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 	return func(ctx workflow.Context, input any, state *utils.State) (any, error) {
 		logger := workflow.GetLogger(ctx)
 

--- a/pkg/zigflow/tasks/task_builder_switch_test.go
+++ b/pkg/zigflow/tasks/task_builder_switch_test.go
@@ -47,8 +47,7 @@ func TestSwitchTaskBuilderBuildRejectsMultipleDefaults(t *testing.T) {
 	builder, err := NewSwitchTaskBuilder(nil, task, "switch-task", nil, testEvents, nil)
 	assert.NoError(t, err)
 
-	fn, err := builder.Build()
-	assert.Nil(t, fn)
+	err = builder.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "multiple switch statements without when")
 }

--- a/pkg/zigflow/tasks/task_builder_try.go
+++ b/pkg/zigflow/tasks/task_builder_try.go
@@ -93,6 +93,19 @@ func (t *TryTaskBuilder) PostLoad() error {
 	return nil
 }
 
+func (t *TryTaskBuilder) Validate() error {
+	for taskType, list := range t.getTasks() {
+		_, builder, err := t.createBuilder(taskType, list)
+		if err != nil {
+			return fmt.Errorf("error registering %s validate tasks for %s: %w", taskType, t.GetTaskName(), err)
+		}
+		if err := builder.Validate(); err != nil {
+			return fmt.Errorf("error validating %s tasks for %s: %w", taskType, t.GetTaskName(), err)
+		}
+	}
+	return nil
+}
+
 func (t *TryTaskBuilder) exec() (TemporalWorkflowFunc, error) {
 	return func(ctx workflow.Context, input any, state *utils.State) (output any, err error) {
 		logger := workflow.GetLogger(ctx)

--- a/pkg/zigflow/tasks/task_builder_wait.go
+++ b/pkg/zigflow/tasks/task_builder_wait.go
@@ -71,3 +71,10 @@ func (t *WaitTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		return nil, nil
 	}, nil
 }
+
+func (t *WaitTaskBuilder) Validate() error {
+	if t.task.Wait == nil {
+		return fmt.Errorf("wait task must have a wait duration")
+	}
+	return nil
+}

--- a/pkg/zigflow/tasks/task_builder_wait_ext.go
+++ b/pkg/zigflow/tasks/task_builder_wait_ext.go
@@ -62,16 +62,6 @@ type WaitExtTaskBuilder struct {
 }
 
 func (t *WaitExtTaskBuilder) Build() (TemporalWorkflowFunc, error) {
-	if t.task.Wait == nil {
-		return nil, fmt.Errorf("wait extension task %q has no body", t.GetTaskName())
-	}
-
-	// Reject non-deterministic jq functions at registration time so a worker
-	// refuses to come up with a wait that would fail Temporal replay.
-	if err := rejectNonDeterministicExpressions(t.task.Wait); err != nil {
-		return nil, fmt.Errorf("wait extension task %q: %w", t.GetTaskName(), err)
-	}
-
 	return func(ctx workflow.Context, _ any, state *utils.State) (any, error) {
 		logger := workflow.GetLogger(ctx)
 
@@ -124,6 +114,23 @@ func (t *WaitExtTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		}
 		return nil, nil
 	}, nil
+}
+
+func (t *WaitExtTaskBuilder) Validate() error {
+	if t.task.Wait == nil {
+		return fmt.Errorf("wait extension task %q has no body", t.GetTaskName())
+	}
+	if err := rejectNonDeterministicExpressions(t.task.Wait); err != nil {
+		return fmt.Errorf("wait extension task %q: %w", t.GetTaskName(), err)
+	}
+	until := t.task.Wait.Until
+	if until == "" || model.IsStrictExpr(until) {
+		return nil
+	}
+	if _, err := time.Parse(time.RFC3339, until); err != nil {
+		return fmt.Errorf("wait.until %q is not a valid RFC 3339 timestamp: %w", until, err)
+	}
+	return nil
 }
 
 // sleepUntil parses the resolved until value as RFC 3339, computes the delta

--- a/pkg/zigflow/tasks/task_builder_wait_ext_test.go
+++ b/pkg/zigflow/tasks/task_builder_wait_ext_test.go
@@ -164,8 +164,8 @@ func TestWaitExtBuilder_RejectsNonDeterministicExpressions(t *testing.T) {
 			builder, err := NewWaitExtTaskBuilder(nil, &models.WaitExtTask{Wait: tc.body}, "wait-ext", nil, testEvents, nil)
 			require.NoError(t, err)
 
-			_, err = builder.Build()
-			require.Error(t, err, "Build must reject non-deterministic wait expression")
+			err = builder.Validate()
+			require.Error(t, err, "Validate must reject non-deterministic wait expression")
 			assert.Contains(t, err.Error(), tc.wantField, "error must name the offending field")
 			assert.Contains(t, err.Error(), tc.wantFn, "error must name the offending function")
 		})
@@ -178,6 +178,68 @@ func TestWaitExtBuilder_AllowsDeterministicExpressions(t *testing.T) {
 	}}, "wait-ext", nil, testEvents, nil)
 	require.NoError(t, err)
 
-	_, err = builder.Build()
-	assert.NoError(t, err, "deterministic wait expressions must be allowed at Build time")
+	assert.NoError(t, builder.Validate(), "deterministic wait expressions must pass Validate")
+}
+
+// TestWaitExtBuilder_ValidateRejectsBadRFC3339 covers literal `until`
+// values that the JSON-schema regex accepts (case-insensitive separator
+// and zone, no range checks on components) but that time.Parse(RFC3339)
+// rejects. Validate is the single source of truth for "is this a real
+// RFC 3339 timestamp" and must catch them at validate time.
+func TestWaitExtBuilder_ValidateRejectsBadRFC3339(t *testing.T) {
+	tests := []struct {
+		name  string
+		until string
+	}{
+		{"lowercase t separator", "2026-12-31t23:59:59Z"},
+		{"lowercase z zone", "2026-12-31T23:59:59z"},
+		{"month 13", "2026-13-01T00:00:00Z"},
+		{"day 32", "2026-01-32T00:00:00Z"},
+		{"hour 25", "2026-12-31T25:00:00Z"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, err := NewWaitExtTaskBuilder(nil,
+				&models.WaitExtTask{Wait: &models.WaitExtBody{Until: tc.until}},
+				"wait-ext",
+				nil,
+				testEvents,
+				nil)
+			require.NoError(t, err)
+
+			err = builder.Validate()
+			require.Error(t, err, "Validate must reject malformed RFC 3339 timestamp")
+			assert.Contains(t, err.Error(), "RFC 3339")
+		})
+	}
+}
+
+// TestWaitExtBuilder_ValidateAcceptsValidUntil ensures Validate does not
+// reject the legitimate `until` shapes: real RFC 3339 timestamps (with or
+// without offset), runtime expressions (resolved later), and the empty
+// string used by the duration form.
+func TestWaitExtBuilder_ValidateAcceptsValidUntil(t *testing.T) {
+	cases := []struct {
+		name  string
+		until string
+	}{
+		{"valid RFC 3339 with Z", "2026-12-31T23:59:59Z"},
+		{"valid RFC 3339 with offset", "2026-12-31T23:59:59+02:00"},
+		{"runtime expression", "${ $data.deadline }"},
+		{"empty (duration form)", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, err := NewWaitExtTaskBuilder(nil,
+				&models.WaitExtTask{Wait: &models.WaitExtBody{Until: tc.until}},
+				"wait-ext",
+				nil,
+				testEvents,
+				nil)
+			require.NoError(t, err)
+			assert.NoError(t, builder.Validate())
+		})
+	}
 }

--- a/pkg/zigflow/workflow_builder.go
+++ b/pkg/zigflow/workflow_builder.go
@@ -80,6 +80,12 @@ func NewWorkflow(
 		return fmt.Errorf("error post-loading workflow: %w", err)
 	}
 
+	l.Debug().Msg("Validating workflow")
+	if err := doBuilder.Validate(); err != nil {
+		l.Error().Err(err).Msg("Error validating workflow")
+		return fmt.Errorf("error validating workflow: %w", err)
+	}
+
 	l.Debug().Msg("Building workflow")
 	if _, err := doBuilder.Build(); err != nil {
 		l.Debug().Err(err).Msg("Error building workflow")
@@ -89,7 +95,9 @@ func NewWorkflow(
 	return nil
 }
 
-func newWorkflowPostLoad(doc *model.Workflow) error {
+// newWorkflowPrepare runs the load-time PostLoad and Validate steps on
+// a parsed workflow with a single DoTaskBuilder.
+func newWorkflowPrepare(doc *model.Workflow) error {
 	workflowType := doc.Document.Name
 	l := log.With().Str("workflowType", workflowType).Logger()
 
@@ -98,17 +106,22 @@ func newWorkflowPostLoad(doc *model.Workflow) error {
 		&model.DoTask{Do: doc.Do},
 		workflowType,
 		doc,
-		&cloudevents.Events{}, // Stubbed as not used by the post loader
-		&tasks.TaskOpts{},     // Stubbed as not used by the post loader
+		&cloudevents.Events{}, // stubbed: not used for prepare, only when the task needs to run
+		&tasks.TaskOpts{},     // stubbed: not used for prepare, only when the task needs to run
 	)
 	if err != nil {
-		l.Error().Err(err).Msg("Error creating Do prep builder")
+		l.Error().Err(err).Msg("Error creating prep builder")
 		return fmt.Errorf("error creating do prep builder: %w", err)
 	}
 
 	if err := doBuilder.PostLoad(); err != nil {
 		l.Error().Err(err).Msg("Error post loading workflow")
 		return fmt.Errorf("error post loading workflow: %w", err)
+	}
+
+	if err := doBuilder.Validate(); err != nil {
+		l.Error().Err(err).Msg("Error validating workflow")
+		return fmt.Errorf("error validating workflow: %w", err)
 	}
 
 	return nil

--- a/toodaloo.md
+++ b/toodaloo.md
@@ -4,4 +4,4 @@
 
 | File | Line Number | Author | Message |
 | --- | --- | --- | --- |
-| [pkg/zigflow/tasks/task_builder_listen.go](pkg/zigflow/tasks/task_builder_listen.go#L330) | 330 | Simon Emms <simon@simonemms.com> | configure the "until" EventConsumptionUntil for "any" events |
+| [pkg/zigflow/tasks/task_builder_listen.go](pkg/zigflow/tasks/task_builder_listen.go#L348) | 348 | Simon Emms <simon@simonemms.com> | configure the "until" EventConsumptionUntil for "any" events |


### PR DESCRIPTION
## Summary
Adds a `Validate() error` method to the `TaskBuilder` interface and wires it into both worker registration (`NewWorkflow`) and document loading (`LoadFromBytes`). Migrates static checks out of `Build()` into `Validate()` for all current Tasks.

## Why?
The Zigflow docs already commit to validating before execution, [Durable execution in YAML](https://zigflow.dev/docs/concepts/durable-execution-in-yaml/#how-zigflow-expresses-it-in-yaml) mentions:
> Validation runs before execution. Unsupported constructs and non-deterministic patterns are rejected at validation time, not when the worker is already serving traffic.

Today most task-level semantic checks live inside `Build()` and only fire at worker registration. `zigflow validate`, `zigflow run
--validate` and the MCP `validate_workflow` tool can't catch them.
This PR adds the missing lifecycle hook so any task builder can opt into "rejected at validation time" without changing call sites.

## How to test
Use the following test workflow definition:

```
document:
  dsl: 1.0.0
  taskQueue: zigflow
  workflowType: wait-bad-until
  version: 0.0.1
  title: Wait with malformed until
  summary: Exercises WaitExtTaskBuilder.Validate by using an out-of-range month.
do:
  - waitForDeadline:
      wait:
        until: 2026-13-31T23:59:59Z
```

Before the change `zigflow validate` would return:

```
✅ wait-bad-until.yaml is valid
```

After this PR the return is:

```
{"level":"error","workflowType":"wait-bad-until","error":"error validating task \"waitForDeadline\": wait.until \"2026-13-31T23:59:59Z\" is not a valid RFC 3339 timestamp: parsing time \"2026-13-31T23:59:59Z\": month out of range","time":"2026-05-27T00:08:28+02:00","message":"Error validating workflow"}
{"level":"error","error":"error preparing workflow: error validating workflow: error validating task \"waitForDeadline\": wait.until \"2026-13-31T23:59:59Z\" is not a valid RFC 3339 timestamp: parsing time \"2026-13-31T23:59:59Z\": month out of range","time":"2026-05-27T00:08:28+02:00","message":"Unable to load workflow file"}
```