### PR TITLE
feat: improved the NDE check and throw a validation error

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -17,7 +17,9 @@
 package cmd
 
 import (
-	"os"
+	"errors"
+	"fmt"
+	"io"
 
 	gh "github.com/mrsimonemms/golang-helpers"
 	"github.com/rs/zerolog/log"
@@ -53,59 +55,7 @@ Arguments:
   workflow-file   Path to the Zigflow workflow file to validate`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			filePath := args[0]
-			result := utils.ValidationResult{
-				File: filePath,
-			}
-
-			if err := zigflow.ValidateFile(filePath); err != nil {
-				return gh.FatalError{
-					Cause: err,
-					Msg:   "Schema validation failed",
-				}
-			}
-
-			workflowDefinition, err := zigflow.LoadFromFile(filePath)
-			if err != nil {
-				return gh.FatalError{
-					Cause: err,
-					Msg:   errMsgUnableToLoadWorkflowFile,
-				}
-			}
-
-			validator, err := utils.NewValidator()
-			if err != nil {
-				return gh.FatalError{
-					Cause: err,
-					Msg:   "Error creating validator",
-				}
-			}
-
-			if res, err := validator.ValidateStruct(workflowDefinition); err != nil {
-				return gh.FatalError{
-					Cause: err,
-					Msg:   "Error creating validation stack",
-				}
-			} else if res != nil {
-				result.Errors = res
-			} else {
-				result.Valid = true
-			}
-
-			if opts.OutputJSON {
-				_ = utils.RenderJSON(os.Stdout, result)
-			} else {
-				utils.RenderHuman(os.Stdout, result)
-			}
-
-			if !result.Valid {
-				return gh.FatalError{
-					Msg:    "Validation failed",
-					Logger: log.Trace,
-				}
-			}
-
-			return nil
+			return runValidateCmd(cmd, args[0], opts.OutputJSON)
 		},
 	}
 
@@ -117,15 +67,252 @@ Arguments:
 	return cmd
 }
 
-type Error struct {
-	Path    string `json:"path"`
-	Rule    string `json:"rule"`
-	Param   string `json:"param,omitempty"`
-	Message string `json:"message"`
+// runValidateCmd validates the workflow file at filePath, rendering the result
+// to the command's output (human-readable by default, JSON when outputJSON is
+// set) and returning a fatal error when validation fails.
+func runValidateCmd(cmd *cobra.Command, filePath string, outputJSON bool) error {
+	result := utils.ValidationResult{
+		File: filePath,
+	}
+
+	out := cmd.OutOrStdout()
+
+	if err := zigflow.ValidateFile(filePath); err != nil {
+		// Render known validation failures (schema, determinism) for
+		// humans by default — concise location + message — and suppress
+		// the noisy nested error/log output by returning a trace-level
+		// FatalError without a Cause. --output-json keeps the structured,
+		// machine-readable form.
+		var (
+			schemaErr  *zigflow.SchemaValidationError
+			invalidErr *zigflow.InvalidRuntimeExpressionError
+			ndErr      *zigflow.NonDeterministicExpressionError
+		)
+		switch {
+		case errors.As(err, &schemaErr):
+			if outputJSON {
+				result.Errors = schemaValidationErrors(schemaErr.Errors)
+				_ = utils.RenderJSON(out, result)
+			} else {
+				renderSchemaFailure(out, filePath, schemaErr.Errors)
+			}
+
+		case errors.As(err, &invalidErr):
+			if outputJSON {
+				result.Errors = invalidExpressionValidationErrors(invalidErr.Expressions)
+				_ = utils.RenderJSON(out, result)
+			} else {
+				renderInvalidExpressionFailure(out, filePath, invalidErr.Expressions)
+			}
+
+		case errors.As(err, &ndErr):
+			if outputJSON {
+				result.Errors = determinismValidationErrors(ndErr.Expressions)
+				_ = utils.RenderJSON(out, result)
+			} else {
+				renderDeterminismFailure(out, filePath, ndErr.Expressions)
+			}
+
+		default:
+			return gh.FatalError{
+				Cause: err,
+				Msg:   "Workflow validation failed",
+			}
+		}
+
+		return gh.FatalError{
+			Msg:    "Workflow validation failed",
+			Logger: log.Trace,
+		}
+	}
+
+	workflowDefinition, err := zigflow.LoadFromFile(filePath)
+	if err != nil {
+		return gh.FatalError{
+			Cause: err,
+			Msg:   errMsgUnableToLoadWorkflowFile,
+		}
+	}
+
+	validator, err := utils.NewValidator()
+	if err != nil {
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Error creating validator",
+		}
+	}
+
+	if res, err := validator.ValidateStruct(workflowDefinition); err != nil {
+		return gh.FatalError{
+			Cause: err,
+			Msg:   "Error creating validation stack",
+		}
+	} else if res != nil {
+		result.Errors = res
+	} else {
+		result.Valid = true
+	}
+
+	if outputJSON {
+		_ = utils.RenderJSON(out, result)
+	} else {
+		utils.RenderHuman(out, result)
+	}
+
+	if !result.Valid {
+		return gh.FatalError{
+			Msg:    "Validation failed",
+			Logger: log.Trace,
+		}
+	}
+
+	return nil
 }
 
-type Result struct {
-	Valid  bool    `json:"valid"`
-	File   string  `json:"file"`
-	Errors []Error `json:"errors,omitempty"`
+// Field labels shared by the human-readable validation renderers.
+const (
+	labelLocation   = "Location"
+	labelExpression = "Expression"
+)
+
+// validationField is one labelled line of a validation problem (e.g.
+// "Location" / "$.do[0]"). An entry is the ordered set of fields describing a
+// single problem.
+type validationField struct {
+	label string
+	value string
+}
+
+// renderValidationFailure prints a concise, human-readable validation failure
+// for any validation kind. A single entry is shown as labelled blocks; multiple
+// entries are bulleted, with the first field as the bullet and the rest
+// indented beneath it. Labels are only shown in the single-entry form.
+func renderValidationFailure(w io.Writer, file, singular, plural string, entries [][]validationField) {
+	_, _ = fmt.Fprintf(w, "❌ %s is invalid\n\n", file)
+
+	if len(entries) == 1 {
+		_, _ = fmt.Fprintf(w, "%s\n\n", singular)
+		for i, f := range entries[0] {
+			if i > 0 {
+				_, _ = fmt.Fprintln(w)
+			}
+			_, _ = fmt.Fprintf(w, "%s:\n  %s\n", f.label, f.value)
+		}
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "%s\n\n", plural)
+	for i, entry := range entries {
+		if i > 0 {
+			_, _ = fmt.Fprintln(w)
+		}
+		_, _ = fmt.Fprintf(w, "• %s\n", entry[0].value)
+		for _, f := range entry[1:] {
+			_, _ = fmt.Fprintf(w, "  %s\n", f.value)
+		}
+	}
+}
+
+// renderSchemaFailure prints a concise, human-readable schema validation error
+// focused on where the problem is and what it is.
+func renderSchemaFailure(w io.Writer, file string, errs []zigflow.SchemaError) {
+	entries := make([][]validationField, len(errs))
+	for i, e := range errs {
+		entries[i] = []validationField{
+			{label: labelLocation, value: e.Location},
+			{label: "Message", value: e.Message},
+		}
+	}
+
+	renderValidationFailure(
+		w, file,
+		"Schema validation failed",
+		"Schema validation errors found:",
+		entries,
+	)
+}
+
+// schemaValidationErrors maps the structured schema failures onto the shared
+// ValidationErrors shape so JSON output stays machine-readable and consistent
+// with determinism/structural validation errors.
+func schemaValidationErrors(errs []zigflow.SchemaError) []utils.ValidationErrors {
+	out := make([]utils.ValidationErrors, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, utils.ValidationErrors{
+			Key:     "schema_validation",
+			Message: e.Message,
+			Path:    e.Location,
+		})
+	}
+	return out
+}
+
+// renderDeterminismFailure prints a concise, human-readable determinism error
+// focused on where the offending expression is and what it is.
+func renderDeterminismFailure(w io.Writer, file string, exprs []zigflow.NonDeterministicExpression) {
+	entries := make([][]validationField, len(exprs))
+	for i, e := range exprs {
+		entries[i] = []validationField{
+			{label: labelLocation, value: e.Path},
+			{label: labelExpression, value: e.Expression},
+		}
+	}
+
+	renderValidationFailure(
+		w, file,
+		"Non-deterministic expression",
+		"Non-deterministic expressions found:",
+		entries,
+	)
+}
+
+// determinismValidationErrors maps the structured determinism failures onto the
+// shared ValidationErrors shape so JSON output stays machine-readable and
+// consistent with schema/structural validation errors.
+func determinismValidationErrors(exprs []zigflow.NonDeterministicExpression) []utils.ValidationErrors {
+	errs := make([]utils.ValidationErrors, 0, len(exprs))
+	for _, e := range exprs {
+		errs = append(errs, utils.ValidationErrors{
+			Key:     "non_deterministic_expression",
+			Message: fmt.Sprintf("non-deterministic expression %q", e.Expression),
+			Path:    e.Path,
+		})
+	}
+	return errs
+}
+
+// renderInvalidExpressionFailure prints a concise, human-readable invalid
+// runtime expression error focused on the location, the offending expression,
+// and the underlying parse error.
+func renderInvalidExpressionFailure(w io.Writer, file string, exprs []zigflow.InvalidRuntimeExpression) {
+	entries := make([][]validationField, len(exprs))
+	for i, e := range exprs {
+		entries[i] = []validationField{
+			{label: labelLocation, value: e.Path},
+			{label: labelExpression, value: e.Expression},
+			{label: "Error", value: e.Err.Error()},
+		}
+	}
+
+	renderValidationFailure(
+		w, file,
+		"Invalid runtime expression",
+		"Invalid runtime expressions found:",
+		entries,
+	)
+}
+
+// invalidExpressionValidationErrors maps the structured invalid-expression
+// failures onto the shared ValidationErrors shape so JSON output stays
+// machine-readable and consistent with the other validation errors.
+func invalidExpressionValidationErrors(exprs []zigflow.InvalidRuntimeExpression) []utils.ValidationErrors {
+	errs := make([]utils.ValidationErrors, 0, len(exprs))
+	for _, e := range exprs {
+		errs = append(errs, utils.ValidationErrors{
+			Key:     "invalid_runtime_expression",
+			Message: fmt.Sprintf("invalid runtime expression %q: %s", e.Expression, e.Err),
+			Path:    e.Path,
+		})
+	}
+	return errs
 }

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -17,11 +17,16 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/utils"
 )
 
 const validWorkflowYAML = `document:
@@ -72,6 +77,233 @@ do:
   - step:
       set:
         hello: world`
+
+const workflowSingleNonDeterministic = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do:
+  - step:
+      if: ${ uuid }
+      set:
+        hello: world`
+
+const workflowMultipleNonDeterministic = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do:
+  - first:
+      if: ${ uuid }
+      set:
+        hello: world
+  - second:
+      if: ${ timestamp }
+      set:
+        hello: world`
+
+// writeTempWorkflow writes content to a temporary workflow file and returns its
+// path, registering cleanup with the test.
+func writeTempWorkflow(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workflow.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// runValidate writes content to a temp file, runs the validate command against
+// it with the given extra args, and returns the captured stdout and the
+// command error.
+func runValidate(t *testing.T, content string, extraArgs ...string) (string, error) {
+	t.Helper()
+	path := writeTempWorkflow(t, content)
+
+	var buf bytes.Buffer
+	cmd := newValidateCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(&buf)
+	cmd.SetArgs(append([]string{path}, extraArgs...))
+
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// runValidateJSON runs the validate command with --output-json against content,
+// asserts the command failed and emitted an invalid result, and returns the
+// decoded result for the caller to make kind-specific assertions on.
+func runValidateJSON(t *testing.T, content string) utils.ValidationResult {
+	t.Helper()
+	out, err := runValidate(t, content, "--output-json")
+	require.Error(t, err)
+
+	var result utils.ValidationResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.False(t, result.Valid)
+	return result
+}
+
+// TestValidateCmdDeterminismOutput verifies that determinism failures are
+// rendered as concise, workflow-level validation failures focused on the
+// location and offending expression — not as schema validation failures.
+func TestValidateCmdDeterminismOutput(t *testing.T) {
+	t.Run("single non-deterministic expression", func(t *testing.T) {
+		out, err := runValidate(t, workflowSingleNonDeterministic)
+		require.Error(t, err)
+
+		assert.Contains(t, out, "is invalid")
+		assert.Contains(t, out, "Non-deterministic expression")
+		assert.Contains(t, out, "Location:")
+		assert.Contains(t, out, "Expression:")
+		assert.Contains(t, out, "${ uuid }")
+		// The old, confusing wording must be gone.
+		assert.NotContains(t, out, "Schema validation failed")
+	})
+
+	t.Run("multiple non-deterministic expressions", func(t *testing.T) {
+		out, err := runValidate(t, workflowMultipleNonDeterministic)
+		require.Error(t, err)
+
+		assert.Contains(t, out, "Non-deterministic expressions found:")
+		assert.Contains(t, out, "${ uuid }")
+		assert.Contains(t, out, "${ timestamp }")
+		// Each location is reported exactly once.
+		assert.Equal(t, 1, strings.Count(out, "${ uuid }"))
+		assert.Equal(t, 1, strings.Count(out, "${ timestamp }"))
+	})
+
+	t.Run("JSON output stays machine-readable", func(t *testing.T) {
+		result := runValidateJSON(t, workflowSingleNonDeterministic)
+		require.Len(t, result.Errors, 1)
+		assert.Equal(t, "non_deterministic_expression", result.Errors[0].Key)
+		assert.Contains(t, result.Errors[0].Message, "${ uuid }")
+		assert.Contains(t, result.Errors[0].Path, "do[0]")
+	})
+}
+
+// workflowInvalidExpression fails expression syntax validation: ${ @@@ } is not
+// valid jq. It sits inside a set body, which is exempt from the determinism
+// rule but not from parse validation.
+const workflowInvalidExpression = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do:
+  - capture:
+      set:
+        id: ${ @@@ }`
+
+// workflowCompileInvalidExpression parses as valid jq but cannot compile: the
+// bare identifier is an unregistered 0-arg function call. It sits in a set body
+// to prove Set still enforces compile validation.
+const workflowCompileInvalidExpression = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do:
+  - capture:
+      set:
+        id: ${ definitely_not_registered }`
+
+// TestValidateCmdInvalidExpressionOutput verifies that invalid runtime
+// expressions are rendered as their own "Invalid runtime expression" failure
+// (location, expression, error) and never mislabelled as non-deterministic.
+func TestValidateCmdInvalidExpressionOutput(t *testing.T) {
+	t.Run("human-readable by default", func(t *testing.T) {
+		out, err := runValidate(t, workflowInvalidExpression)
+		require.Error(t, err)
+
+		assert.Contains(t, out, "is invalid")
+		assert.Contains(t, out, "Invalid runtime expression")
+		assert.Contains(t, out, "Location:")
+		assert.Contains(t, out, "Expression:")
+		assert.Contains(t, out, "Error:")
+		assert.Contains(t, out, "${ @@@ }")
+		// A parse failure must not be rendered as non-determinism.
+		assert.NotContains(t, out, "Non-deterministic")
+	})
+
+	t.Run("compile-invalid expression in set body", func(t *testing.T) {
+		out, err := runValidate(t, workflowCompileInvalidExpression)
+		require.Error(t, err)
+
+		assert.Contains(t, out, "Invalid runtime expression")
+		assert.Contains(t, out, "${ definitely_not_registered }")
+		// A compile failure inside a set body must not be rendered as
+		// non-determinism, nor silently accepted.
+		assert.NotContains(t, out, "Non-deterministic")
+	})
+
+	t.Run("JSON output stays machine-readable", func(t *testing.T) {
+		result := runValidateJSON(t, workflowInvalidExpression)
+		require.Len(t, result.Errors, 1)
+		assert.Equal(t, "invalid_runtime_expression", result.Errors[0].Key)
+		assert.Contains(t, result.Errors[0].Message, "${ @@@ }")
+		assert.Contains(t, result.Errors[0].Path, "set.id")
+	})
+}
+
+// workflowSchemaMissingDo fails JSON Schema validation: the required top-level
+// "do" property is missing (e.g. the user wrote "do2").
+const workflowSchemaMissingDo = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do2:
+  - step:
+      set:
+        hello: world`
+
+// workflowSchemaLegacyName fails JSON Schema validation deeper in the document:
+// the required document.workflowType is missing (legacy document.name used).
+const workflowSchemaLegacyName = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  name: test
+  version: 0.0.1
+do:
+  - step:
+      set:
+        hello: world`
+
+// TestValidateCmdSchemaOutput verifies that schema validation failures are
+// rendered for humans by default (location + message under an "is invalid"
+// heading) rather than as JSON/log-style output.
+func TestValidateCmdSchemaOutput(t *testing.T) {
+	t.Run("human-readable by default", func(t *testing.T) {
+		out, err := runValidate(t, workflowSchemaMissingDo)
+		require.Error(t, err)
+
+		assert.Contains(t, out, "is invalid")
+		assert.Contains(t, out, "Schema validation failed")
+		assert.Contains(t, out, "Location:")
+		assert.Contains(t, out, "Message:")
+		// Must not leak the raw, log/JSON-style error envelope.
+		assert.NotContains(t, out, "\"level\"")
+		assert.NotContains(t, out, "validating https://")
+	})
+
+	t.Run("location points at the offending document path", func(t *testing.T) {
+		out, err := runValidate(t, workflowSchemaLegacyName)
+		require.Error(t, err)
+
+		assert.Contains(t, out, "$.document")
+	})
+
+	t.Run("JSON output stays machine-readable", func(t *testing.T) {
+		result := runValidateJSON(t, workflowSchemaMissingDo)
+		require.NotEmpty(t, result.Errors)
+		assert.Equal(t, "schema_validation", result.Errors[0].Key)
+		assert.NotEmpty(t, result.Errors[0].Path)
+		assert.NotEmpty(t, result.Errors[0].Message)
+	})
+}
 
 func TestNewValidateCmd(t *testing.T) {
 	tests := []struct {

--- a/pkg/mcp/validate_workflow.go
+++ b/pkg/mcp/validate_workflow.go
@@ -44,6 +44,22 @@ type ValidateWorkflowOutput struct {
 	Errors []ValidateWorkflowError `json:"errors,omitempty"`
 }
 
+// validateBytesStage maps an error returned by zigflow.ValidateBytes onto the
+// MCP validation stage that best describes it. Expression failures (both
+// non-determinism and invalid syntax) are reported as "expression"; schema
+// failures as "schema"; anything else is treated as a genuine parse failure.
+func validateBytesStage(err error) string {
+	switch {
+	case errors.Is(err, zigflow.ErrSchemaValidation):
+		return "schema"
+	case errors.Is(err, zigflow.ErrNonDeterministicExpression),
+		errors.Is(err, zigflow.ErrInvalidRuntimeExpression):
+		return "expression"
+	default:
+		return "parse"
+	}
+}
+
 func (m *MCP) ValidateWorkflow(
 	ctx context.Context,
 	req *mcp.CallToolRequest,
@@ -60,15 +76,11 @@ func (m *MCP) ValidateWorkflow(
 
 	data := []byte(input.YAML)
 
-	// Schema validation: non-schema errors from ValidateBytes are parse failures.
+	// ValidateBytes can fail for several distinct reasons; classify them so the
+	// reported stage is accurate rather than always "parse".
 	if err := zigflow.ValidateBytes(data); err != nil {
-		stage := "parse"
-		if errors.Is(err, zigflow.ErrSchemaValidation) {
-			stage = "schema"
-		}
-
 		return nil, ValidateWorkflowOutput{
-			Errors: []ValidateWorkflowError{{Stage: stage, Message: err.Error()}},
+			Errors: []ValidateWorkflowError{{Stage: validateBytesStage(err), Message: err.Error()}},
 		}, nil
 	}
 

--- a/pkg/mcp/validate_workflow_test.go
+++ b/pkg/mcp/validate_workflow_test.go
@@ -128,6 +128,61 @@ do:
 	assert.NotEmpty(t, out.Errors[0].Message)
 }
 
+// --- expression stage ---
+
+// nonDeterministicYAML passes schema validation but uses a non-deterministic
+// expression (timestamp) outside a Set body, which is rejected by the
+// determinism pass.
+const nonDeterministicYAML = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do:
+  - waitForCooldown:
+      wait:
+        seconds: ${ timestamp }
+`
+
+// invalidExpressionYAML passes schema validation but contains jq that cannot be
+// parsed, inside a Set body.
+const invalidExpressionYAML = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+do:
+  - capture:
+      set:
+        id: ${ @@@ }
+`
+
+func TestValidateWorkflow_NonDeterministicExpression_ExpressionStage(t *testing.T) {
+	m := newTestMCP()
+	_, out, err := m.ValidateWorkflow(context.Background(), nil, ValidateWorkflowInput{
+		YAML: nonDeterministicYAML,
+	})
+	require.NoError(t, err)
+	assert.False(t, out.Valid)
+	require.Len(t, out.Errors, 1)
+	assert.Equal(t, "expression", out.Errors[0].Stage,
+		"non-deterministic expression must not be reported as a parse failure")
+	assert.NotEmpty(t, out.Errors[0].Message)
+}
+
+func TestValidateWorkflow_InvalidRuntimeExpression_ExpressionStage(t *testing.T) {
+	m := newTestMCP()
+	_, out, err := m.ValidateWorkflow(context.Background(), nil, ValidateWorkflowInput{
+		YAML: invalidExpressionYAML,
+	})
+	require.NoError(t, err)
+	assert.False(t, out.Valid)
+	require.Len(t, out.Errors, 1)
+	assert.Equal(t, "expression", out.Errors[0].Stage,
+		"invalid runtime expression must not be reported as a parse failure")
+	assert.NotEmpty(t, out.Errors[0].Message)
+}
+
 // --- struct stage ---
 
 func TestValidateWorkflow_StructValidationFailure_StructStage(t *testing.T) {

--- a/pkg/utils/expression_determinism.go
+++ b/pkg/utils/expression_determinism.go
@@ -1,0 +1,625 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/itchyny/gojq"
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+)
+
+// DeterminismIssue describes one non-deterministic construct found in an
+// expression. Path is a best-effort breadcrumb describing where in the
+// expression tree the issue was found, useful for error messages.
+type DeterminismIssue struct {
+	Symbol string
+	Reason string
+	Path   string
+}
+
+func (d DeterminismIssue) String() string {
+	if d.Path != "" {
+		return fmt.Sprintf("%s (%s) at %s", d.Symbol, d.Reason, d.Path)
+	}
+	return fmt.Sprintf("%s (%s)", d.Symbol, d.Reason)
+}
+
+// DeterminismAnalysis is the result of analysing an expression for Temporal
+// replay safety. Deterministic is true when every symbol referenced by the
+// expression is derivable from workflow state or from a known pure builtin.
+type DeterminismAnalysis struct {
+	Deterministic bool
+	Issues        []DeterminismIssue
+}
+
+// AnalyseExpressionDeterminism parses expr with gojq and walks the full AST to
+// determine whether the expression is replay-safe for Temporal durable
+// execution. An expression is replay-safe when every value it produces is a
+// function of workflow state, input, or known pure builtins. Anything that
+// reads the host clock, host environment, or any other ambient state is
+// non-deterministic and must be wrapped in a Set task.
+//
+// expr may include the strict expression form (${ ... }); the wrapper is
+// stripped before parsing.
+func AnalyseExpressionDeterminism(expr string) (*DeterminismAnalysis, error) {
+	if model.IsStrictExpr(expr) {
+		expr = model.SanitizeExpr(expr)
+	}
+	query, err := gojq.Parse(expr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse expression %q: %w", expr, err)
+	}
+	a := &determinismAnalyser{}
+	a.walkQuery(query, newScope(nil), "")
+	return &DeterminismAnalysis{
+		Deterministic: len(a.issues) == 0,
+		Issues:        a.issues,
+	}, nil
+}
+
+// IsExpressionDeterministic is a convenience wrapper around
+// AnalyseExpressionDeterminism that returns false on parse errors so callers
+// fail closed.
+func IsExpressionDeterministic(expr string) bool {
+	a, err := AnalyseExpressionDeterminism(expr)
+	if err != nil {
+		return false
+	}
+	return a.Deterministic
+}
+
+// stateVars enumerates the variable names Zigflow injects into every jq
+// evaluation from workflow State. Reading these values is always replay-safe
+// because they come from workflow history.
+var stateVars = map[string]struct{}{
+	"$context": {},
+	"$data":    {},
+	"$env":     {},
+	"$input":   {},
+	"$output":  {},
+}
+
+// nonDeterministicReasons lists symbols that are explicitly non-deterministic
+// and the reason they are unsafe. Used to produce useful error messages; the
+// allow-list in deterministicBuiltins is what actually drives classification.
+var nonDeterministicReasons = map[string]string{
+	"now":           "reads the host wall-clock",
+	"localtime":     "reads the host timezone",
+	"strflocaltime": "reads the host timezone",
+	"env":           "reads host environment variables",
+	"input":         "reads from an external input stream",
+	"inputs":        "reads from an external input stream",
+	"debug":         "writes to stderr as a side effect",
+	"stderr":        "writes to stderr as a side effect",
+	"$ENV":          "reads host environment variables",
+	"$__loc__":      "exposes compile-time location which varies between builds",
+}
+
+// deterministicBuiltins is the allow-list of gojq builtins that are pure and
+// replay-safe. Anything not listed here is treated as non-deterministic, so
+// the analyser fails closed for builtins added in future gojq releases.
+//
+// Sourced from gojq's internalFuncs and builtin.jq. Functions that read the
+// host clock, host environment, or any external stream are deliberately
+// omitted.
+var deterministicBuiltins = map[string]struct{}{
+	// Pure value operations
+	"empty":           {},
+	"not":             {},
+	"path":            {},
+	"paths":           {},
+	"leaf_paths":      {},
+	"builtins":        {},
+	"abs":             {},
+	"length":          {},
+	"utf8bytelength":  {},
+	"keys":            {},
+	"keys_unsorted":   {},
+	"values":          {},
+	"has":             {},
+	"in":              {},
+	"add":             {},
+	"any":             {},
+	"all":             {},
+	"toboolean":       {},
+	"tonumber":        {},
+	"tostring":        {},
+	"type":            {},
+	"reverse":         {},
+	"contains":        {},
+	"inside":          {},
+	"indices":         {},
+	"index":           {},
+	"rindex":          {},
+	"startswith":      {},
+	"endswith":        {},
+	"ltrimstr":        {},
+	"rtrimstr":        {},
+	"trimstr":         {},
+	"ltrim":           {},
+	"rtrim":           {},
+	"trim":            {},
+	"explode":         {},
+	"implode":         {},
+	"split":           {},
+	"splits":          {},
+	"join":            {},
+	"ascii":           {},
+	"ascii_downcase":  {},
+	"ascii_upcase":    {},
+	"tojson":          {},
+	"fromjson":        {},
+	"tostream":        {},
+	"fromstream":      {},
+	"truncate_stream": {},
+	"format":          {},
+
+	// Selection / iteration
+	"select":       {},
+	"map":          {},
+	"map_values":   {},
+	"recurse":      {},
+	"recurse_down": {},
+	"walk":         {},
+	"to_entries":   {},
+	"from_entries": {},
+	"with_entries": {},
+	"while":        {},
+	"until":        {},
+	"repeat":       {},
+	"range":        {},
+	"limit":        {},
+	"first":        {},
+	"last":         {},
+	"nth":          {},
+	"isempty":      {},
+	"truncate":     {},
+	"skip":         {},
+
+	// Type predicates
+	"arrays":    {},
+	"objects":   {},
+	"iterables": {},
+	"booleans":  {},
+	"numbers":   {},
+	"strings":   {},
+	"nulls":     {},
+	"values_":   {},
+	"scalars":   {},
+	"finites":   {},
+	"infinites": {},
+	"normals":   {},
+
+	// Sorting / grouping
+	"min":       {},
+	"min_by":    {},
+	"max":       {},
+	"max_by":    {},
+	"sort":      {},
+	"sort_by":   {},
+	"group_by":  {},
+	"unique":    {},
+	"unique_by": {},
+
+	// Path operations
+	"flatten":   {},
+	"setpath":   {},
+	"delpaths":  {},
+	"getpath":   {},
+	"transpose": {},
+	"bsearch":   {},
+	"del":       {},
+	"pick":      {},
+	"paths_":    {},
+
+	// Time formatting (operate on input values; do not read the clock)
+	"gmtime":          {},
+	"mktime":          {},
+	"strftime":        {},
+	"strptime":        {},
+	"todate":          {},
+	"fromdate":        {},
+	"todateiso8601":   {},
+	"fromdateiso8601": {},
+
+	// Regex (deterministic against input)
+	"test":    {},
+	"match":   {},
+	"capture": {},
+	"scan":    {},
+	"sub":     {},
+	"gsub":    {},
+	"splits_": {},
+
+	// Math (pure)
+	"sin": {}, "cos": {}, "tan": {},
+	"asin": {}, "acos": {}, "atan": {},
+	"sinh": {}, "cosh": {}, "tanh": {},
+	"asinh": {}, "acosh": {}, "atanh": {},
+	"floor": {}, "round": {}, "nearbyint": {}, "rint": {},
+	"ceil": {}, "trunc": {}, "significand": {},
+	"fabs": {}, "sqrt": {}, "cbrt": {},
+	"exp": {}, "exp10": {}, "exp2": {}, "expm1": {},
+	"frexp": {}, "modf": {},
+	"log": {}, "log10": {}, "log1p": {}, "log2": {}, "logb": {},
+	"gamma": {}, "tgamma": {}, "lgamma": {},
+	"erf": {}, "erfc": {},
+	"j0": {}, "j1": {}, "jn": {},
+	"y0": {}, "y1": {}, "yn": {},
+	"atan2": {}, "copysign": {}, "drem": {},
+	"fdim": {}, "fmax": {}, "fmin": {}, "fmod": {},
+	"hypot": {}, "nextafter": {}, "nexttoward": {},
+	"remainder": {}, "ldexp": {}, "scalb": {}, "scalbln": {},
+	"pow": {}, "fma": {},
+	"infinite": {}, "isfinite": {}, "isinfinite": {},
+	"nan": {}, "isnan": {}, "isnormal": {},
+
+	// Collection helpers
+	"combinations": {},
+	"INDEX":        {},
+	"IN":           {},
+	"JOIN":         {},
+
+	// Error / control flow (deterministic, terminates the query)
+	"error":      {},
+	"halt":       {},
+	"halt_error": {},
+
+	// Aliases / private helpers prefixed with _ (used internally for operators)
+	"_plus":        {},
+	"_negate":      {},
+	"_add":         {},
+	"_subtract":    {},
+	"_multiply":    {},
+	"_divide":      {},
+	"_modulo":      {},
+	"_alternative": {},
+	"_equal":       {},
+	"_notequal":    {},
+	"_greater":     {},
+	"_less":        {},
+	"_greatereq":   {},
+	"_lesseq":      {},
+	"_index":       {},
+	"_slice":       {},
+	"_range":       {},
+	"_min_by":      {},
+	"_max_by":      {},
+	"_sort_by":     {},
+	"_group_by":    {},
+	"_unique_by":   {},
+	"_match":       {},
+	"_captures":    {},
+}
+
+// IsDeterministicBuiltin reports whether name is a known pure gojq builtin.
+// Exposed for tests and to keep classification centralised in one place.
+func IsDeterministicBuiltin(name string) bool {
+	_, ok := deterministicBuiltins[name]
+	return ok
+}
+
+// scope tracks locally introduced names (FuncDef names and arguments, plus
+// pattern variables from `as $x`). Names are looked up walking from innermost
+// to outermost scope.
+type scope struct {
+	parent *scope
+	names  map[string]struct{}
+}
+
+func newScope(parent *scope) *scope {
+	return &scope{parent: parent, names: map[string]struct{}{}}
+}
+
+func (s *scope) add(name string) {
+	s.names[name] = struct{}{}
+}
+
+func (s *scope) contains(name string) bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if _, ok := cur.names[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+type determinismAnalyser struct {
+	issues []DeterminismIssue
+}
+
+func (a *determinismAnalyser) flag(symbol, reason, path string) {
+	a.issues = append(a.issues, DeterminismIssue{Symbol: symbol, Reason: reason, Path: path})
+}
+
+func joinPath(path, segment string) string {
+	if path == "" {
+		return segment
+	}
+	return path + "/" + segment
+}
+
+func (a *determinismAnalyser) walkQuery(q *gojq.Query, sc *scope, path string) {
+	if q == nil {
+		return
+	}
+	// Imports are not replay-safe: the loaded module can introduce arbitrary
+	// definitions including ones that read external state.
+	for _, im := range q.Imports {
+		target := im.ImportPath
+		if target == "" {
+			target = im.IncludePath
+		}
+		a.flag("import", fmt.Sprintf("module %q is loaded at evaluation time and is not replay-safe", target), path)
+	}
+
+	// FuncDef names are hoisted within their containing query so a definition
+	// can be referenced before it appears textually. Add them all first, then
+	// walk each body in a child scope containing its argument names.
+	inner := newScope(sc)
+	for _, fd := range q.FuncDefs {
+		inner.add(fd.Name)
+	}
+	for _, fd := range q.FuncDefs {
+		fnScope := newScope(inner)
+		for _, arg := range fd.Args {
+			fnScope.add(arg)
+		}
+		a.walkQuery(fd.Body, fnScope, joinPath(path, "def "+fd.Name))
+	}
+
+	if q.Term != nil {
+		a.walkTerm(q.Term, inner, path)
+		return
+	}
+
+	if q.Right != nil {
+		a.walkQuery(q.Left, inner, joinPath(path, q.Op.String()))
+		// `Left as Pattern | Right` introduces pattern variables that are in
+		// scope for Right only.
+		rightScope := inner
+		if len(q.Patterns) > 0 {
+			rightScope = newScope(inner)
+			for _, p := range q.Patterns {
+				collectPatternVars(rightScope, p)
+			}
+		}
+		a.walkQuery(q.Right, rightScope, joinPath(path, q.Op.String()))
+	}
+}
+
+func (a *determinismAnalyser) walkTerm(t *gojq.Term, sc *scope, path string) {
+	if t == nil {
+		return
+	}
+	a.walkTermBody(t, sc, path)
+	for _, suffix := range t.SuffixList {
+		if suffix.Index != nil {
+			a.walkIndex(suffix.Index, sc, path)
+		}
+	}
+}
+
+func (a *determinismAnalyser) walkTermBody(t *gojq.Term, sc *scope, path string) {
+	switch t.Type {
+	case gojq.TermTypeIndex:
+		a.walkIndex(t.Index, sc, path)
+	case gojq.TermTypeFunc:
+		a.walkFunc(t.Func, sc, path)
+	case gojq.TermTypeObject:
+		a.walkObject(t.Object, sc, path)
+	case gojq.TermTypeArray:
+		if t.Array != nil {
+			a.walkQuery(t.Array.Query, sc, path)
+		}
+	case gojq.TermTypeUnary:
+		if t.Unary != nil {
+			a.walkTerm(t.Unary.Term, sc, joinPath(path, t.Unary.Op.String()))
+		}
+	case gojq.TermTypeString:
+		a.walkString(t.Str, sc, path)
+	case gojq.TermTypeIf:
+		a.walkIf(t.If, sc, joinPath(path, "if"))
+	case gojq.TermTypeTry:
+		a.walkTry(t.Try, sc, path)
+	case gojq.TermTypeReduce:
+		a.walkReduce(t.Reduce, sc, path)
+	case gojq.TermTypeForeach:
+		a.walkForeach(t.Foreach, sc, path)
+	case gojq.TermTypeLabel:
+		a.walkLabel(t.Label, sc, path)
+	case gojq.TermTypeQuery:
+		a.walkQuery(t.Query, sc, path)
+	}
+	// Remaining cases (Identity, Recurse, Null, True, False, Number, Format,
+	// Break) are deterministic leaves with no children to walk.
+}
+
+func (a *determinismAnalyser) walkObject(o *gojq.Object, sc *scope, path string) {
+	if o == nil {
+		return
+	}
+	for _, kv := range o.KeyVals {
+		if kv.KeyString != nil {
+			a.walkString(kv.KeyString, sc, path)
+		}
+		if kv.KeyQuery != nil {
+			a.walkQuery(kv.KeyQuery, sc, path)
+		}
+		if kv.Val != nil {
+			a.walkQuery(kv.Val, sc, path)
+		}
+	}
+}
+
+func (a *determinismAnalyser) walkTry(t *gojq.Try, sc *scope, path string) {
+	if t == nil {
+		return
+	}
+	a.walkQuery(t.Body, sc, joinPath(path, "try"))
+	a.walkQuery(t.Catch, sc, joinPath(path, "catch"))
+}
+
+func (a *determinismAnalyser) walkReduce(r *gojq.Reduce, sc *scope, path string) {
+	if r == nil {
+		return
+	}
+	a.walkQuery(r.Query, sc, joinPath(path, "reduce"))
+	inner := newScope(sc)
+	collectPatternVars(inner, r.Pattern)
+	a.walkQuery(r.Start, inner, joinPath(path, "reduce/start"))
+	a.walkQuery(r.Update, inner, joinPath(path, "reduce/update"))
+}
+
+func (a *determinismAnalyser) walkForeach(f *gojq.Foreach, sc *scope, path string) {
+	if f == nil {
+		return
+	}
+	a.walkQuery(f.Query, sc, joinPath(path, "foreach"))
+	inner := newScope(sc)
+	collectPatternVars(inner, f.Pattern)
+	a.walkQuery(f.Start, inner, joinPath(path, "foreach/start"))
+	a.walkQuery(f.Update, inner, joinPath(path, "foreach/update"))
+	a.walkQuery(f.Extract, inner, joinPath(path, "foreach/extract"))
+}
+
+func (a *determinismAnalyser) walkLabel(l *gojq.Label, sc *scope, path string) {
+	if l == nil {
+		return
+	}
+	inner := newScope(sc)
+	inner.add(l.Ident)
+	a.walkQuery(l.Body, inner, joinPath(path, "label "+l.Ident))
+}
+
+// walkFunc classifies a referenced name as deterministic or not. A name is
+// replay-safe when any of the following hold:
+//
+//  1. the name is locally declared (FuncDef, FuncDef arg, pattern var, label),
+//  2. the name is a Zigflow workflow state variable ($context, $data, etc.),
+//  3. the name is a Zigflow registered function explicitly marked deterministic,
+//  4. the name is a gojq builtin on the deterministic allow-list.
+//
+// Any other identifier is flagged as non-deterministic. Unknown identifiers
+// fail closed, so analysis remains safe for future gojq builtins and for
+// user-defined names that have not been classified.
+func (a *determinismAnalyser) walkFunc(f *gojq.Func, sc *scope, path string) {
+	if f == nil {
+		return
+	}
+	a.classifyName(f.Name, sc, path)
+	for i, arg := range f.Args {
+		a.walkQuery(arg, sc, fmt.Sprintf("%s(arg%d)", joinPath(path, f.Name), i))
+	}
+}
+
+func (a *determinismAnalyser) classifyName(name string, sc *scope, path string) {
+	if name == "" {
+		return
+	}
+	// Locally declared names (FuncDefs, args, pattern vars, labels) are safe;
+	// their bodies are walked separately.
+	if sc.contains(name) {
+		return
+	}
+	// Zigflow state variables are populated from workflow history.
+	if _, ok := stateVars[name]; ok {
+		return
+	}
+	// Zigflow-registered functions: trust the registry's classification.
+	for _, fn := range jqFuncs {
+		if fn.Name == name {
+			if fn.Deterministic {
+				return
+			}
+			a.flag(name, reasonFor(name, fmt.Sprintf("Zigflow function %q is non-deterministic", name)), path)
+			return
+		}
+	}
+	// Known deterministic gojq builtins.
+	if _, ok := deterministicBuiltins[name]; ok {
+		return
+	}
+	// Fail closed for everything else.
+	a.flag(name, reasonFor(name, fmt.Sprintf("identifier %q is not a known replay-safe symbol", name)), path)
+}
+
+func reasonFor(name, fallback string) string {
+	if r, ok := nonDeterministicReasons[name]; ok {
+		return r
+	}
+	return fallback
+}
+
+// walkIndex walks an index suffix such as `.foo`, `.["x"]`, or `.[start:end]`.
+// Index keys are deterministic; the inner queries (if any) are walked.
+func (a *determinismAnalyser) walkIndex(i *gojq.Index, sc *scope, path string) {
+	if i == nil {
+		return
+	}
+	if i.Str != nil {
+		a.walkString(i.Str, sc, path)
+	}
+	if i.Start != nil {
+		a.walkQuery(i.Start, sc, path)
+	}
+	if i.End != nil {
+		a.walkQuery(i.End, sc, path)
+	}
+}
+
+func (a *determinismAnalyser) walkString(s *gojq.String, sc *scope, path string) {
+	if s == nil {
+		return
+	}
+	for _, q := range s.Queries {
+		a.walkQuery(q, sc, path)
+	}
+}
+
+func (a *determinismAnalyser) walkIf(i *gojq.If, sc *scope, path string) {
+	if i == nil {
+		return
+	}
+	a.walkQuery(i.Cond, sc, joinPath(path, "cond"))
+	a.walkQuery(i.Then, sc, joinPath(path, "then"))
+	for idx, el := range i.Elif {
+		a.walkQuery(el.Cond, sc, fmt.Sprintf("%s/elif%d/cond", path, idx))
+		a.walkQuery(el.Then, sc, fmt.Sprintf("%s/elif%d/then", path, idx))
+	}
+	a.walkQuery(i.Else, sc, joinPath(path, "else"))
+}
+
+// collectPatternVars walks a pattern and adds every variable it introduces to
+// sc. Patterns appear in `as`, `reduce` and `foreach` constructs.
+func collectPatternVars(sc *scope, p *gojq.Pattern) {
+	if p == nil {
+		return
+	}
+	if p.Name != "" {
+		sc.add(p.Name)
+	}
+	for _, child := range p.Array {
+		collectPatternVars(sc, child)
+	}
+	for _, kv := range p.Object {
+		if kv.Val != nil {
+			collectPatternVars(sc, kv.Val)
+		}
+	}
+}

--- a/pkg/utils/expression_determinism_test.go
+++ b/pkg/utils/expression_determinism_test.go
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	exprNow         = "${ now }"
+	exprTimestamp   = "${ timestamp }"
+	exprUUID        = "${ uuid }"
+	symbolNow       = "now"
+	symbolTimestamp = "timestamp"
+	symbolUUID      = "uuid"
+)
+
+func TestAnalyseExpressionDeterminism_Deterministic(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{"state variable", "${ $data.delay }"},
+		{"state variable plus literal", "${ $data.delay + 10 }"},
+		{"length of state array", "${ length($data.items) }"},
+		{"identity", "${ . }"},
+		{"context access", "${ $context.user.id }"},
+		{"input access", "${ $input.name }"},
+		{"map over state", "${ $data.items | map(. * 2) }"},
+		{"select over state", "${ $data.items[] | select(.active) }"},
+		{"object literal from state", `${ {name: $data.name, age: $data.age} }`},
+		{"array literal from state", "${ [$data.a, $data.b] }"},
+		{"string interpolation from state", `${ "hello \($data.name)" }`},
+		{"if-then-else over state", "${ if $data.x > 0 then $data.a else $data.b end }"},
+		{"reduce over state", "${ reduce $data.items[] as $i (0; . + $i) }"},
+		{"foreach over state", "${ foreach $data.items[] as $i (0; . + $i; .) }"},
+		{"try over state", "${ try $data.x catch $data.y }"},
+		{"local def referencing state", "${ def double: . * 2; $data.x | double }"},
+		{"label and break", "${ label $out | $data.items[] | if . == 5 then ., break $out else . end }"},
+		{"strftime takes input not clock", `${ $data.epoch | strftime("%Y-%m-%d") }`},
+		{"plain string literal", `${ "static" }`},
+		{"arithmetic on literals", "${ 1 + 2 * 3 }"},
+		{"slice on state", "${ $data.items[0:2] }"},
+		{"iter on state", "${ $data.items[] }"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			analysis, err := AnalyseExpressionDeterminism(tc.expr)
+			require.NoError(t, err)
+			assert.True(t, analysis.Deterministic,
+				"expected expression to be deterministic, got issues: %+v", analysis.Issues)
+		})
+	}
+}
+
+func TestAnalyseExpressionDeterminism_NonDeterministic(t *testing.T) {
+	tests := []struct {
+		name       string
+		expr       string
+		wantSymbol string
+	}{
+		{"bare timestamp", exprTimestamp, symbolTimestamp},
+		{"bare uuid", exprUUID, symbolUUID},
+		{"bare random", "${ random }", "random"},
+		{"bare now", exprNow, symbolNow},
+		{"bare env", "${ env.HOST }", "env"},
+		{"$ENV variable", "${ $ENV.HOST }", "$ENV"},
+		{"timestamp nested in arithmetic", "${ $data.delay + timestamp }", symbolTimestamp},
+		{"uuid nested in array literal", "${ length([$data.id, uuid]) }", symbolUUID},
+		{"timestamp inside object", `${ {created: timestamp} }`, symbolTimestamp},
+		{"now inside if branch", "${ if $data.flag then now else 0 end }", symbolNow},
+		{"uuid as argument to map", "${ $data.items | map(uuid) }", symbolUUID},
+		{"unknown function", "${ totally_made_up }", "totally_made_up"},
+		{"timestamp_iso8601 piped", "${ timestamp_iso8601 | length }", "timestamp_iso8601"},
+		{"localtime nested", "${ $data.epoch | localtime }", "localtime"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			analysis, err := AnalyseExpressionDeterminism(tc.expr)
+			require.NoError(t, err)
+			assert.False(t, analysis.Deterministic,
+				"expected expression to be non-deterministic")
+			require.NotEmpty(t, analysis.Issues)
+			symbols := make([]string, 0, len(analysis.Issues))
+			for _, issue := range analysis.Issues {
+				symbols = append(symbols, issue.Symbol)
+			}
+			assert.Contains(t, symbols, tc.wantSymbol,
+				"expected issue for %q, got: %+v", tc.wantSymbol, analysis.Issues)
+		})
+	}
+}
+
+func TestAnalyseExpressionDeterminism_StateVariablesAreReplaySafe(t *testing.T) {
+	for v := range stateVars {
+		t.Run(v, func(t *testing.T) {
+			analysis, err := AnalyseExpressionDeterminism("${ " + v + " }")
+			require.NoError(t, err)
+			assert.True(t, analysis.Deterministic,
+				"state variable %s must be replay-safe, got: %+v", v, analysis.Issues)
+		})
+	}
+}
+
+func TestAnalyseExpressionDeterminism_ParseError(t *testing.T) {
+	_, err := AnalyseExpressionDeterminism("${ @@@ }")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse")
+}
+
+func TestAnalyseExpressionDeterminism_UnknownFunctionsFailClosed(t *testing.T) {
+	// Custom functions that are not registered as replay-safe must be flagged
+	// as non-deterministic. This is the fail-closed behaviour: we'd rather
+	// reject a safe expression than silently accept an unsafe one.
+	analysis, err := AnalyseExpressionDeterminism("${ my_custom_func($data.x) }")
+	require.NoError(t, err)
+	assert.False(t, analysis.Deterministic)
+	require.NotEmpty(t, analysis.Issues)
+	assert.Equal(t, "my_custom_func", analysis.Issues[0].Symbol)
+}
+
+func TestAnalyseExpressionDeterminism_LocallyDefinedFuncIsSafe(t *testing.T) {
+	// Locally defined functions that only reference state are safe.
+	analysis, err := AnalyseExpressionDeterminism("${ def add_one: . + 1; $data.x | add_one }")
+	require.NoError(t, err)
+	assert.True(t, analysis.Deterministic,
+		"locally defined function over state must be deterministic, got: %+v", analysis.Issues)
+}
+
+func TestAnalyseExpressionDeterminism_LocallyDefinedFuncBodyIsChecked(t *testing.T) {
+	// A user-defined function whose body uses `timestamp` is still
+	// non-deterministic, even if the function name itself is local.
+	analysis, err := AnalyseExpressionDeterminism("${ def tick: timestamp; tick }")
+	require.NoError(t, err)
+	assert.False(t, analysis.Deterministic)
+	require.NotEmpty(t, analysis.Issues)
+	assert.Equal(t, "timestamp", analysis.Issues[0].Symbol)
+}
+
+func TestAnalyseExpressionDeterminism_AsPatternVarIsSafe(t *testing.T) {
+	// Variables introduced by `as $x` patterns are deterministic — they bind
+	// to the value of the left-hand side, which is itself walked.
+	analysis, err := AnalyseExpressionDeterminism("${ $data.items[] as $i | $i + 1 }")
+	require.NoError(t, err)
+	assert.True(t, analysis.Deterministic, "got issues: %+v", analysis.Issues)
+}
+
+func TestAnalyseExpressionDeterminism_ImportsAreRejected(t *testing.T) {
+	// Imports load arbitrary modules at evaluation time; treat them as
+	// non-deterministic.
+	analysis, err := AnalyseExpressionDeterminism(`${ import "./mod" as m; m::foo }`)
+	if err != nil {
+		// Some gojq builds may reject the import syntax at parse time; either
+		// outcome rejects the expression, which is the contract we care about.
+		return
+	}
+	assert.False(t, analysis.Deterministic)
+}
+
+func TestIsExpressionDeterministic(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		want bool
+	}{
+		{"deterministic", "${ $data.delay }", true},
+		{"non-deterministic", exprTimestamp, false},
+		{"parse error fails closed", "${ @@@ }", false},
+		{"nested non-deterministic", "${ $data.delay + uuid }", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsExpressionDeterministic(tc.expr))
+		})
+	}
+}
+
+func TestIsDeterministicBuiltin(t *testing.T) {
+	t.Run("length is deterministic", func(t *testing.T) {
+		assert.True(t, IsDeterministicBuiltin("length"))
+	})
+	t.Run("map is deterministic", func(t *testing.T) {
+		assert.True(t, IsDeterministicBuiltin("map"))
+	})
+	t.Run("now is not on the allow-list", func(t *testing.T) {
+		assert.False(t, IsDeterministicBuiltin(symbolNow))
+	})
+	t.Run("env is not on the allow-list", func(t *testing.T) {
+		assert.False(t, IsDeterministicBuiltin("env"))
+	})
+	t.Run("unknown identifier is not on the allow-list", func(t *testing.T) {
+		assert.False(t, IsDeterministicBuiltin("totally_made_up"))
+	})
+}
+
+func TestAnalyseExpressionDeterminism_BareExpressionWithoutWrapper(t *testing.T) {
+	// The analyser should also handle expressions that are not wrapped in
+	// ${ ... } — for example when callers have already sanitised.
+	analysis, err := AnalyseExpressionDeterminism("$data.x + 1")
+	require.NoError(t, err)
+	assert.True(t, analysis.Deterministic)
+
+	analysis, err = AnalyseExpressionDeterminism(symbolTimestamp)
+	require.NoError(t, err)
+	assert.False(t, analysis.Deterministic)
+}

--- a/pkg/utils/runtime_expressions.go
+++ b/pkg/utils/runtime_expressions.go
@@ -39,16 +39,20 @@ const (
 
 type ExpressionWrapperFunc func(func() (any, error)) (any, error)
 
+// jqFunc describes a function exposed to Zigflow runtime expressions. The
+// Deterministic flag is the source of truth for replay-safety classification;
+// AnalyseExpressionDeterminism reads this list when walking expressions.
 type jqFunc struct {
-	Name    string                         // Becomes the name of the function to use (eg, ${ uuid })
-	MinArgs int                            // Minimum number of args
-	MaxArgs int                            // Maximum number of args
-	Func    func(vars any, args []any) any // The function - receives the variables and arguments
+	Name          string
+	MinArgs       int
+	MaxArgs       int
+	Deterministic bool
+	Func          func(vars any, args []any) any
 }
 
-// List of functions that are available as a function.
-// All registered functions are non-deterministic and will trigger an error
-// when used outside of a set task (i.e. without a side-effect wrapper).
+// jqFuncs is the registry of Zigflow-defined jq functions. Anything marked
+// Deterministic=false is rejected outside a Set task because its result would
+// not survive Temporal workflow replay.
 var jqFuncs []jqFunc = []jqFunc{
 	{
 		Name: jqFuncUUID,
@@ -75,17 +79,19 @@ var jqFuncs []jqFunc = []jqFunc{
 func EvaluateString(str string, ctx any, state *State, evaluationWrapper ...ExpressionWrapperFunc) (any, error) {
 	// Check if the string is a runtime expression (e.g., ${ .some.path })
 	if model.IsStrictExpr(str) {
-		// Error if a non-deterministic function is used without a side-effect wrapper.
-		// A wrapper is only provided by tasks (e.g. set) that correctly isolate
-		// non-deterministic calls inside workflow.SideEffect.
+		// Error if a non-deterministic construct is used without a side-effect
+		// wrapper. A wrapper is only provided by tasks (e.g. set) that
+		// correctly isolate non-deterministic calls inside workflow.SideEffect.
 		if len(evaluationWrapper) == 0 {
-			expr := model.SanitizeExpr(str)
-			if fnName := LeadingNonDeterministicFunc(expr); fnName != "" {
-				log.Error().
-					Str("expression", str).
-					Str("function", fnName).
-					Str("docs", ndeDocsURL).
-					Msg("Non-deterministic function used outside of a set task — this may cause workflow replay failures")
+			if analysis, err := AnalyseExpressionDeterminism(str); err == nil && !analysis.Deterministic {
+				for _, issue := range analysis.Issues {
+					log.Error().
+						Str("expression", str).
+						Str("symbol", issue.Symbol).
+						Str("reason", issue.Reason).
+						Str("docs", ndeDocsURL).
+						Msg("Non-deterministic expression used outside of a set task — this may cause workflow replay failures")
+				}
 			}
 		}
 
@@ -109,36 +115,6 @@ func buildEvaluationWrapperFn(evaluationWrapper ...ExpressionWrapperFunc) Expres
 	}
 
 	return wrapperFn
-}
-
-// LeadingNonDeterministicFunc returns the name of the non-deterministic function
-// that expr begins with, or an empty string if it does not.
-// Only the leading identifier is inspected: `uuid` errors, but `$data.uuid`
-// and `.uuid` do not, as those are variable or field references, not calls.
-func LeadingNonDeterministicFunc(expr string) string {
-	expr = strings.TrimSpace(expr)
-	if expr == "" || !isIdentStart(expr[0]) {
-		return ""
-	}
-	end := 1
-	for end < len(expr) && isIdentChar(expr[end]) {
-		end++
-	}
-	ident := expr[:end]
-	for _, fn := range jqFuncs {
-		if fn.Name == ident {
-			return ident
-		}
-	}
-	return ""
-}
-
-func isIdentStart(c byte) bool {
-	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_'
-}
-
-func isIdentChar(c byte) bool {
-	return isIdentStart(c) || c >= '0' && c <= '9'
 }
 
 func TraverseAndEvaluateObj(
@@ -234,6 +210,47 @@ func toAnySlice[T any](in []T) []any {
 	return out
 }
 
+// jqCompilerOptions builds the gojq compiler options shared by runtime
+// evaluation and validation: the given workflow state variables plus every
+// Zigflow-registered function. Keeping this in one place ensures validation
+// compiles expressions under exactly the same rules as runtime, so the two
+// cannot drift.
+func jqCompilerOptions(variableNames []string) []gojq.CompilerOption {
+	opts := []gojq.CompilerOption{
+		gojq.WithVariables(variableNames),
+	}
+	for _, j := range jqFuncs {
+		opts = append(opts, gojq.WithFunction(j.Name, j.MinArgs, j.MaxArgs, j.Func))
+	}
+	return opts
+}
+
+// CompileExpression parses and compiles expr using the exact same gojq options
+// as runtime evaluation (the Zigflow workflow state variables and registered
+// functions). It returns an error if the expression cannot parse or compile —
+// for example, referencing an unregistered variable or function — which would
+// otherwise only surface at execution time. The strict expression wrapper
+// (${ ... }) is stripped before parsing.
+func CompileExpression(expr string) error {
+	if model.IsStrictExpr(expr) {
+		expr = model.SanitizeExpr(expr)
+	}
+
+	query, err := gojq.Parse(expr)
+	if err != nil {
+		return fmt.Errorf("failed to parse expression %q: %w", expr, err)
+	}
+
+	// Use the canonical state variable names so validation matches runtime,
+	// where the same names are always injected via State.GetAsMap.
+	names, _ := getVariableNamesAndValues(NewState().GetAsMap())
+	if _, err := gojq.Compile(query, jqCompilerOptions(names)...); err != nil {
+		return fmt.Errorf("failed to compile expression %q: %w", expr, err)
+	}
+
+	return nil
+}
+
 func evaluateJQExpression(expression string, ctx any, state *State) (any, error) {
 	query, err := gojq.Parse(expression)
 	if err != nil {
@@ -243,15 +260,7 @@ func evaluateJQExpression(expression string, ctx any, state *State) (any, error)
 	// Get the variable names & values in a single pass:
 	names, values := getVariableNamesAndValues(state.GetAsMap())
 
-	fns := []gojq.CompilerOption{
-		gojq.WithVariables(names),
-	}
-
-	for _, j := range jqFuncs {
-		fns = append(fns, gojq.WithFunction(j.Name, j.MinArgs, j.MaxArgs, j.Func))
-	}
-
-	code, err := gojq.Compile(query, fns...)
+	code, err := gojq.Compile(query, jqCompilerOptions(names)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile jq expression: %s, error: %w", expression, err)
 	}

--- a/pkg/utils/runtime_expressions_test.go
+++ b/pkg/utils/runtime_expressions_test.go
@@ -271,13 +271,42 @@ func TestEvaluateStringJqFunctions(t *testing.T) {
 	})
 }
 
+// TestCompileExpression proves the validation-time compile helper accepts the
+// same registered variables and functions that runtime evaluation does, and
+// rejects unregistered symbols that would otherwise only fail at execution.
+func TestCompileExpression(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{name: "registered zigflow function", expr: "${ uuid }"},
+		{name: "state variable", expr: "${ $data.foo }"},
+		{name: "deterministic builtin", expr: "${ .a | length }"},
+		{name: "plain path", expr: "${ .msg }"},
+		{name: "unregistered symbol", expr: "${ definitely_not_registered }", wantErr: true},
+		{name: "parse error", expr: "${ @@@ }", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CompileExpression(tc.expr)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestEvaluateStringNonDeterministicWithWrapper(t *testing.T) {
 	tests := []struct {
 		Name string
 		Expr string
 	}{
-		{Name: "uuid with wrapper", Expr: "${ uuid }"},
-		{Name: "timestamp with wrapper", Expr: "${ timestamp }"},
+		{Name: "uuid with wrapper", Expr: exprUUID},
+		{Name: "timestamp with wrapper", Expr: exprTimestamp},
 		{Name: "timestamp_iso8601 with wrapper", Expr: "${ timestamp_iso8601 }"},
 	}
 
@@ -289,90 +318,6 @@ func TestEvaluateStringNonDeterministicWithWrapper(t *testing.T) {
 			result, err := EvaluateString(test.Expr, nil, NewState(), wrapper)
 			require.NoError(t, err)
 			assert.NotNil(t, result)
-		})
-	}
-}
-
-func TestLeadingNonDeterministicFunc(t *testing.T) {
-	tests := []struct {
-		Name     string
-		Expr     string
-		Expected string
-	}{
-		// Registered non-deterministic functions
-		{Name: "uuid is detected", Expr: jqFuncUUID, Expected: jqFuncUUID},
-		{Name: "timestamp is detected", Expr: jqFuncTimestamp, Expected: jqFuncTimestamp},
-		{Name: "timestamp_iso8601 is detected", Expr: jqFuncTimestampISO, Expected: jqFuncTimestampISO},
-
-		// Leading whitespace is trimmed
-		{Name: "uuid with leading spaces", Expr: "  uuid", Expected: jqFuncUUID},
-
-		// Only the leading identifier matters; a pipe still makes it non-det
-		{Name: "uuid piped to length", Expr: "uuid | length", Expected: jqFuncUUID},
-
-		// Field accesses and variable references are NOT function calls
-		{Name: "field access .uuid is not a function", Expr: ".uuid", Expected: ""},
-		{Name: "variable $data.uuid is not a function", Expr: "$data.uuid", Expected: ""},
-		{Name: "jq path .foo is not a function", Expr: ".foo", Expected: ""},
-
-		// Unknown identifiers that look like functions but aren't registered
-		{Name: "unknown identifier returns empty", Expr: "my_func", Expected: ""},
-		{Name: "length is not registered", Expr: "length", Expected: ""},
-
-		// Edge cases
-		{Name: "empty string returns empty", Expr: "", Expected: ""},
-		{Name: "only whitespace returns empty", Expr: "   ", Expected: ""},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			got := LeadingNonDeterministicFunc(test.Expr)
-			assert.Equal(t, test.Expected, got)
-		})
-	}
-}
-
-func TestIsIdentStart(t *testing.T) {
-	tests := []struct {
-		Name     string
-		Char     byte
-		Expected bool
-	}{
-		{Name: "lowercase letter", Char: 'a', Expected: true},
-		{Name: "uppercase letter", Char: 'Z', Expected: true},
-		{Name: "underscore", Char: '_', Expected: true},
-		{Name: "digit is not an ident start", Char: '0', Expected: false},
-		{Name: "dot is not an ident start", Char: '.', Expected: false},
-		{Name: "dollar is not an ident start", Char: '$', Expected: false},
-		{Name: "hyphen is not an ident start", Char: '-', Expected: false},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			assert.Equal(t, test.Expected, isIdentStart(test.Char))
-		})
-	}
-}
-
-func TestIsIdentChar(t *testing.T) {
-	tests := []struct {
-		Name     string
-		Char     byte
-		Expected bool
-	}{
-		{Name: "lowercase letter", Char: 'z', Expected: true},
-		{Name: "uppercase letter", Char: 'A', Expected: true},
-		{Name: "underscore", Char: '_', Expected: true},
-		{Name: "digit", Char: '9', Expected: true},
-		{Name: "dot is not an ident char", Char: '.', Expected: false},
-		{Name: "dollar is not an ident char", Char: '$', Expected: false},
-		{Name: "space is not an ident char", Char: ' ', Expected: false},
-		{Name: "pipe is not an ident char", Char: '|', Expected: false},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			assert.Equal(t, test.Expected, isIdentChar(test.Char))
 		})
 	}
 }

--- a/pkg/zigflow/expression_determinism.go
+++ b/pkg/zigflow/expression_determinism.go
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zigflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/zigflow/zigflow/pkg/utils"
+	"github.com/zigflow/zigflow/pkg/zigflow/metadata"
+)
+
+// ErrNonDeterministicExpression is returned when a workflow contains a runtime
+// expression whose result is not derivable from workflow state, outside a Set
+// task. Such expressions break Temporal replay because the result is not
+// captured in workflow history.
+var ErrNonDeterministicExpression = errors.New("non-deterministic expression")
+
+// NonDeterministicExpression identifies a single offending runtime expression
+// and where it sits in the workflow document. It is the machine-readable unit
+// behind a determinism failure.
+type NonDeterministicExpression struct {
+	Path       string `json:"path"`
+	Expression string `json:"expression"`
+}
+
+// NonDeterministicExpressionError is returned by ValidateWorkflowDeterminism
+// when one or more expressions outside a Set task are not replay-safe. It
+// wraps ErrNonDeterministicExpression (so errors.Is still matches) and its
+// Error() string is unchanged from the previous behaviour, while Expressions
+// exposes the failures in structured form for callers that want to render or
+// process them without parsing the message.
+type NonDeterministicExpressionError struct {
+	Expressions []NonDeterministicExpression
+	msg         string
+}
+
+func (e *NonDeterministicExpressionError) Error() string { return e.msg }
+
+func (e *NonDeterministicExpressionError) Unwrap() error { return ErrNonDeterministicExpression }
+
+// ErrInvalidRuntimeExpression is returned when a workflow contains a runtime
+// expression that cannot be parsed as jq, regardless of where it appears. This
+// is a syntax failure, distinct from non-determinism: it would only surface at
+// execution time otherwise.
+var ErrInvalidRuntimeExpression = errors.New("invalid runtime expression")
+
+// InvalidRuntimeExpression identifies a single runtime expression that failed
+// to parse, where it sits in the workflow document, and the underlying parse
+// error.
+type InvalidRuntimeExpression struct {
+	Path       string `json:"path"`
+	Expression string `json:"expression"`
+	Err        error  `json:"-"`
+}
+
+// InvalidRuntimeExpressionError is returned by ValidateWorkflowDeterminism when
+// one or more collected expressions cannot be parsed. It wraps
+// ErrInvalidRuntimeExpression (so errors.Is matches) and exposes the failures
+// in structured form for callers that want to render them.
+type InvalidRuntimeExpressionError struct {
+	Expressions []InvalidRuntimeExpression
+	msg         string
+}
+
+func (e *InvalidRuntimeExpressionError) Error() string { return e.msg }
+
+func (e *InvalidRuntimeExpressionError) Unwrap() error { return ErrInvalidRuntimeExpression }
+
+// ExpressionRef identifies one strict-form runtime expression found inside a
+// workflow definition. It records where the expression is in the document and
+// whether the location permits non-deterministic constructs.
+//
+// Non-determinism is permitted in two kinds of location: Set task bodies (the
+// `set` map), which the SetTask builder evaluates inside workflow.SideEffect so
+// the result is captured in workflow history; and document.metadata.scheduleInput,
+// which is interpolated at schedule-registration time, outside the workflow.
+// Every other location, including a Set task's own TaskBase fields
+// (if/input/output/export/then/metadata), must be deterministic.
+type ExpressionRef struct {
+	Value                string
+	Path                 string
+	AllowsNonDeterminism bool
+}
+
+// CollectExpressions walks doc and returns every strict-form runtime
+// expression (${ ... }) it contains, tagged with location and whether
+// non-determinism is permitted there. The returned slice is in document
+// order so error messages remain stable across runs.
+func CollectExpressions(doc *model.Workflow) ([]ExpressionRef, error) {
+	if doc == nil {
+		return nil, nil
+	}
+	c := &expressionCollector{}
+	if doc.Input != nil {
+		if err := c.collectRaw(doc.Input, "workflow.input", false); err != nil {
+			return nil, err
+		}
+	}
+	if doc.Output != nil {
+		if err := c.collectRaw(doc.Output, "workflow.output", false); err != nil {
+			return nil, err
+		}
+	}
+	if doc.Schedule != nil {
+		if err := c.collectRaw(doc.Schedule, "workflow.schedule", false); err != nil {
+			return nil, err
+		}
+	}
+	// document.metadata.scheduleInput is interpolated at schedule-registration
+	// time (see metadata.GetScheduleInfo), so it must be parse/compile-validated
+	// like any other runtime expression. It runs outside the workflow, so it is
+	// exempt from the determinism rule (AllowsNonDeterminism=true), exactly like
+	// a Set body. Other document.metadata keys are static config and are not
+	// evaluated as expressions, so they are deliberately not collected.
+	if doc.Document.Metadata != nil {
+		if input, ok := doc.Document.Metadata[metadata.MetadataScheduleInput]; ok {
+			path := "document.metadata." + metadata.MetadataScheduleInput
+			if err := c.collectRaw(input, path, true); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if doc.Do != nil {
+		if err := c.collectTaskList(doc.Do, "do"); err != nil {
+			return nil, err
+		}
+	}
+	return c.refs, nil
+}
+
+// ValidateWorkflowDeterminism is the single workflow-level expression
+// validation check. It walks doc and validates every collected expression.
+//
+// Every expression is parsed and compiled (via utils.CompileExpression, using
+// the same gojq options as runtime) regardless of location. An expression that
+// cannot parse or compile returns an *InvalidRuntimeExpressionError (wrapping
+// ErrInvalidRuntimeExpression), which takes priority over any determinism
+// findings.
+//
+// Determinism is only evaluated for expressions that parse and compile
+// successfully. Expressions inside a Set task's `set` body are exempt from the
+// determinism rule — but not from parse/compile validation — because they are
+// evaluated under workflow.SideEffect and their result is captured in workflow
+// history. A non-deterministic expression elsewhere returns an
+// *NonDeterministicExpressionError (wrapping ErrNonDeterministicExpression).
+func ValidateWorkflowDeterminism(doc *model.Workflow) error {
+	refs, err := CollectExpressions(doc)
+	if err != nil {
+		return fmt.Errorf("collect expressions: %w", err)
+	}
+	var issues []string
+	var failures []NonDeterministicExpression
+	seen := map[NonDeterministicExpression]bool{}
+	// addFailure records one offending location+expression exactly once, so the
+	// same expression flagged for multiple non-deterministic symbols is not
+	// reported as multiple failures to callers.
+	addFailure := func(path, expression string) {
+		f := NonDeterministicExpression{Path: path, Expression: expression}
+		if seen[f] {
+			return
+		}
+		seen[f] = true
+		failures = append(failures, f)
+	}
+
+	var invalidIssues []string
+	var invalids []InvalidRuntimeExpression
+	addInvalid := func(path, expression string, err error) {
+		invalidIssues = append(invalidIssues, fmt.Sprintf("%s: %s", path, err))
+		invalids = append(invalids, InvalidRuntimeExpression{
+			Path:       path,
+			Expression: expression,
+			Err:        err,
+		})
+	}
+
+	for _, ref := range refs {
+		// Every expression must parse and compile under the same gojq options
+		// as runtime, regardless of where it appears. Set bodies are exempt
+		// from the determinism rule, not from parse/compile validation, so this
+		// gate runs before the AllowsNonDeterminism check.
+		if err := utils.CompileExpression(ref.Value); err != nil {
+			addInvalid(ref.Path, ref.Value, err)
+			continue
+		}
+
+		// Determinism is only evaluated once parse and compile have succeeded,
+		// and only for locations that do not permit non-determinism.
+		if ref.AllowsNonDeterminism {
+			continue
+		}
+		analysis, err := utils.AnalyseExpressionDeterminism(ref.Value)
+		if err != nil {
+			// Unreachable in practice: CompileExpression already parsed the
+			// same expression. Classify defensively as invalid rather than
+			// silently dropping the error.
+			addInvalid(ref.Path, ref.Value, err)
+			continue
+		}
+		if analysis.Deterministic {
+			continue
+		}
+		addFailure(ref.Path, ref.Value)
+		for _, issue := range analysis.Issues {
+			issues = append(issues, fmt.Sprintf(
+				"%s: expression %q uses non-deterministic value %q (%s). "+
+					"Non-deterministic expressions are only allowed in Set tasks, "+
+					"where the result is captured in workflow history. "+
+					"Move this expression into a Set task and reference the stored value from workflow state",
+				ref.Path, ref.Value, issue.Symbol, issue.Reason,
+			))
+		}
+	}
+
+	// Parse failures take priority over and are reported separately from
+	// non-determinism: an unparseable expression has no meaningful determinism
+	// verdict.
+	if len(invalids) > 0 {
+		return &InvalidRuntimeExpressionError{
+			Expressions: invalids,
+			msg:         formatValidationIssues(ErrInvalidRuntimeExpression, invalidIssues),
+		}
+	}
+
+	if len(issues) == 0 {
+		return nil
+	}
+	return &NonDeterministicExpressionError{
+		Expressions: failures,
+		msg:         formatValidationIssues(ErrNonDeterministicExpression, issues),
+	}
+}
+
+// formatValidationIssues renders a sentinel error and its per-expression issue
+// lines into the bullet-list message shared by the structured expression
+// validation errors.
+func formatValidationIssues(sentinel error, issues []string) string {
+	return fmt.Sprintf("%s:\n  - %s", sentinel, strings.Join(issues, "\n  - "))
+}
+
+type expressionCollector struct {
+	refs []ExpressionRef
+}
+
+func (c *expressionCollector) collectTaskList(list *model.TaskList, path string) error {
+	if list == nil {
+		return nil
+	}
+	for i, item := range *list {
+		itemPath := fmt.Sprintf("%s[%d].%s", path, i, item.Key)
+		if err := c.collectTaskItem(item, itemPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// collectTaskItem walks one TaskItem. TaskBase fields are always
+// deterministic-only. The task body is split based on type: container tasks
+// recurse into their child task lists, Set tasks contribute their `set` map
+// as the only non-deterministic-permissive location, and every other task
+// type has its full body walked as deterministic.
+func (c *expressionCollector) collectTaskItem(item *model.TaskItem, path string) error {
+	if item == nil || item.Task == nil {
+		return nil
+	}
+	if base := item.GetBase(); base != nil {
+		if err := c.collectRaw(base, path, false); err != nil {
+			return err
+		}
+	}
+
+	switch {
+	case item.AsSetTask() != nil:
+		st := item.AsSetTask()
+		return c.collectRaw(st.Set, path+".set", true)
+
+	case item.AsDoTask() != nil:
+		dt := item.AsDoTask()
+		return c.collectTaskList(dt.Do, path+".do")
+
+	case item.AsForkTask() != nil:
+		ft := item.AsForkTask()
+		return c.collectTaskList(ft.Fork.Branches, path+".fork.branches")
+
+	case item.AsForTask() != nil:
+		ft := item.AsForTask()
+		if err := c.collectRaw(ft.For, path+".for", false); err != nil {
+			return err
+		}
+		c.addStringExpr(ft.While, path+".while", false)
+		return c.collectTaskList(ft.Do, path+".do")
+
+	case item.AsTryTask() != nil:
+		tt := item.AsTryTask()
+		if err := c.collectTaskList(tt.Try, path+".try"); err != nil {
+			return err
+		}
+		if tt.Catch != nil {
+			if err := c.collectTaskList(tt.Catch.Do, path+".catch.do"); err != nil {
+				return err
+			}
+			if err := c.collectCatchControl(tt.Catch, path+".catch"); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Default: leaf or extension task (Call*, Run, Wait, Listen, Emit, Raise,
+	// Switch, WaitExt, …). Walk the entire task body as raw JSON, having
+	// already covered the TaskBase fields above, and exclude them here so we
+	// do not double-count.
+	return c.collectTaskBodyExcludingBase(item.Task, path)
+}
+
+// collectCatchControl walks the deterministic parts of a TryTaskCatch: the
+// When / ExceptWhen guards and the retry policy. The catch.do task list is
+// walked separately by the caller.
+func (c *expressionCollector) collectCatchControl(catch *model.TryTaskCatch, path string) error {
+	temp := struct {
+		Errors     any                      `json:"errors,omitempty"`
+		As         string                   `json:"as,omitempty"`
+		When       *model.RuntimeExpression `json:"when,omitempty"`
+		ExceptWhen *model.RuntimeExpression `json:"exceptWhen,omitempty"`
+		Retry      *model.RetryPolicy       `json:"retry,omitempty"`
+	}{
+		Errors:     catch.Errors,
+		As:         catch.As,
+		When:       catch.When,
+		ExceptWhen: catch.ExceptWhen,
+		Retry:      catch.Retry,
+	}
+	return c.collectRaw(temp, path, false)
+}
+
+// collectTaskBodyExcludingBase marshals a Task to JSON, drops the TaskBase
+// fields (already walked by the caller), and walks the remainder.
+func (c *expressionCollector) collectTaskBodyExcludingBase(task model.Task, path string) error {
+	raw, err := json.Marshal(task)
+	if err != nil {
+		return fmt.Errorf("marshal task at %s: %w", path, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return fmt.Errorf("unmarshal task at %s: %w", path, err)
+	}
+	for _, key := range taskBaseKeys {
+		delete(m, key)
+	}
+	c.walkRaw(m, path, false)
+	return nil
+}
+
+// taskBaseKeys lists every JSON field on model.TaskBase. Kept as a constant so
+// the default case can drop them in one place when walking a task body.
+var taskBaseKeys = []string{
+	keyIf,
+	keyInput,
+	keyOutput,
+	keyExport,
+	keyTimeout,
+	keyThen,
+	keyMetadata,
+}
+
+const (
+	keyIf       = "if"
+	keyInput    = "input"
+	keyOutput   = "output"
+	keyExport   = "export"
+	keyTimeout  = "timeout"
+	keyThen     = "then"
+	keyMetadata = "metadata"
+)
+
+func (c *expressionCollector) collectRaw(v any, path string, allowsNonDeterminism bool) error {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal at %s: %w", path, err)
+	}
+	var node any
+	if err := json.Unmarshal(raw, &node); err != nil {
+		return fmt.Errorf("unmarshal at %s: %w", path, err)
+	}
+	c.walkRaw(node, path, allowsNonDeterminism)
+	return nil
+}
+
+func (c *expressionCollector) walkRaw(node any, path string, allowsNonDeterminism bool) {
+	switch v := node.(type) {
+	case string:
+		c.addStringExpr(v, path, allowsNonDeterminism)
+	case map[string]any:
+		// Range order over a map is randomised, so sort keys to keep collected
+		// expressions in a stable order across runs (affects CLI/JSON output
+		// and tests).
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			c.walkRaw(v[k], joinDocPath(path, k), allowsNonDeterminism)
+		}
+	case []any:
+		for i, vv := range v {
+			c.walkRaw(vv, fmt.Sprintf("%s[%d]", path, i), allowsNonDeterminism)
+		}
+	}
+}
+
+func (c *expressionCollector) addStringExpr(s, path string, allowsNonDeterminism bool) {
+	if !model.IsStrictExpr(s) {
+		return
+	}
+	c.refs = append(c.refs, ExpressionRef{
+		Value:                s,
+		Path:                 path,
+		AllowsNonDeterminism: allowsNonDeterminism,
+	})
+}
+
+func joinDocPath(path, segment string) string {
+	if path == "" {
+		return segment
+	}
+	return path + "." + segment
+}

--- a/pkg/zigflow/expression_determinism_test.go
+++ b/pkg/zigflow/expression_determinism_test.go
@@ -1,0 +1,676 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zigflow_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/zigflow"
+)
+
+const workflowHeader = `document:
+  dsl: 1.0.0
+  taskQueue: default
+  workflowType: test
+  version: 0.0.1
+`
+
+// TestLoadFromBytes_RejectsNonDeterministicAcrossTaskTypes proves the central
+// determinism pass catches non-determinism in every expression-bearing task
+// type, not just wait_ext. Each case uses the same offending symbol so the
+// only variable is the surrounding task type.
+func TestLoadFromBytes_RejectsNonDeterministicAcrossTaskTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "wait extension seconds field",
+			body: `do:
+  - waitForCooldown:
+      wait:
+        seconds: ${ $data.delay + timestamp }
+`,
+		},
+		{
+			name: "wait extension until field",
+			body: `do:
+  - waitUntil:
+      wait:
+        until: ${ timestamp_iso8601 }
+`,
+		},
+		{
+			name: "call http endpoint",
+			body: `do:
+  - getUser:
+      call: http
+      with:
+        method: get
+        endpoint: ${ "https://example.com/" + uuid }
+`,
+		},
+		{
+			name: "for in expression",
+			body: `do:
+  - loop:
+      for:
+        each: item
+        in: ${ [uuid, $data.x] }
+      do:
+        - body:
+            set:
+              v: ${ $data.x }
+`,
+		},
+		{
+			name: "for while expression",
+			body: `do:
+  - loop:
+      for:
+        each: item
+        in: ${ $data.items }
+      while: ${ now < 1000 }
+      do:
+        - body:
+            set:
+              v: ${ $data.x }
+`,
+		},
+		{
+			name: "switch when expression",
+			body: `do:
+  - decide:
+      switch:
+        - case1:
+            when: ${ $data.x == timestamp }
+            then: continue
+        - default:
+            then: continue
+`,
+		},
+		{
+			name: "task base if expression",
+			body: `do:
+  - skipMaybe:
+      if: ${ now > 1000 }
+      set:
+        v: ${ $data.x }
+`,
+		},
+		{
+			name: "task base output expression",
+			body: `do:
+  - withOutput:
+      output:
+        as: ${ uuid }
+      set:
+        v: ${ $data.x }
+`,
+		},
+		{
+			name: "task base export expression",
+			body: `do:
+  - withExport:
+      export:
+        as: ${ timestamp }
+      set:
+        v: ${ $data.x }
+`,
+		},
+		{
+			name: "task base metadata expression",
+			body: `do:
+  - withMeta:
+      metadata:
+        traceId: ${ uuid }
+      set:
+        v: ${ $data.x }
+`,
+		},
+		{
+			name: "run task workflow input",
+			body: `do:
+  - subflow:
+      run:
+        workflow:
+          namespace: default
+          type: child
+          version: 0.0.1
+          input:
+            id: ${ uuid }
+`,
+		},
+		{
+			name: "try catch when expression",
+			body: `do:
+  - guarded:
+      try:
+        - inner:
+            set:
+              v: ${ $data.x }
+      catch:
+        when: ${ now > 0 }
+        do:
+          - handler:
+              set:
+                v: ${ $data.x }
+`,
+		},
+		{
+			name: "try catch.do task base output",
+			body: `do:
+  - guarded:
+      try:
+        - inner:
+            set:
+              v: ${ $data.x }
+      catch:
+        do:
+          - handler:
+              output:
+                as: ${ uuid }
+              set:
+                v: ${ $data.x }
+`,
+		},
+		{
+			name: "fork branch task non-deterministic",
+			body: `do:
+  - parallel:
+      fork:
+        branches:
+          - branchA:
+              wait:
+                seconds: ${ timestamp }
+          - branchB:
+              set:
+                v: ${ $data.x }
+`,
+		},
+		{
+			name: "nested do task non-deterministic",
+			body: `do:
+  - outer:
+      do:
+        - inner:
+            wait:
+              seconds: ${ timestamp + $data.delay }
+`,
+		},
+		{
+			name: "workflow output as",
+			body: `output:
+  as: ${ timestamp }
+do:
+  - step:
+      set:
+        v: ${ $data.x }
+`,
+		},
+		{
+			name: "workflow input from",
+			body: `input:
+  from: ${ uuid }
+do:
+  - step:
+      set:
+        v: ${ $data.x }
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := workflowHeader + tc.body
+			_, err := zigflow.LoadFromBytes([]byte(yaml))
+			require.Error(t, err, "non-deterministic expression must be rejected")
+			assert.ErrorIs(t, err, zigflow.ErrNonDeterministicExpression,
+				"error must be %v; got %v", zigflow.ErrNonDeterministicExpression, err)
+		})
+	}
+}
+
+// TestLoadFromBytes_AllowsNonDeterminismInsideSetBody proves the same symbols
+// that fail outside Set tasks succeed when wrapped in a Set body.
+func TestLoadFromBytes_AllowsNonDeterminismInsideSetBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "bare uuid in set",
+			body: `do:
+  - capture:
+      set:
+        id: ${ uuid }
+`,
+		},
+		{
+			name: "timestamp in set",
+			body: `do:
+  - capture:
+      set:
+        now: ${ timestamp }
+`,
+		},
+		{
+			name: "nested timestamp in set arithmetic",
+			body: `do:
+  - capture:
+      set:
+        delayedAt: ${ $data.delay + timestamp }
+`,
+		},
+		{
+			name: "uuid deep inside set object",
+			body: `do:
+  - capture:
+      set:
+        meta:
+          ids:
+            - ${ uuid }
+            - ${ uuid }
+`,
+		},
+		{
+			name: "mixed set expressions",
+			body: `do:
+  - capture:
+      set:
+        id: ${ uuid }
+        ts: ${ timestamp }
+        derived: ${ $data.base + 1 }
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := workflowHeader + tc.body
+			wf, err := zigflow.LoadFromBytes([]byte(yaml))
+			require.NoError(t, err, "set body must allow non-determinism")
+			require.NotNil(t, wf)
+		})
+	}
+}
+
+// TestLoadFromBytes_SetTaskBaseFieldsMustBeDeterministic proves that the Set
+// exemption only covers the set body — TaskBase fields on a Set task are
+// still evaluated outside the side effect and must remain replay-safe.
+func TestLoadFromBytes_SetTaskBaseFieldsMustBeDeterministic(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "if on set task",
+			body: `do:
+  - capture:
+      if: ${ now > 0 }
+      set:
+        id: ${ uuid }
+`,
+		},
+		{
+			name: "output on set task",
+			body: `do:
+  - capture:
+      output:
+        as: ${ timestamp }
+      set:
+        id: ${ uuid }
+`,
+		},
+		{
+			name: "metadata on set task",
+			body: `do:
+  - capture:
+      metadata:
+        marker: ${ now }
+      set:
+        id: ${ uuid }
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := workflowHeader + tc.body
+			_, err := zigflow.LoadFromBytes([]byte(yaml))
+			require.Error(t, err, "set task base fields must be deterministic")
+			assert.ErrorIs(t, err, zigflow.ErrNonDeterministicExpression)
+		})
+	}
+}
+
+// TestLoadFromBytes_AllowsDeterministicExpressions confirms the existing
+// expression catalogue continues to load. Without this, regressions in the
+// analyser's allow-list could silently break valid workflows.
+func TestLoadFromBytes_AllowsDeterministicExpressions(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - waitForCooldown:
+      wait:
+        seconds: ${ $data.delay + 10 }
+  - loop:
+      for:
+        each: item
+        in: ${ $data.items }
+      do:
+        - body:
+            set:
+              v: ${ $data.x }
+  - getUser:
+      call: http
+      with:
+        method: get
+        endpoint: ${ "https://example.com/" + ($input.userId | tostring) }
+  - decide:
+      switch:
+        - case1:
+            when: ${ $data.count > 0 }
+            then: continue
+        - default:
+            then: continue
+`
+
+	wf, err := zigflow.LoadFromBytes([]byte(yaml))
+	require.NoError(t, err, "deterministic workflow must load cleanly")
+	require.NotNil(t, wf)
+}
+
+// TestValidateBytes_RejectsNonDeterministic ensures the determinism check
+// is reachable via ValidateBytes too, not only LoadFromBytes. This is the
+// MCP and CLI validate entry point.
+func TestValidateBytes_RejectsNonDeterministic(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - waitForCooldown:
+      wait:
+        seconds: ${ timestamp }
+`
+	err := zigflow.ValidateBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, zigflow.ErrNonDeterministicExpression)
+}
+
+// TestValidateBytes_AcceptsValidSetWorkflow ensures ValidateBytes does not
+// over-reject; a workflow using Set for non-determinism must validate clean.
+func TestValidateBytes_AcceptsValidSetWorkflow(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - capture:
+      set:
+        id: ${ uuid }
+        ts: ${ timestamp }
+`
+	err := zigflow.ValidateBytes([]byte(yaml))
+	require.NoError(t, err)
+}
+
+// TestValidateBytes_RejectsInvalidExpressionInsideSetBody proves that Set
+// bodies are exempt from the determinism rule but NOT from syntax validation:
+// an unparseable jq expression inside a set body must be rejected as an invalid
+// runtime expression, not silently accepted to fail later at execution time.
+func TestValidateBytes_RejectsInvalidExpressionInsideSetBody(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - capture:
+      set:
+        id: ${ @@@ }
+`
+	err := zigflow.ValidateBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, zigflow.ErrInvalidRuntimeExpression,
+		"invalid jq in a set body must wrap ErrInvalidRuntimeExpression")
+	assert.NotErrorIs(t, err, zigflow.ErrNonDeterministicExpression,
+		"a parse failure must not be reported as non-determinism")
+}
+
+// TestValidateBytes_RejectsCompileInvalidExpressionInsideSetBody proves that a
+// parse-valid but compile-invalid expression (an unregistered symbol, which jq
+// treats as a 0-arg function call) inside a Set body is rejected. Set exempts
+// determinism, not compile validation, so this must not slip through to fail at
+// execution time.
+func TestValidateBytes_RejectsCompileInvalidExpressionInsideSetBody(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - capture:
+      set:
+        id: ${ definitely_not_registered }
+`
+	err := zigflow.ValidateBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, zigflow.ErrInvalidRuntimeExpression,
+		"compile-invalid expression in a set body must wrap ErrInvalidRuntimeExpression")
+	assert.NotErrorIs(t, err, zigflow.ErrNonDeterministicExpression,
+		"a compile failure must not be reported as non-determinism")
+}
+
+// TestValidateBytes_RejectsInvalidExpressionOutsideSet proves the same parse
+// validation applies to expressions outside a Set body (here a free-form HTTP
+// query argument).
+func TestValidateBytes_RejectsInvalidExpressionOutsideSet(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - getUser:
+      call: http
+      with:
+        method: get
+        endpoint: https://example.com
+        query:
+          id: ${ @@@ }
+`
+	err := zigflow.ValidateBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, zigflow.ErrInvalidRuntimeExpression)
+	assert.NotErrorIs(t, err, zigflow.ErrNonDeterministicExpression)
+}
+
+// TestValidateBytes_InvalidExpressionTakesPriorityOverNonDeterminism proves a
+// parse failure is reported as an invalid runtime expression even when another
+// expression is non-deterministic: parsing must succeed before determinism is
+// judged.
+func TestValidateBytes_InvalidExpressionTakesPriorityOverNonDeterminism(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - waitForCooldown:
+      wait:
+        seconds: ${ timestamp }
+  - getUser:
+      call: http
+      with:
+        method: get
+        endpoint: https://example.com
+        query:
+          id: ${ @@@ }
+`
+	err := zigflow.ValidateBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, zigflow.ErrInvalidRuntimeExpression)
+	assert.NotErrorIs(t, err, zigflow.ErrNonDeterministicExpression)
+}
+
+// scheduleWorkflow builds a workflow whose document.metadata.scheduleInput
+// carries the given expression. scheduleInput is interpolated at
+// schedule-registration time, so it must be parse/compile-validated.
+func scheduleWorkflow(expr string) string {
+	return `document:
+  dsl: 1.0.0
+  taskQueue: zigflow
+  workflowType: schedule
+  version: 0.0.1
+  metadata:
+    scheduleWorkflowName: schedule
+    scheduleInput:
+      - envvars: ` + expr + `
+schedule:
+  every:
+    minutes: 3
+do:
+  - wait:
+      wait:
+        seconds: 5
+`
+}
+
+// TestValidateBytes_RejectsInvalidExpressionInScheduleInput proves that
+// document.metadata.scheduleInput, which is interpolated at registration time,
+// is parse/compile-validated rather than only failing later at `zigflow run`.
+func TestValidateBytes_RejectsInvalidExpressionInScheduleInput(t *testing.T) {
+	t.Run("parse invalid", func(t *testing.T) {
+		err := zigflow.ValidateBytes([]byte(scheduleWorkflow("${ @@@ }")))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, zigflow.ErrInvalidRuntimeExpression)
+		assert.NotErrorIs(t, err, zigflow.ErrNonDeterministicExpression)
+	})
+
+	t.Run("compile invalid", func(t *testing.T) {
+		err := zigflow.ValidateBytes([]byte(scheduleWorkflow("${ definitely_not_registered }")))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, zigflow.ErrInvalidRuntimeExpression)
+		assert.NotErrorIs(t, err, zigflow.ErrNonDeterministicExpression)
+	})
+}
+
+// TestValidateBytes_AllowsNonDeterministicExpressionInScheduleInput proves that
+// scheduleInput is exempt from the determinism rule (it runs at registration,
+// outside the workflow), so a valid non-deterministic expression is accepted.
+func TestValidateBytes_AllowsNonDeterministicExpressionInScheduleInput(t *testing.T) {
+	err := zigflow.ValidateBytes([]byte(scheduleWorkflow("${ now }")))
+	require.NoError(t, err, "scheduleInput must allow non-determinism")
+}
+
+// TestCollectExpressions_CollectsScheduleInput proves the scheduleInput
+// expression is collected at the expected path and tagged as allowing
+// non-determinism.
+func TestCollectExpressions_CollectsScheduleInput(t *testing.T) {
+	wf, err := zigflow.LoadFromBytes([]byte(scheduleWorkflow("${ $env.EXAMPLE }")))
+	require.NoError(t, err)
+
+	refs, err := zigflow.CollectExpressions(wf)
+	require.NoError(t, err)
+
+	var found bool
+	for _, ref := range refs {
+		if ref.Value == "${ $env.EXAMPLE }" {
+			found = true
+			assert.Equal(t, "document.metadata.scheduleInput[0].envvars", ref.Path)
+			assert.True(t, ref.AllowsNonDeterminism,
+				"scheduleInput is evaluated at registration and must be determinism-exempt")
+		}
+	}
+	assert.True(t, found, "scheduleInput expression must be collected")
+}
+
+// TestCollectExpressions_TagsSetBodyAsAllowingNonDeterminism asserts the
+// per-location tag, since the rest of the code depends on it.
+func TestCollectExpressions_TagsSetBodyAsAllowingNonDeterminism(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - capture:
+      if: ${ $data.flag }
+      set:
+        id: ${ uuid }
+`
+	wf, err := zigflow.LoadFromBytes([]byte(yaml))
+	require.NoError(t, err)
+
+	refs, err := zigflow.CollectExpressions(wf)
+	require.NoError(t, err)
+
+	var foundSet, foundIf bool
+	for _, ref := range refs {
+		switch ref.Value {
+		case "${ uuid }":
+			foundSet = true
+			assert.True(t, ref.AllowsNonDeterminism,
+				"set body expression must allow non-determinism at %s", ref.Path)
+			assert.True(t, strings.Contains(ref.Path, ".set"),
+				"set body expression path must mention set, got %s", ref.Path)
+		case "${ $data.flag }":
+			foundIf = true
+			assert.False(t, ref.AllowsNonDeterminism,
+				"taskbase if expression must not allow non-determinism at %s", ref.Path)
+		}
+	}
+	assert.True(t, foundSet, "expected to find ${ uuid } in collected refs")
+	assert.True(t, foundIf, "expected to find ${ $data.flag } in collected refs")
+}
+
+// TestValidateWorkflowDeterminism_ReportsEveryIssue confirms the validator
+// collects every non-deterministic reference rather than stopping at the
+// first. Users fixing a broken workflow should see the full list.
+func TestValidateWorkflowDeterminism_ReportsEveryIssue(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - first:
+      wait:
+        seconds: ${ timestamp }
+  - second:
+      if: ${ uuid }
+      set:
+        v: ${ $data.x }
+`
+	// Cannot load (will fail), so analyse via a hand-built doc through
+	// LoadFromBytes is impossible. Instead use the public collector via a
+	// minimum-fixture workflow: build a *model.Workflow* via the loader on a
+	// deterministic skeleton, then call ValidateWorkflowDeterminism is not
+	// possible without exposing internals. Instead just check the error
+	// message references both offending fields.
+	_, err := zigflow.LoadFromBytes([]byte(yaml))
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "timestamp", "error must mention timestamp")
+	assert.Contains(t, msg, "uuid", "error must mention uuid")
+}
+
+// TestCollectExpressions_StableOrderForMapBackedStructures proves that
+// expressions collected from a map (here a Set body with several keys) are
+// returned in a stable, sorted order across runs, despite Go randomising map
+// iteration. Unstable order would make CLI/JSON output and tests flaky.
+func TestCollectExpressions_StableOrderForMapBackedStructures(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - capture:
+      set:
+        zebra: ${ $data.z }
+        alpha: ${ $data.a }
+        mango: ${ $data.m }
+`
+	wf, err := zigflow.LoadFromBytes([]byte(yaml))
+	require.NoError(t, err)
+
+	// Keys are sorted, so the set body expressions appear in alphabetical order.
+	wantPaths := []string{
+		"do[0].capture.set.alpha",
+		"do[0].capture.set.mango",
+		"do[0].capture.set.zebra",
+	}
+
+	pathsFor := func() []string {
+		refs, err := zigflow.CollectExpressions(wf)
+		require.NoError(t, err)
+		var paths []string
+		for _, ref := range refs {
+			paths = append(paths, ref.Path)
+		}
+		return paths
+	}
+
+	first := pathsFor()
+	assert.Equal(t, wantPaths, first, "set body expressions must be in sorted order")
+
+	// Repeat to catch map-iteration randomisation.
+	for i := 0; i < 50; i++ {
+		assert.Equal(t, first, pathsFor(), "collected order must be stable across runs")
+	}
+}

--- a/pkg/zigflow/loader.go
+++ b/pkg/zigflow/loader.go
@@ -88,8 +88,16 @@ func LoadFromBytes(data []byte) (*model.Workflow, error) {
 }
 
 // ValidateBytes validates raw YAML or JSON bytes against the Zigflow JSON
-// Schema. It returns ErrSchemaValidation (via errors.Is) if the document does
-// not conform.
+// Schema and runs the central workflow validation pass.
+//
+// Two classes of error can be returned:
+//   - ErrSchemaValidation (via errors.Is) when the document does not conform
+//     to the Zigflow JSON Schema.
+//   - ErrNonDeterministicExpression (via errors.Is) when the workflow contains
+//     a runtime expression outside a Set task that is not replay-safe.
+//
+// Other errors (YAML/JSON parse failures, task-builder validation errors) are
+// surfaced as wrapped errors.
 func ValidateBytes(data []byte) error {
 	jsonBytes, err := yaml.YAMLToJSON(data)
 	if err != nil {
@@ -102,7 +110,15 @@ func ValidateBytes(data []byte) error {
 	}
 
 	if err := schema.ValidateDocument(rawDoc); err != nil {
-		return fmt.Errorf("%w: %s", ErrSchemaValidation, err)
+		return newSchemaValidationError(err)
+	}
+
+	// Run the central workflow-level validation pass. LoadFromBytes invokes
+	// newWorkflowPrepare, which validates task structure and expression
+	// determinism in one place. Doing the load here means ValidateBytes is a
+	// complete validation entry point: schema, structure, and determinism.
+	if _, err := LoadFromBytes(data); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/zigflow/schema_error.go
+++ b/pkg/zigflow/schema_error.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zigflow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SchemaError identifies a single JSON Schema violation: where it is in the
+// document (a best-effort instance-style path) and what the problem is. It is
+// the machine-readable unit behind a schema validation failure.
+type SchemaError struct {
+	Location string `json:"location"`
+	Message  string `json:"message"`
+}
+
+// SchemaValidationError wraps the underlying JSON Schema validation failure. It
+// preserves the original error message (Error() is unchanged from the previous
+// fmt.Errorf wrapping) and matches ErrSchemaValidation via errors.Is, while
+// exposing the failures in structured form for callers that want to render or
+// process them without parsing the message.
+type SchemaValidationError struct {
+	Errors []SchemaError
+	cause  error
+}
+
+func (e *SchemaValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrSchemaValidation, e.cause)
+}
+
+func (e *SchemaValidationError) Unwrap() error { return ErrSchemaValidation }
+
+// newSchemaValidationError builds a SchemaValidationError from the error
+// returned by schema.ValidateDocument, parsing it into structured entries for
+// human-readable rendering. The original error is retained verbatim so the
+// message and wrapping behaviour are unchanged.
+func newSchemaValidationError(cause error) *SchemaValidationError {
+	return &SchemaValidationError{
+		Errors: parseSchemaErrors(cause),
+		cause:  cause,
+	}
+}
+
+// parseSchemaErrors turns the (single, colon-nested) error string produced by
+// google/jsonschema-go into one or more structured entries. The library does
+// not expose instance locations, so the location is derived best-effort from
+// the deepest schema keyword-location in the message. errors.Join'd failures
+// are split on newlines.
+func parseSchemaErrors(err error) []SchemaError {
+	if err == nil {
+		return nil
+	}
+
+	var out []SchemaError
+	for _, line := range strings.Split(err.Error(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// The library nests context as repeated "validating <schema>: "
+		// prefixes, where <schema> is the root id or a schema pointer such as
+		// "/properties/document". Strip those, keeping the deepest pointer as
+		// the location, and treat the remainder as the message.
+		location := ""
+		rest := line
+		for strings.HasPrefix(rest, "validating ") {
+			after := rest[len("validating "):]
+			idx := strings.Index(after, ": ")
+			if idx < 0 {
+				break
+			}
+			token := after[:idx]
+			rest = after[idx+2:]
+			if strings.HasPrefix(token, "/") {
+				location = token
+			}
+		}
+
+		out = append(out, SchemaError{
+			Location: schemaPointerToInstancePath(location),
+			Message:  rest,
+		})
+	}
+
+	return out
+}
+
+// schemaPointerToInstancePath converts a JSON Schema keyword-location pointer
+// (e.g. "/properties/document/properties/workflowType") into a best-effort
+// instance path (e.g. "$.document.workflowType"). It is intentionally lenient:
+// applicator keywords are skipped and unrecognised segments are ignored so a
+// useful, stable location is produced even as the schema evolves.
+func schemaPointerToInstancePath(pointer string) string {
+	if pointer == "" {
+		return "$"
+	}
+
+	parts := strings.Split(strings.Trim(pointer, "/"), "/")
+	path := "$"
+	for i := 0; i < len(parts); i++ {
+		switch parts[i] {
+		case "properties", "patternProperties":
+			if i+1 < len(parts) {
+				path += "." + parts[i+1]
+				i++
+			}
+		case "items", "prefixItems", "additionalItems", "contains":
+			path += "[]"
+		case "$defs", "definitions", "allOf", "anyOf", "oneOf", "not", "if", "then", "else":
+			// Applicator / definition keywords carry a following index or name
+			// that is not part of the instance path; skip it.
+			if i+1 < len(parts) {
+				i++
+			}
+		default:
+			// Unknown keyword (e.g. unevaluatedProperties): ignore it rather
+			// than guess at an instance segment.
+		}
+	}
+
+	return path
+}

--- a/pkg/zigflow/schema_error_test.go
+++ b/pkg/zigflow/schema_error_test.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zigflow
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schemaRoot is the prefix google/jsonschema-go puts on every error: the root
+// schema id. Shared by the test cases to keep the fixtures readable.
+const schemaRoot = "validating https://zigflow.dev/schema.json: "
+
+func TestSchemaValidationError_PreservesWrapping(t *testing.T) {
+	cause := errors.New(`validating https://zigflow.dev/schema.json: required: missing properties: ["do"]`)
+	err := newSchemaValidationError(cause)
+
+	// errors.Is must still match the sentinel so existing callers (CLI, MCP)
+	// keep working.
+	assert.ErrorIs(t, err, ErrSchemaValidation)
+
+	// Error() must match the previous fmt.Errorf("%w: %s", ...) wrapping.
+	want := fmt.Sprintf("%s: %s", ErrSchemaValidation, cause)
+	assert.Equal(t, want, err.Error())
+}
+
+func TestParseSchemaErrors(t *testing.T) {
+	tests := []struct {
+		Name         string
+		Err          error
+		WantLen      int
+		WantLocation string
+		WantMessage  string
+	}{
+		{
+			Name:         "root-level required property",
+			Err:          errors.New(schemaRoot + `required: missing properties: ["do"]`),
+			WantLen:      1,
+			WantLocation: "$",
+			WantMessage:  `required: missing properties: ["do"]`,
+		},
+		{
+			Name:         "nested document property",
+			Err:          errors.New(schemaRoot + `validating /properties/document: required: missing properties: ["workflowType"]`),
+			WantLen:      1,
+			WantLocation: "$.document",
+			WantMessage:  `required: missing properties: ["workflowType"]`,
+		},
+		{
+			Name: "unknown keyword keeps parent location",
+			Err: errors.New(schemaRoot +
+				`validating /properties/document: ` +
+				`validating /properties/document/unevaluatedProperties: ` +
+				`not: validated against <anonymous schema>`),
+			WantLen:      1,
+			WantLocation: "$.document",
+			WantMessage:  "not: validated against <anonymous schema>",
+		},
+		{
+			Name:         "items become an index segment",
+			Err:          errors.New(schemaRoot + `validating /properties/do/items/properties/type: type: 1 has type "number", want "string"`),
+			WantLen:      1,
+			WantLocation: "$.do[].type",
+			WantMessage:  `type: 1 has type "number", want "string"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			got := parseSchemaErrors(test.Err)
+			require.Len(t, got, test.WantLen)
+			assert.Equal(t, test.WantLocation, got[0].Location)
+			assert.Equal(t, test.WantMessage, got[0].Message)
+		})
+	}
+}
+
+func TestParseSchemaErrors_MultipleJoined(t *testing.T) {
+	// errors.Join renders sub-errors on separate lines.
+	err := errors.New(
+		schemaRoot + `validating /properties/document: required: missing properties: ["workflowType"]` +
+			"\n" +
+			schemaRoot + `validating /properties/do: type: 1 has type "number", want "array"`,
+	)
+
+	got := parseSchemaErrors(err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "$.document", got[0].Location)
+	assert.Equal(t, "$.do", got[1].Location)
+}

--- a/pkg/zigflow/tasks/task_builder_wait_ext.go
+++ b/pkg/zigflow/tasks/task_builder_wait_ext.go
@@ -79,9 +79,9 @@ func (t *WaitExtTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		// Evaluate any runtime expressions against the workflow state.
 		// No SideEffect wrapper: $data, $input, $context and $env are
 		// already in workflow history and therefore deterministic.
-		// Non-deterministic jq functions are rejected up front by
-		// rejectNonDeterministicExpressions, so anything reaching here
-		// is safe to evaluate directly.
+		// Non-deterministic expressions are rejected up front by the
+		// central workflow determinism pass (ValidateWorkflowDeterminism),
+		// so anything reaching here is safe to evaluate directly.
 		evaluated, err := utils.TraverseAndEvaluateObj(model.NewObjectOrRuntimeExpr(cloned), nil, state)
 		if err != nil {
 			return nil, fmt.Errorf("error evaluating wait extension expressions: %w", err)
@@ -120,9 +120,6 @@ func (t *WaitExtTaskBuilder) Validate() error {
 	if t.task.Wait == nil {
 		return fmt.Errorf("wait extension task %q has no body", t.GetTaskName())
 	}
-	if err := rejectNonDeterministicExpressions(t.task.Wait); err != nil {
-		return fmt.Errorf("wait extension task %q: %w", t.GetTaskName(), err)
-	}
 	until := t.task.Wait.Until
 	if until == "" || model.IsStrictExpr(until) {
 		return nil
@@ -157,36 +154,6 @@ func (t *WaitExtTaskBuilder) sleepUntil(ctx workflow.Context, untilStr string) e
 		}
 		logger.Error("Error creating sleep instruction", "error", err)
 		return fmt.Errorf("error creating sleep: %w", err)
-	}
-	return nil
-}
-
-// rejectNonDeterministicExpressions errors if any wait field is a runtime
-// expression whose leading jq function is non-deterministic. Such waits
-// would not be replay-safe.
-func rejectNonDeterministicExpressions(body *models.WaitExtBody) error {
-	fields := []struct {
-		name  string
-		value any
-	}{
-		{keyUntil, body.Until},
-		{"days", body.Days},
-		{"hours", body.Hours},
-		{"minutes", body.Minutes},
-		{"seconds", body.Seconds},
-		{"milliseconds", body.Milliseconds},
-	}
-	for _, f := range fields {
-		s, ok := f.value.(string)
-		if !ok || !model.IsStrictExpr(s) {
-			continue
-		}
-		if fn := utils.LeadingNonDeterministicFunc(model.SanitizeExpr(s)); fn != "" {
-			return fmt.Errorf(
-				"field %q uses non-deterministic function %q; compute it in a preceding set task and reference the result instead",
-				f.name, fn,
-			)
-		}
 	}
 	return nil
 }

--- a/pkg/zigflow/tasks/task_builder_wait_ext_test.go
+++ b/pkg/zigflow/tasks/task_builder_wait_ext_test.go
@@ -28,11 +28,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-// wantFnUUID is a test-local constant for the repeated wantFn entries in the
-// non-deterministic rejection table; collapses three identical literals so
-// goconst doesn't flag the test data.
-const wantFnUUID = "uuid"
-
 // runWaitExtBuilder is a small helper that wires the builder into a test
 // workflow environment with a given start time and state, executes it, and
 // returns the resulting environment for assertions about env.Now() and any
@@ -143,42 +138,6 @@ func TestWaitExtBuilder_StringValuedDurationErrors(t *testing.T) {
 	err := env.GetWorkflowError()
 	require.Error(t, err, "non-numeric resolved duration must surface as a workflow error")
 	assert.Contains(t, err.Error(), "seconds")
-}
-
-func TestWaitExtBuilder_RejectsNonDeterministicExpressions(t *testing.T) {
-	tests := []struct {
-		name      string
-		body      *models.WaitExtBody
-		wantField string
-		wantFn    string
-	}{
-		{"uuid in until", &models.WaitExtBody{Until: "${ uuid }"}, "until", wantFnUUID},
-		{"timestamp_iso8601 in until", &models.WaitExtBody{Until: "${ timestamp_iso8601 }"}, "until", "timestamp_iso8601"},
-		{"timestamp in seconds", &models.WaitExtBody{Seconds: "${ timestamp }"}, "seconds", "timestamp"},
-		{"uuid piped to length in hours", &models.WaitExtBody{Hours: "${ uuid | length }"}, "hours", wantFnUUID},
-		{"uuid in milliseconds", &models.WaitExtBody{Milliseconds: "${ uuid }"}, "milliseconds", wantFnUUID},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			builder, err := NewWaitExtTaskBuilder(nil, &models.WaitExtTask{Wait: tc.body}, "wait-ext", nil, testEvents, nil)
-			require.NoError(t, err)
-
-			err = builder.Validate()
-			require.Error(t, err, "Validate must reject non-deterministic wait expression")
-			assert.Contains(t, err.Error(), tc.wantField, "error must name the offending field")
-			assert.Contains(t, err.Error(), tc.wantFn, "error must name the offending function")
-		})
-	}
-}
-
-func TestWaitExtBuilder_AllowsDeterministicExpressions(t *testing.T) {
-	builder, err := NewWaitExtTaskBuilder(nil, &models.WaitExtTask{Wait: &models.WaitExtBody{
-		Seconds: "${ $data.cooldown }",
-	}}, "wait-ext", nil, testEvents, nil)
-	require.NoError(t, err)
-
-	assert.NoError(t, builder.Validate(), "deterministic wait expressions must pass Validate")
 }
 
 // TestWaitExtBuilder_ValidateRejectsBadRFC3339 covers literal `until`

--- a/pkg/zigflow/workflow_builder.go
+++ b/pkg/zigflow/workflow_builder.go
@@ -86,6 +86,12 @@ func NewWorkflow(
 		return fmt.Errorf("error validating workflow: %w", err)
 	}
 
+	l.Debug().Msg("Validating workflow expression determinism")
+	if err := ValidateWorkflowDeterminism(doc); err != nil {
+		l.Error().Err(err).Msg("Error validating workflow expression determinism")
+		return fmt.Errorf("error validating workflow expression determinism: %w", err)
+	}
+
 	l.Debug().Msg("Building workflow")
 	if _, err := doBuilder.Build(); err != nil {
 		l.Debug().Err(err).Msg("Error building workflow")
@@ -122,6 +128,15 @@ func newWorkflowPrepare(doc *model.Workflow) error {
 	if err := doBuilder.Validate(); err != nil {
 		l.Error().Err(err).Msg("Error validating workflow")
 		return fmt.Errorf("error validating workflow: %w", err)
+	}
+
+	if err := ValidateWorkflowDeterminism(doc); err != nil {
+		// Logged at debug, not error: the failure is returned to the caller,
+		// which is responsible for surfacing it (the CLI renders a concise,
+		// human-readable message). Logging at error here duplicated that
+		// diagnostic at the default log level.
+		l.Debug().Err(err).Msg("Workflow expression determinism validation failed")
+		return fmt.Errorf("error validating workflow expression determinism: %w", err)
 	}
 
 	return nil

--- a/pkg/zigflow/workflow_builder_test.go
+++ b/pkg/zigflow/workflow_builder_test.go
@@ -112,3 +112,30 @@ func TestNewWorkflowRunsPostLoadBeforeBuild_GRPCEmptyHostPort(t *testing.T) {
 	assert.Equal(t, "localhost", task.With.Service.Host, "PostLoad must have set the default Host")
 	assert.Equal(t, 50051, task.With.Service.Port, "PostLoad must have set the default Port")
 }
+
+// TestNewWorkflowRejectsNonDeterministicExpression is a regression test proving
+// that NewWorkflow() — the public path that turns a *model.Workflow directly
+// into an executable workflow — enforces the same determinism guarantees as
+// the loader. Before the fix, NewWorkflow() never called
+// ValidateWorkflowDeterminism, so a programmatically constructed workflow could
+// smuggle a non-deterministic expression (e.g. ${ uuid }) outside a Set task.
+func TestNewWorkflowRejectsNonDeterministicExpression(t *testing.T) {
+	task := &model.RunTask{
+		TaskBase: model.TaskBase{
+			// ${ uuid } is non-deterministic and lives outside a Set task body,
+			// so it must be rejected.
+			If: &model.RuntimeExpression{Value: "${ uuid }"},
+		},
+		Run: model.RunTaskConfiguration{
+			Script: &model.Script{
+				Language:   "python",
+				InlineCode: utils.Ptr("print('hello')"),
+			},
+		},
+	}
+
+	err := zigflow.NewWorkflow(stubWorker{}, newTestWorkflow("non-deterministic-test", task), nil, nil, nil, nil)
+	require.Error(t, err, "NewWorkflow must reject a non-deterministic expression outside a Set task")
+	assert.ErrorIs(t, err, zigflow.ErrNonDeterministicExpression,
+		"error must wrap %v; got %v", zigflow.ErrNonDeterministicExpression, err)
+}


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->
This implements a much strong check for nondeterminstic errors in the workflow. Temporal's replay functionality fails when it's not determinstic, so one big selling point of Zigflow is to make a non-determinstic workflow impossible (or, at least, very hard).

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #420 

## How to test
<!-- Provide steps to test this PR -->
