### PR TITLE
feat(http): register HTTP activities by workflowType.taskName

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,8 @@ Dimsi <dimosh3k@gmail.com>
 Hynek <dimosh3k@gmail.com>
 Maciek Bryński <maciek@brynski.pl>
 mrsimonemms <275848+mrsimonemms@users.noreply.github.com>
+Shlomit Manor <shlomit.manor@branch.io>
+shlomit.manor <shlomit.manor@branch.io>
 Simon Emms <simon@simonemms.com>
 Sumit <sumit.seeftech@gmail.com>
 Yorick Smeets <yorick@energyessentials.nl>

--- a/docs/docs/dsl/tasks/call.md
+++ b/docs/docs/dsl/tasks/call.md
@@ -154,6 +154,14 @@ backoff.
 `Retry-After` delays are not capped by Zigflow. Use Temporal timeout settings,
 such as `ScheduleToCloseTimeout`, to enforce a maximum execution time.
 
+### SDK metrics {/*#http-sdk-metrics*/}
+
+Each `call: http` task is registered on its worker under the name
+`<workflowType>.<taskName>` (for example `call-http.getUser`). Temporal's
+SDK metrics use that name for the `activity_type` label, so individual
+HTTP tasks can be attributed in dashboards and alerts. The original
+`CallHTTPActivity` registration is preserved for backwards compatibility.
+
 **Activity names are case-sensitive.** The `name` field in an activity call
 must exactly match the name the activity was registered with on the remote
 worker.

--- a/pkg/zigflow/tasks/activity_registration.go
+++ b/pkg/zigflow/tasks/activity_registration.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"sync"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/worker"
+)
+
+// Tracks (worker, name) pairs already registered so repeated Build
+// calls do not double-register. Temporal's RegisterActivityWithOptions
+// panics on duplicate names.
+var activityRegistry sync.Map
+
+type activityRegistryKey struct {
+	worker worker.Worker
+	name   string
+}
+
+// Registers fn on w under name, skipping if (w, name) was already seen.
+func registerActivityOnce(w worker.Worker, fn any, name string) {
+	if w == nil || name == "" {
+		return
+	}
+
+	key := activityRegistryKey{worker: w, name: name}
+	if _, loaded := activityRegistry.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+
+	w.RegisterActivityWithOptions(fn, activity.RegisterOptions{Name: name})
+}

--- a/pkg/zigflow/tasks/task_builder_call_http.go
+++ b/pkg/zigflow/tasks/task_builder_call_http.go
@@ -49,8 +49,29 @@ type CallHTTPTaskBuilder struct {
 	builder[*model.CallHTTP]
 }
 
+// Per-task activity name "<workflowType>.<taskName>" so SDK metrics
+// carry a distinct activity_type label per HTTP task. Falls back to the
+// bare task name if the workflow has no name.
+func (t *CallHTTPTaskBuilder) callHTTPActivityName() string {
+	taskName := t.GetTaskName()
+	if t.doc == nil || t.doc.Document.Name == "" {
+		return taskName
+	}
+	return t.doc.Document.Name + "." + taskName
+}
+
+// callHTTPActivity is a package-level singleton whose method value is
+// registered under per-task names. A bound method value is required so
+// Temporal invokes the activity with the receiver supplied; an unbound
+// method expression would pass the activity's first argument as the
+// receiver, causing a nil pointer dereference at runtime.
+var callHTTPActivity = &activities.CallHTTP{}
+
 func (t *CallHTTPTaskBuilder) Build() (TemporalWorkflowFunc, error) {
+	activityName := t.callHTTPActivityName()
+	registerActivityOnce(t.temporalWorker, callHTTPActivity.CallHTTPActivity, activityName)
+
 	return func(ctx workflow.Context, input any, state *utils.State) (any, error) {
-		return t.executeActivity(ctx, (*activities.CallHTTP).CallHTTPActivity, input, state)
+		return t.executeActivity(ctx, activityName, input, state)
 	}, nil
 }

--- a/pkg/zigflow/tasks/task_builder_call_http_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_http_test.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
+	"go.temporal.io/sdk/activity"
 )
 
 func TestParseHTTPArguments(t *testing.T) {
@@ -91,4 +93,65 @@ func TestParseOutput(t *testing.T) {
 			assert.Equal(t, tc.expect, got)
 		})
 	}
+}
+
+func newTestHTTPTask() *model.CallHTTP {
+	return &model.CallHTTP{
+		Call: "http",
+		With: model.HTTPArguments{
+			Method:   "GET",
+			Endpoint: model.NewEndpoint("https://example.com"),
+		},
+	}
+}
+
+func TestCallHTTPTaskBuilderRegistersPerTaskActivityName(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-http-metrics"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-http-metrics.fetchData",
+		}).
+		Once()
+
+	b, err := NewCallHTTPTaskBuilder(w, newTestHTTPTask(), "fetchData", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	_, err = b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+func TestCallHTTPTaskBuilderRegistersOncePerWorker(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-http-dedup"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-http-dedup.authenticate",
+		}).
+		Once()
+
+	b, err := NewCallHTTPTaskBuilder(w, newTestHTTPTask(), "authenticate", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		_, err = b.Build()
+		assert.NoError(t, err)
+	}
+
+	w.AssertExpectations(t)
+}
+
+func TestCallHTTPTaskBuilderBuildWithoutWorker(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-http-nil-worker"}}
+
+	b, err := NewCallHTTPTaskBuilder(nil, newTestHTTPTask(), "step", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	fn, err := b.Build()
+	assert.NoError(t, err)
+	assert.NotNil(t, fn)
 }

--- a/pkg/zigflow/tasks/task_builder_do_test.go
+++ b/pkg/zigflow/tasks/task_builder_do_test.go
@@ -687,7 +687,7 @@ func (m *WorkflowRegistryMock) RegisterActivity(a any) {
 
 // RegisterActivityWithOptions implements [worker.Worker].
 func (m *WorkflowRegistryMock) RegisterActivityWithOptions(a any, options activity.RegisterOptions) {
-	panic("unimplemented")
+	m.Called(a, options)
 }
 
 // RegisterDynamicActivity implements [worker.Worker].


### PR DESCRIPTION
## Description

`call: http` tasks currently all register a single Go-level activity named `CallHTTPActivity`, so Temporal's SDK metrics emit `activity_type="CallHTTPActivity"` for every HTTP call regardless of which YAML task ran. In a workflow with several HTTP calls (e.g. `requestAdNetworkCredentials`, `authenticate`, `fetchData`) the metric labels are indistinguishable, so dashboards and alerts cannot attribute duration, error rate or retry counts to a specific task.

This PR additionally registers `CallHTTPActivity` under `<workflowType>.<taskName>` for each `call: http` task during workflow construction, and dispatches via the string name. Temporal's SDK metrics then carry the per-task `activity_type` label natively, with no custom metric code, no new metric names, and no changes inside the activity body.

### Approach

- Registration happens in `CallHTTPTaskBuilder.Build`. `DoTaskBuilder.Build` already recurses through nested `do`/`for`/`try`/`fork` blocks calling each child's `Build`, so registration at builder construction naturally walks the whole task tree without a separate YAML walker.
- A small `registerActivityOnce` helper backed by a `sync.Map` keyed on `(worker, name)` dedups repeated `Build` invocations. Temporal's `RegisterActivityWithOptions` panics on duplicate registrations, so dedup is required for correctness.
- Dispatch in the returned `TemporalWorkflowFunc` now uses the string name instead of the Go function reference, which is what flips the SDK metric label.

### Backwards compatibility

The original `&CallHTTP{}` registration in `cmd/run/workers.go` is left untouched. Anything dispatching by the original Go function name continues to work; the per-task names are purely additive.

### Cardinality

YAML task names are static identifiers in workflow definitions. The set of distinct `<workflowType>.<taskName>` per worker is bounded and known at worker startup, so label cardinality stays the same order as the number of HTTP tasks across loaded workflows. Well within safe Prometheus territory.

### Naming

Per the issue discussion, format is `<workflowType>.<taskName>` (e.g. `a-snap-performance.requestAdNetworkCredentials`) to make metric names self-describing and reduce the chance of cross-workflow collisions. Falls back to the bare task name if the workflow document has no name.

### Scope

`call: http` only, as agreed in the issue. The same fix applies to `call: grpc` and `run:` and can be done as follow-ups.

## Related Issue(s)

Fixes #442

## How to test

- `go test ./pkg/zigflow/tasks/...` — three new tests cover (a) per-task name registration, (b) dedup across multiple `Build` invocations, (c) nil-worker safety used by `newWorkflowPrepare`.
- End to end: run a workflow with two `call: http` tasks and Prometheus metrics enabled (`temporal.WithPrometheusMetrics(...)`). Distinct `activity_type` labels should appear for each task.