### PR TITLE
fix: evaluate activity with expressions in the workflow before schedu…

### DIFF
--- a/pkg/utils/runtime_expressions.go
+++ b/pkg/utils/runtime_expressions.go
@@ -39,6 +39,14 @@ const (
 
 type ExpressionWrapperFunc func(func() (any, error)) (any, error)
 
+// TraverseEvaluateOpts configures TraverseAndEvaluateObj. SkipExpression, when
+// set, leaves matching strict-form runtime expressions unchanged instead of
+// evaluating them. This is used when an expression must be evaluated later with
+// activity-scoped state (for example $data.activity references).
+type TraverseEvaluateOpts struct {
+	SkipExpression func(string) bool
+}
+
 // jqFunc describes a function exposed to Zigflow runtime expressions. The
 // Deterministic flag is the source of truth for replay-safety classification;
 // AnalyseExpressionDeterminism reads this list when walking expressions.
@@ -123,6 +131,16 @@ func TraverseAndEvaluateObj(
 	state *State,
 	evaluationWrapper ...ExpressionWrapperFunc,
 ) (any, error) {
+	return TraverseAndEvaluateObjWithOpts(runtimeExpr, ctx, state, TraverseEvaluateOpts{}, evaluationWrapper...)
+}
+
+func TraverseAndEvaluateObjWithOpts(
+	runtimeExpr *model.ObjectOrRuntimeExpr,
+	ctx any,
+	state *State,
+	opts TraverseEvaluateOpts,
+	evaluationWrapper ...ExpressionWrapperFunc,
+) (any, error) {
 	if runtimeExpr == nil {
 		return nil, nil
 	}
@@ -142,15 +160,26 @@ func TraverseAndEvaluateObj(
 	// export/output definitions at once.
 	//
 	// Clone the value first so each evaluation works on an isolated copy.
-	return traverseAndEvaluate(swUtil.DeepCloneValue(runtimeExpr.AsStringOrMap()), ctx, state, wrapperFn)
+	return traverseAndEvaluate(
+		swUtil.DeepCloneValue(runtimeExpr.AsStringOrMap()),
+		ctx,
+		state,
+		opts,
+		wrapperFn,
+	)
 }
 
-func traverseAndEvaluate(node, ctx any, state *State, evaluationWrapper ExpressionWrapperFunc) (any, error) {
+func traverseAndEvaluate(
+	node, ctx any,
+	state *State,
+	opts TraverseEvaluateOpts,
+	evaluationWrapper ExpressionWrapperFunc,
+) (any, error) {
 	switch v := node.(type) {
 	case map[string]any:
 		// Traverse a object
 		for key, value := range v {
-			evaluatedValue, err := traverseAndEvaluate(value, ctx, state, evaluationWrapper)
+			evaluatedValue, err := traverseAndEvaluate(value, ctx, state, opts, evaluationWrapper)
 			if err != nil {
 				return nil, err
 			}
@@ -163,7 +192,7 @@ func traverseAndEvaluate(node, ctx any, state *State, evaluationWrapper Expressi
 		// to avoid mutating the original, which may be shared across workflow executions.
 		clone := make(map[string]string, len(v))
 		for key, value := range v {
-			evaluatedValue, err := traverseAndEvaluate(value, ctx, state, evaluationWrapper)
+			evaluatedValue, err := traverseAndEvaluate(value, ctx, state, opts, evaluationWrapper)
 			if err != nil {
 				return nil, err
 			}
@@ -176,11 +205,14 @@ func traverseAndEvaluate(node, ctx any, state *State, evaluationWrapper Expressi
 		return clone, nil
 	case []any:
 		// Traverse an array
-		return traverseSlice(v, ctx, state, evaluationWrapper)
+		return traverseSlice(v, ctx, state, opts, evaluationWrapper)
 	case []string:
 		// Traverse an array
-		return traverseSlice(toAnySlice(v), ctx, state, evaluationWrapper)
+		return traverseSlice(toAnySlice(v), ctx, state, opts, evaluationWrapper)
 	case string:
+		if model.IsStrictExpr(v) && opts.SkipExpression != nil && opts.SkipExpression(v) {
+			return v, nil
+		}
 		if evaluationWrapper != nil {
 			return EvaluateString(v, ctx, state, evaluationWrapper)
 		}
@@ -191,9 +223,15 @@ func traverseAndEvaluate(node, ctx any, state *State, evaluationWrapper Expressi
 	}
 }
 
-func traverseSlice(v []any, ctx any, state *State, evaluationWrapper ExpressionWrapperFunc) ([]any, error) {
+func traverseSlice(
+	v []any,
+	ctx any,
+	state *State,
+	opts TraverseEvaluateOpts,
+	evaluationWrapper ExpressionWrapperFunc,
+) ([]any, error) {
 	for i, value := range v {
-		evaluatedValue, err := traverseAndEvaluate(value, ctx, state, evaluationWrapper)
+		evaluatedValue, err := traverseAndEvaluate(value, ctx, state, opts, evaluationWrapper)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/zigflow/activities/grpc.go
+++ b/pkg/zigflow/activities/grpc.go
@@ -48,22 +48,12 @@ func (c *CallGRPC) CallGRPCActivity(
 	stopHeartbeat := metadata.StartActivityHeartbeat(ctx, task.GetBase())
 	defer stopHeartbeat()
 
-	ob, err := utils.TraverseAndEvaluateObj(model.NewObjectOrRuntimeExpr(map[string]any{
-		"service": task.With.Service,
-		"args":    task.With.Arguments,
-		"method":  task.With.Method,
-		"proto":   task.With.Proto,
-	}), nil, state)
-	if err != nil {
-		return nil, temporal.NewNonRetryableApplicationError("error traversing grpc data object", "CallGRPC error", err)
-	}
-
-	obj := ob.(map[string]any)
-
-	service := obj["service"].(model.GRPCService)
-	args := obj["args"].(map[string]any)
-	method := obj["method"].(string)
-	proto := obj["proto"].(*model.ExternalResource)
+	// Runtime expressions in the task with payload are resolved in the workflow
+	// before the activity is scheduled.
+	service := task.With.Service
+	args := task.With.Arguments
+	method := task.With.Method
+	proto := task.With.Proto
 
 	address := fmt.Sprintf("%s:%d", service.Host, service.Port)
 

--- a/pkg/zigflow/activities/http.go
+++ b/pkg/zigflow/activities/http.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"time"
 
-	swUtil "github.com/serverlessworkflow/sdk-go/v3/impl/utils"
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/metadata"
@@ -170,13 +169,7 @@ func (c *CallHTTP) callHTTPAction(ctx context.Context, task *model.CallHTTP, tim
 ) {
 	logger := activity.GetLogger(ctx)
 
-	args, err := ParseHTTPArguments(task, state)
-	if err != nil {
-		return resp,
-			method, url,
-			reqHeaders,
-			err
-	}
+	args := HTTPArgumentsFromTask(task)
 
 	method = strings.ToUpper(args.Method)
 	url = args.Endpoint.String()
@@ -241,42 +234,11 @@ func (c *CallHTTP) classifyHTTPStatus(code int) httpRetryability {
 	}
 }
 
-// ParseHTTPArguments note that I looked at the github.com/go-viper/mapstructure/v2.Decode
-// function, but this wasn't able to decode some of the more complex data types. This is
-// more heavyweight than I'd like, but it's fine for now.
-func ParseHTTPArguments(task *model.CallHTTP, state *utils.State) (*model.HTTPArguments, error) {
-	// First, we need to convert it to map[string]any
-	b, err := json.Marshal(task.With)
-	if err != nil {
-		return nil, fmt.Errorf("error marshalling object to bytes: %w", err)
-	}
-
-	// Next, convert it to a map so we can traverse
-	var data map[string]any
-	if err := json.Unmarshal(b, &data); err != nil {
-		return nil, fmt.Errorf("error unmarshalling data to map: %w", err)
-	}
-
-	// Clone and traverse, interpolating the data
-	cloneData := swUtil.DeepClone(data)
-	obj, err := utils.TraverseAndEvaluateObj(model.NewObjectOrRuntimeExpr(cloneData), nil, state)
-	if err != nil {
-		return nil, fmt.Errorf("error traversing http data object: %w", err)
-	}
-
-	// Now, put it back to a JSON string
-	e, err := json.Marshal(obj)
-	if err != nil {
-		return nil, fmt.Errorf("error marshalling object to bytes: %w", err)
-	}
-
-	// Finally, convert back to HTTPArguments
-	var result model.HTTPArguments
-	if err := json.Unmarshal(e, &result); err != nil {
-		return nil, fmt.Errorf("error unmarshalling data to map: %w", err)
-	}
-
-	return &result, nil
+// HTTPArgumentsFromTask returns the call HTTP with payload. Runtime expressions
+// in the payload are resolved in the workflow before the activity is scheduled.
+func HTTPArgumentsFromTask(task *model.CallHTTP) *model.HTTPArguments {
+	with := task.With
+	return &with
 }
 
 // Calculate the delay in seconds. If 0 returned, use the default Temporal RetryPolicy

--- a/pkg/zigflow/expression_determinism_test.go
+++ b/pkg/zigflow/expression_determinism_test.go
@@ -674,3 +674,49 @@ func TestCollectExpressions_StableOrderForMapBackedStructures(t *testing.T) {
 		assert.Equal(t, first, pathsFor(), "collected order must be stable across runs")
 	}
 }
+
+// TestCollectExpressions_CollectsActivityWithPayload proves expressions inside
+// activity with payloads (for example grpc arguments) are collected for validation.
+func TestCollectExpressions_CollectsActivityWithPayload(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - callGrpc:
+      call: grpc
+      with:
+        method: Command1
+        arguments:
+          input: ${ $env.GRPC_INPUT }
+`
+	wf, err := zigflow.LoadFromBytes([]byte(yaml))
+	require.NoError(t, err)
+
+	refs, err := zigflow.CollectExpressions(wf)
+	require.NoError(t, err)
+
+	var found bool
+	for _, ref := range refs {
+		if ref.Value == "${ $env.GRPC_INPUT }" {
+			found = true
+			assert.Contains(t, ref.Path, "arguments")
+			assert.False(t, ref.AllowsNonDeterminism)
+		}
+	}
+	assert.True(t, found, "grpc with.arguments expression must be collected")
+}
+
+// TestValidateBytes_RejectsInvalidExpressionInActivityWith proves invalid
+// expressions inside activity with payloads fail validation.
+func TestValidateBytes_RejectsInvalidExpressionInActivityWith(t *testing.T) {
+	yaml := workflowHeader + `do:
+  - getUser:
+      call: http
+      with:
+        method: get
+        endpoint: https://example.com
+        headers:
+          X-Token: ${ @@@ }
+`
+	err := zigflow.ValidateBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, zigflow.ErrInvalidRuntimeExpression)
+	assert.NotErrorIs(t, err, zigflow.ErrNonDeterministicExpression)
+}

--- a/pkg/zigflow/tasks/task_builder.go
+++ b/pkg/zigflow/tasks/task_builder.go
@@ -68,8 +68,14 @@ func (d *builder[T]) executeActivity(ctx workflow.Context, activity, input any, 
 	logger := workflow.GetLogger(ctx)
 	logger.Debug("Calling activity", "name", d.name)
 
+	resolvedTask, err := evaluateTaskForActivity(d.task, state.Clone().AddWorkflowInfo(ctx))
+	if err != nil {
+		logger.Error("Error evaluating activity task expressions", "name", d.name, "error", err)
+		return nil, fmt.Errorf("error evaluating activity task expressions: %w", err)
+	}
+
 	var res any
-	if err := workflow.ExecuteActivity(ctx, activity, d.task, input, state).Get(ctx, &res); err != nil {
+	if err := workflow.ExecuteActivity(ctx, activity, resolvedTask, input, state).Get(ctx, &res); err != nil {
 		if temporal.IsCanceledError(err) {
 			return nil, nil
 		}

--- a/pkg/zigflow/tasks/task_builder_activity_eval.go
+++ b/pkg/zigflow/tasks/task_builder_activity_eval.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/zigflow/zigflow/pkg/utils"
+)
+
+// evaluateTaskForActivity resolves runtime expressions in a task definition
+// before it is passed to a Temporal activity. Expressions that reference
+// activity-scoped state are left for the activity to evaluate.
+func evaluateTaskForActivity[T model.Task](task T, state *utils.State) (T, error) {
+	var zero T
+
+	payload, err := json.Marshal(task)
+	if err != nil {
+		return zero, fmt.Errorf("marshal activity task: %w", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return zero, fmt.Errorf("unmarshal activity task: %w", err)
+	}
+
+	evaluated, err := utils.TraverseAndEvaluateObjWithOpts(
+		model.NewObjectOrRuntimeExpr(data),
+		nil,
+		state,
+		utils.TraverseEvaluateOpts{SkipExpression: skipActivityScopedExpression},
+	)
+	if err != nil {
+		return zero, fmt.Errorf("evaluate activity task expressions: %w", err)
+	}
+
+	evaluatedMap, ok := evaluated.(map[string]any)
+	if !ok {
+		return zero, fmt.Errorf("evaluate activity task expressions: expected map, got %T", evaluated)
+	}
+
+	resolved, err := json.Marshal(evaluatedMap)
+	if err != nil {
+		return zero, fmt.Errorf("marshal evaluated activity task: %w", err)
+	}
+
+	var result T
+	if err := json.Unmarshal(resolved, &result); err != nil {
+		return zero, fmt.Errorf("unmarshal evaluated activity task: %w", err)
+	}
+
+	return result, nil
+}
+
+func skipActivityScopedExpression(expr string) bool {
+	return strings.Contains(expr, "$data.activity")
+}

--- a/pkg/zigflow/tasks/task_builder_activity_eval_test.go
+++ b/pkg/zigflow/tasks/task_builder_activity_eval_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/utils"
+)
+
+func TestEvaluateTaskForActivity_ResolvesEnvExpressions(t *testing.T) {
+	task := &model.CallGRPC{
+		Call: "grpc",
+		With: model.GRPCArguments{
+			Arguments: map[string]any{
+				"input": "${ $env." + testConstGRPCInputEnv + " }",
+			},
+		},
+	}
+
+	state := utils.NewState()
+	state.Env[testConstGRPCInputEnv] = testConstHello
+
+	resolved, err := evaluateTaskForActivity(task, state)
+	require.NoError(t, err)
+	assert.Equal(t, testConstHello, resolved.With.Arguments["input"])
+}
+
+func TestEvaluateTaskForActivity_SkipsActivityScopedExpressions(t *testing.T) {
+	task := &model.RunTask{
+		Run: model.RunTaskConfiguration{
+			Container: &model.Container{
+				Image: "alpine",
+				Environment: map[string]string{
+					"WORKFLOW_ID": `${ $data.activity.workflow_execution_id }`,
+				},
+			},
+		},
+	}
+
+	state := utils.NewState()
+
+	resolved, err := evaluateTaskForActivity(task, state)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		`${ $data.activity.workflow_execution_id }`,
+		resolved.Run.Container.Environment["WORKFLOW_ID"],
+	)
+}

--- a/pkg/zigflow/tasks/task_builder_call_grpc_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_grpc_test.go
@@ -17,11 +17,58 @@
 package tasks
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/utils"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 )
+
+func TestCallGRPCTaskBuilderEvaluatesWithBeforeActivity(t *testing.T) {
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+
+	var captured *model.CallGRPC
+	env.RegisterActivityWithOptions(func(_ context.Context, task *model.CallGRPC, _ any, _ *utils.State) (any, error) {
+		captured = task
+		return map[string]any{testConstOK: true}, nil
+	}, activity.RegisterOptions{Name: "CallGRPCActivity"})
+
+	task := &model.CallGRPC{
+		Call: "grpc",
+		With: model.GRPCArguments{
+			Method: "Command1",
+			Arguments: map[string]any{
+				"input": "${ $env." + testConstGRPCInputEnv + " }",
+			},
+		},
+	}
+
+	b, err := NewCallGRPCTaskBuilder(nil, task, "grpcTask", nil, testEvents, nil)
+	assert.NoError(t, err)
+
+	fn, err := b.Build()
+	assert.NoError(t, err)
+
+	workflowFunc := func(ctx workflow.Context) (any, error) {
+		state := utils.NewState()
+		state.Env[testConstGRPCInputEnv] = testConstHello
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: time.Minute})
+		return fn(ctx, nil, state)
+	}
+
+	env.ExecuteWorkflow(workflowFunc)
+
+	assert.NoError(t, env.GetWorkflowError())
+	require.NotNil(t, captured)
+	assert.Equal(t, testConstHello, captured.With.Arguments["input"])
+}
 
 func TestCallGRPCTaskBuilderPostLoadSetsHostDefault(t *testing.T) {
 	task := &model.CallGRPC{

--- a/pkg/zigflow/tasks/task_builder_call_http_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_http_test.go
@@ -17,19 +17,30 @@
 package tasks
 
 import (
+	"context"
 	"encoding/base64"
 	"testing"
+	"time"
 
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 )
 
-func TestParseHTTPArguments(t *testing.T) {
-	state := utils.NewState()
-	state.Env["token"] = "abc-123"
-	state.Data["flag"] = true
+func TestCallHTTPTaskBuilderEvaluatesWithBeforeActivity(t *testing.T) {
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+
+	var captured *model.CallHTTP
+	env.RegisterActivityWithOptions(func(_ context.Context, task *model.CallHTTP, _ any, _ *utils.State) (any, error) {
+		captured = task
+		return map[string]any{testConstOK: true}, nil
+	}, activity.RegisterOptions{Name: "CallHTTPActivity"})
 
 	task := &model.CallHTTP{
 		Call: "http",
@@ -37,7 +48,7 @@ func TestParseHTTPArguments(t *testing.T) {
 			Method:   "GET",
 			Endpoint: model.NewEndpoint("https://example.com"),
 			Headers: map[string]string{
-				// #nosec G101 -- DSL expression, not a hardcoded credential. Value is a JQ expression resolved at runtime from environment variables.
+				// #nosec G101 -- DSL expression, not a hardcoded credential.
 				"X-Token": "${ $env.token }",
 			},
 			Query: map[string]any{
@@ -46,12 +57,27 @@ func TestParseHTTPArguments(t *testing.T) {
 		},
 	}
 
-	got, err := activities.ParseHTTPArguments(task, state)
+	b, err := NewCallHTTPTaskBuilder(nil, task, "httpTask", nil, testEvents, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "GET", got.Method)
-	assert.Equal(t, "https://example.com", got.Endpoint.String())
-	assert.Equal(t, "abc-123", got.Headers["X-Token"])
-	assert.Equal(t, true, got.Query["debug"])
+
+	fn, err := b.Build()
+	assert.NoError(t, err)
+
+	workflowFunc := func(ctx workflow.Context) (any, error) {
+		state := utils.NewState()
+		state.Env["token"] = "abc-123"
+		state.Data["flag"] = true
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: time.Minute})
+		return fn(ctx, nil, state)
+	}
+
+	env.ExecuteWorkflow(workflowFunc)
+
+	assert.NoError(t, env.GetWorkflowError())
+	require.NotNil(t, captured)
+	assert.Equal(t, "abc-123", captured.With.Headers["X-Token"])
+	assert.Equal(t, true, captured.With.Query["debug"])
+	assert.NotContains(t, captured.With.Headers["X-Token"], "${")
 }
 
 func TestParseOutput(t *testing.T) {

--- a/pkg/zigflow/tasks/task_builder_run.go
+++ b/pkg/zigflow/tasks/task_builder_run.go
@@ -161,8 +161,14 @@ func (t *RunTaskBuilder) executeCommand(ctx workflow.Context, activityFn, input 
 	logger := workflow.GetLogger(ctx)
 	logger.Debug("Executing a command", "task", t.GetTaskName())
 
+	resolvedTask, err := evaluateTaskForActivity(t.task, state.Clone().AddWorkflowInfo(ctx))
+	if err != nil {
+		logger.Error("Error evaluating run task expressions", "task", t.GetTaskName(), "error", err)
+		return nil, fmt.Errorf("error evaluating run task expressions: %w", err)
+	}
+
 	args := append([]any{
-		t.task, input, state,
+		resolvedTask, input, state,
 	}, additional...)
 
 	var res any

--- a/pkg/zigflow/tasks/test_helpers_test.go
+++ b/pkg/zigflow/tasks/test_helpers_test.go
@@ -85,6 +85,10 @@ const (
 	testConstChild = "child"
 	// testConstOK is the string value assigned to an env var in set-task tests.
 	testConstOK = "ok"
+	// testConstHello is a sample string used in grpc/http activity input tests.
+	testConstHello = "hello"
+	// testConstGRPCInputEnv is the env var name used in grpc with-payload tests.
+	testConstGRPCInputEnv = "GRPC_INPUT"
 	// testConstItems is the map key used for the items slice in for-task tests.
 	testConstItems = "items"
 	// testConstDone is the string value returned by child workflows in run-task tests.


### PR DESCRIPTION
### **Summary**
Activity-backed tasks (http, grpc, run, and call) were passing unresolved ${ ... } strings into Temporal activity inputs. Expressions were evaluated inside activities instead of in the workflow, which made history harder to inspect, split validation responsibility, and weakened the determinism boundary.

This change resolves runtime expressions in task payloads in the workflow before ExecuteActivity, using workflow-enriched state ($env, $data, $input, $data.workflow). The activity receives concrete values in its input payload.

Expressions that depend on $data.activity are left unchanged at workflow time and are still evaluated inside the activity (for example Docker container env vars).

1. gRPC / HTTP: interpolation removed from activities; they use the pre-resolved with payload.
2. Run: executeCommand evaluates the task at workflow time with the same skip rule.
3. Call activity: already evaluated arguments in the workflow; unchanged.
4. Expression collection and zigflow validate already walked activity with payloads; tests confirm collection and invalid-expression rejection.

Test plan

- [ ]  `go test ./pkg/zigflow/... ./pkg/zigflow/tasks/... ./pkg/zigflow/activities/...`
- [ ]  `pre-commit` run on changed files (golangci-lint, fmt, vet, etc.)
- [ ]  `go test -tags=e2e ./tests/e2e/...` (including callHTTP)

 