### PR TITLE
Add zigflow-workflow skill for AI-assisted workflow authoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: v2.0.0
     hooks:
       - id: markdown-toc
-        exclude: ^docs
+        exclude: ^(docs|skills)
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.22.1
     hooks:

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Dimsi <dimosh3k@gmail.com>
 Hynek <dimosh3k@gmail.com>
+Jingchao <alswlx@gmail.com>
 Maciek Bryński <maciek@brynski.pl>
 mrsimonemms <275848+mrsimonemms@users.noreply.github.com>
 Simon Emms <simon@simonemms.com>

--- a/skills/zigflow-workflow/SKILL.md
+++ b/skills/zigflow-workflow/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: zigflow-workflow
+version: 1.0.0
+description: >
+  Write, validate and debug Zigflow workflow YAML definitions. Loads the DSL
+  schema, checks expressions, suggests task types, enforces determinism rules
+  and state lifecycle.
+
+  Use when the user wants to write a new workflow, add tasks to an existing
+  workflow, fix validation errors, or understand how to use the Zigflow DSL.
+
+  Keywords: workflow, yaml, dsl, task, set, call, http, grpc, activity, for,
+  fork, switch, wait, listen, signal, query, raise, try, catch, run, schedule,
+  expression, validate, determinism, output, export, context, data
+---
+# Zigflow Workflow Authoring Guide
+
+You are an expert at writing Zigflow workflow YAML definitions.
+Zigflow compiles declarative YAML into Temporal workflows.
+
+## When to Use
+
+- Writing a new workflow YAML from scratch
+- Adding tasks to an existing workflow
+- Fixing validation errors from `zigflow validate`
+- Understanding which task type to use
+- Debugging expression or state issues
+- Converting workflow ideas into valid Zigflow YAML
+
+## When NOT to Use
+
+- Modifying the Zigflow engine source code (Go code in `pkg/` or `cmd/`)
+- Deploying or running workflows (`zigflow run` handles that)
+- Writing Temporal SDK code directly
+
+---
+
+## Workflow Structure
+
+Every workflow file has this shape:
+
+```yaml
+document:
+  dsl: 1.0.0
+  taskQueue: my-queue        # RFC 1123 DNS label (letters, digits, hyphens)
+  workflowType: my-workflow  # RFC 1123 DNS label
+  version: 0.0.1            # semver
+  title: Human-Readable Name # optional
+  summary: What this does    # optional
+  metadata:                  # optional, for activityOptions, schedules, tags
+    activityOptions:
+      startToCloseTimeout:
+        minutes: 1
+input:                       # optional, JSON Schema validation
+  schema:
+    format: json
+    document:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: number
+do:
+  - stepName:
+      # exactly one task key per step
+```
+
+### Critical Rules
+
+1. `do` is an **array of single-key maps**, NOT a map of steps
+2. `taskQueue` and `workflowType` must be RFC 1123 DNS labels
+   (no underscores, dots or spaces)
+3. `dsl` and `version` must be valid semver
+4. `document` rejects unknown fields. No `name`, `description`,
+   or `author`. Use `title` and `summary`
+
+---
+
+## Task Types (exactly 11)
+
+| Task | Purpose | Example |
+| ------ | --------- | --------- |
+| `set` | Set values in `$data`, safe for non-deterministic functions | `set: { id: "${ uuid }" }` |
+| `call: http` | Make HTTP requests | `call: http` + `with: { method, endpoint }` |
+| `call: grpc` | Make gRPC calls | `call: grpc` + `with: { service, method, proto }` |
+| `call: activity` | Call external Temporal activities | `call: activity` + `with: { name, arguments, taskQueue }` |
+| `do` | Group tasks into a sub-workflow | `do: [...]` |
+| `for` | Loop over arrays, objects or counts | `for: { in: expr }` + `do: [...]` |
+| `fork` | Run branches in parallel | `fork: { compete: bool, branches: [...] }` |
+| `switch` | Conditional routing | `switch: [{ case: { when: expr, then: target } }]` |
+| `wait` | Pause on a durable timer | `wait: { seconds: 5 }` |
+| `listen` | Wait for signals or queries | `listen: { to: { one: { with: { id, type } } } }` |
+| `try` | Error handling | `try: [...] catch: { do: [...] }` |
+| `raise` | Throw an error | `raise: { error: { type, status } }` |
+| `run` | Execute child workflows or containers | `run: { workflow: { type: name } }` |
+
+**There is no** `http`, `parallel`, `function`, `delay` or `emit` task type.
+
+---
+
+## Expressions
+
+Runtime expressions use jq syntax wrapped in `${ ... }`:
+
+```yaml
+set:
+  greeting: ${ "Hello " + $input.name }
+```
+
+### Available Variables
+
+| Variable | Meaning |
+| ---------- | --------- |
+| `$input` | Workflow input (immutable) |
+| `$data` | Accumulated task results (grows per task) |
+| `$context` | Exported state (replaced on each `export`) |
+| `$output` | Most recent task's result (ephemeral) |
+| `$env` | Environment variables loaded by prefix |
+
+**No** `$workflow`, `$task`, `$steps`, `$vars`, or `$now`.
+
+### Built-in Functions (only in `set` tasks)
+
+| Function | Purpose |
+| ---------- | --------- |
+| `uuid` | Generate a UUID |
+| `timestamp` | Unix timestamp |
+| `timestamp_iso8601` | ISO 8601 timestamp |
+
+These are **non-deterministic** and MUST only be used inside `set`
+tasks. Using them in `call`, `wait`, or other tasks causes
+validation failure.
+
+---
+
+## Data Flow Model
+
+### `output.as` vs `export.as`
+
+| Directive | Writes to | Purpose |
+| --- | --- | --- |
+| `output.as` | `$output` | Shapes workflow return value |
+| `export.as` | `$context` | Persists values for later tasks |
+
+### How `$data` works
+
+- A `set` task merges its fields directly: `set: { foo: 1 }` → `$data.foo`
+- An activity-backed task (`call: http`, etc.) stores result
+  under task name: task named `fetchUser` → `$data.fetchUser`
+
+### Key rule: `export` REPLACES `$context`
+
+To preserve prior context values, merge explicitly:
+
+```yaml
+export:
+  as: '${ $context + { newField: . } }'
+```
+
+---
+
+## Duration Format
+
+Durations use **plural integer keys**. No ISO 8601.
+
+```yaml
+wait:
+  days: 1
+  hours: 2
+  minutes: 30
+  seconds: 15
+  milliseconds: 500
+```
+
+**Invalid**: `PT1M`, `minute: 1`, `second: 5`
+
+---
+
+## Determinism Rules
+
+Temporal replays workflow history. These rules prevent non-determinism errors:
+
+1. `uuid`, `timestamp`, `timestamp_iso8601` → only in `set` tasks
+2. Reference the generated value via `$data` in later tasks
+3. No wall-clock time in `wait` expressions directly
+
+### Pattern: generate-then-use
+
+```yaml
+do:
+  - generateId:
+      set:
+        requestId: ${ uuid }
+  - callApi:
+      call: http
+      with:
+        method: post
+        endpoint: https://api.example.com/orders
+        body:
+          requestId: ${ $data.requestId }
+```
+
+---
+
+## Common Patterns
+
+### HTTP Call
+
+```yaml
+- fetchUser:
+    call: http
+    with:
+      method: get
+      endpoint: ${ "https://api.example.com/users/" + ($input.userId | tostring) }
+```
+
+### For Loop (iterate array)
+
+```yaml
+- processItems:
+    for:
+      each: item
+      in: ${ $input.items }
+      at: index
+    do:
+      - handle:
+          set:
+            current: ${ $data.item }
+```
+
+### For Loop (repeat N times)
+
+```yaml
+- repeat:
+    for:
+      in: ${ 5 }
+    do:
+      - step:
+          set:
+            iteration: ${ $data.index }
+```
+
+### Fork (parallel, all complete)
+
+```yaml
+- parallel:
+    fork:
+      compete: false
+      branches:
+        - branchA:
+            do: [...]
+        - branchB:
+            do: [...]
+```
+
+### Fork (race, first wins)
+
+```yaml
+- race:
+    fork:
+      compete: true
+      branches:
+        - fast:
+            do: [...]
+        - slow:
+            do: [...]
+```
+
+### Switch (conditional routing)
+
+```yaml
+- router:
+    switch:
+      - caseA:
+          when: ${ $input.type == "a" }
+          then: handleA
+      - caseB:
+          when: ${ $input.type == "b" }
+          then: handleB
+      - default:
+          then: handleDefault
+```
+
+Flow directives for `then`: `continue`, `exit`, `end`, or a named task.
+
+### Signal Listener
+
+```yaml
+- awaitApproval:
+    listen:
+      to:
+        one:
+          with:
+            id: approve
+            type: signal
+```
+
+### Query Listener
+
+```yaml
+- queryState:
+    listen:
+      to:
+        one:
+          with:
+            id: get_state
+            type: query
+            data:
+              status: ${ $data.status }
+```
+
+### Try/Catch
+
+```yaml
+- safe:
+    try:
+      - riskyCall:
+          call: http
+          with:
+            method: get
+            endpoint: https://might-fail.example.com
+    catch:
+      do:
+        - handleError:
+            set:
+              error: caught
+```
+
+### Child Workflow
+
+```yaml
+- callChild:
+    run:
+      workflow:
+        type: child-workflow-name
+```
+
+### Schedule
+
+```yaml
+document:
+  metadata:
+    scheduleWorkflowName: my-workflow
+    scheduleId: my-schedule
+schedule:
+  every:
+    minutes: 30
+  cron: "0 9 * * *"
+```
+
+### Multiple Workflows in One File
+
+```yaml
+do:
+  - parentWorkflow:
+      do:
+        - step1:
+            set: { a: 1 }
+        - callChild:
+            run:
+              workflow:
+                type: child-workflow
+  - child-workflow:
+      do:
+        - step1:
+            set: { b: 2 }
+```
+
+---
+
+## Validation
+
+Always validate after writing:
+
+```bash
+zigflow validate workflow.yaml
+```
+
+For JSON output (CI-friendly):
+
+```bash
+zigflow validate --output-json workflow.yaml
+```
+
+Common validation errors:
+
+| Error | Cause | Fix |
+| ------- | ------- | ----- |
+| `unsupported task type` | Used `http:` instead of `call: http` | Use correct task type |
+| `non-deterministic expression` | `uuid`/`timestamp` outside `set` | Move to a `set` task |
+| `unsupported dsl version` | `dsl` not in range `>=1.0.0, <2.0.0` | Use `dsl: 1.0.0` |
+| Schema error at `document` | Unknown field in document | Remove `name`/`description`, use `title`/`summary` |
+| `endpoint` missing | Used `url` instead of `endpoint` | Rename to `endpoint` |
+
+---
+
+## Workflow Approach
+
+When helping the user write a workflow:
+
+1. **Ask what the workflow should do** if not clear
+2. **Pick the right task types** from the 11 available
+3. **Generate valid YAML** following all rules above
+4. **Check determinism** — any generated value in `set` first
+5. **Check data flow** — use `export` to persist, `output` to shape returns
+6. **Suggest running** `zigflow validate` to confirm
+
+When fixing validation errors:
+
+1. Read the error message carefully
+2. Map it to the common-mistakes table above
+3. Apply the fix
+4. Explain why it failed (so the user learns)

--- a/skills/zigflow-workflow/references/common-mistakes.md
+++ b/skills/zigflow-workflow/references/common-mistakes.md
@@ -1,0 +1,68 @@
+# Common Mistakes Quick Reference
+
+When you see these patterns, fix them immediately.
+
+## Wrong task types
+
+| Written | Fix |
+| --- | --- |
+| `http:` | `call: http` with `with: { method, endpoint }` |
+| `parallel:` | `fork: { compete: false, branches: [...] }` |
+| `function:` | `call: activity` with `with: { name, arguments, taskQueue }` |
+| `delay:` | `wait: { seconds: N }` |
+| `emit:` | Not supported, remove |
+
+## Wrong field names
+
+| Written | Fix |
+| --- | --- |
+| `url:` | `endpoint:` |
+| `document.name` | `document.title` |
+| `document.description` | `document.summary` |
+| `document.author` | Put in `document.metadata` |
+
+## Wrong expression syntax
+
+| Written | Fix |
+| --- | --- |
+| `{{ $input.x }}` | `${ $input.x }` |
+| `${{ $input.x }}` | `${ $input.x }` |
+| `$.input.x` | `${ $input.x }` |
+| `$workflow.id` | `${ $data.workflow.workflow_execution_id }` |
+| `$now` | `${ timestamp }` inside a `set` task |
+| `$steps.foo` | `${ $data.foo }` |
+| `$vars.x` | `${ $context.x }` |
+
+## Wrong duration format
+
+| Written | Fix |
+| --- | --- |
+| `wait: PT1M` | `wait: { minutes: 1 }` |
+| `wait: { minute: 1 }` | `wait: { minutes: 1 }` |
+| `wait: { second: 5 }` | `wait: { seconds: 5 }` |
+| `wait: 60` | `wait: { seconds: 60 }` |
+
+## Determinism violations
+
+| Pattern | Fix |
+| --- | --- |
+| `uuid` in a `call` body | Move `${ uuid }` to a preceding `set` task, reference via `$data` |
+| `timestamp` in `wait.until` | Generate in `set`, then `wait: { until: ${ $data.myTimestamp } }` |
+| `timestamp_iso8601` anywhere except `set` | Move to `set` |
+
+## Data flow confusion
+
+| Mistake | Explanation |
+| --- | --- |
+| Using `$output` 3 tasks later | `$output` only holds the MOST RECENT task result. Use `export` to persist to `$context` |
+| `export.as: ${ newVal }` loses old context | `export` REPLACES `$context`. Merge: `${ $context + { newVal: . } }` |
+| Expecting task input to auto-receive previous output | Chain explicitly via `$output` or `$data.<taskName>` |
+
+## Structure mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| `do` as a map (YAML object) | `do` must be a list: `do: [ - name: { task } ]` |
+| Multiple task keys in one step | Each step has exactly ONE task key |
+| `taskQueue: my_queue.v2` | RFC 1123: `my-queue-v2` (no underscores, dots) |
+| `workflowType: My Workflow` | RFC 1123: `my-workflow` (no spaces, lowercase) |

--- a/skills/zigflow-workflow/references/metadata.md
+++ b/skills/zigflow-workflow/references/metadata.md
@@ -1,0 +1,124 @@
+# Document Metadata Reference
+
+The `document.metadata` object is the extension point for
+Zigflow-specific configuration that does not exist in the
+Serverless Workflow specification.
+
+## Activity Options
+
+Controls Temporal activity timeouts and retries for the entire
+workflow (can be overridden per task via task-level `metadata`).
+
+```yaml
+document:
+  metadata:
+    activityOptions:
+      startToCloseTimeout:
+        minutes: 1
+      heartbeatTimeout:
+        seconds: 30
+      retryPolicy:
+        maximumAttempts: 3
+```
+
+### Available fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `startToCloseTimeout` | duration | 15s | Max time for a single activity execution |
+| `heartbeatTimeout` | duration | none | Timeout between heartbeats |
+| `retryPolicy.maximumAttempts` | int | 5 | Max retry attempts |
+
+---
+
+## Schedule Metadata
+
+Required when using the `schedule` top-level key.
+
+```yaml
+document:
+  metadata:
+    scheduleWorkflowName: my-workflow  # required: which workflow to trigger
+    scheduleId: my-schedule-id         # optional: custom schedule ID
+    scheduleInput:                     # optional: input for the triggered workflow
+      - key: value
+```
+
+---
+
+## Continue-As-New Override
+
+For testing or tuning the history length threshold that triggers Temporal continue-as-new:
+
+```yaml
+document:
+  metadata:
+    canMaxHistoryLength: 100
+```
+
+---
+
+## Search Attributes
+
+Set at the task level (not document level) via task `metadata`:
+
+```yaml
+- myTask:
+    metadata:
+      searchAttributes:
+        customField:
+          type: int
+          value: 42
+    set:
+      data: hello
+```
+
+---
+
+## Heartbeat
+
+Configure activity heartbeat at the task level:
+
+```yaml
+- longTask:
+    metadata:
+      heartbeat:
+        seconds: 10
+    call: http
+    with:
+      method: get
+      endpoint: https://slow-api.example.com
+```
+
+---
+
+## Signal/Query Timeout
+
+For `listen` tasks, set an await timeout:
+
+```yaml
+- awaitSignal:
+    metadata:
+      timeout: 60s
+    listen:
+      to:
+        one:
+          with:
+            id: my-signal
+            type: signal
+```
+
+---
+
+## Tags and Display
+
+For the example catalog and documentation generation:
+
+```yaml
+document:
+  metadata:
+    tags:
+      - http
+      - activity
+    display: false  # hide from example listings
+```

--- a/skills/zigflow-workflow/references/task-types.md
+++ b/skills/zigflow-workflow/references/task-types.md
@@ -1,0 +1,355 @@
+# Task Type Reference
+
+## set
+
+Set values in `$data`. Only place where `uuid`, `timestamp`,
+`timestamp_iso8601` are allowed.
+
+```yaml
+- captureInput:
+    set:
+      requestId: ${ uuid }
+      userId: ${ $input.userId }
+      greeting: ${ "Hello " + $input.name }
+```
+
+Fields merge directly into `$data`. Read as `$data.requestId`, `$data.userId`, etc.
+
+---
+
+## call: http
+
+Make HTTP requests. Result stored in `$data.<taskName>`.
+
+```yaml
+- fetchUser:
+    call: http
+    with:
+      method: get
+      endpoint: ${ "https://api.example.com/users/" + ($input.id | tostring) }
+      headers:
+        Authorization: ${ "Bearer " + $env.API_TOKEN }
+      body:
+        name: ${ $input.name }
+```
+
+Properties for `with`:
+- `method` (required): get, post, put, patch, delete
+- `endpoint` (required): URL string or expression. NOT `url`.
+- `headers` (optional): map of header name to value
+- `body` (optional): request body (objects become JSON)
+
+Result is an HTTPResponse object with `statusCode`, `headers`, `content`.
+
+---
+
+## call: grpc
+
+Make gRPC calls.
+
+```yaml
+- callService:
+    call: grpc
+    with:
+      service: my.service.v1.MyService
+      method: GetUser
+      proto: https://example.com/protos/service.proto
+      arguments:
+        user_id: ${ $input.userId }
+```
+
+---
+
+## call: activity
+
+Call external Temporal activities written in any SDK language.
+
+```yaml
+- fetchProfile:
+    call: activity
+    with:
+      name: activitycall.FetchProfile
+      arguments:
+        - ${ $data.userId }
+        - ${ $data.requestId }
+      taskQueue: my-activity-worker
+```
+
+---
+
+## do
+
+Group tasks into a named sub-workflow. When at the top level,
+each `do` becomes a separate Temporal workflow type.
+
+```yaml
+- subFlow:
+    do:
+      - step1:
+          set: { a: 1 }
+      - step2:
+          call: http
+          with:
+            method: get
+            endpoint: https://example.com
+```
+
+---
+
+## for
+
+Loop over arrays, objects or a count.
+
+### Over an array
+
+```yaml
+- loopItems:
+    for:
+      each: item    # variable name for current element
+      in: ${ $input.items }
+      at: index     # variable name for current index
+    do:
+      - process:
+          set:
+            current: ${ $data.item }
+            pos: ${ $data.index }
+```
+
+### Over an object
+
+```yaml
+- loopMap:
+    for:
+      in: ${ $input.config }
+    do:
+      - step:
+          set:
+            key: ${ $data.index }
+            value: ${ $data.item }
+```
+
+### Repeat N times
+
+```yaml
+- repeat5:
+    for:
+      in: ${ 5 }
+    do:
+      - step:
+          set:
+            n: ${ $data.item }
+```
+
+### With while condition
+
+```yaml
+- loopUntil:
+    for:
+      in: ${ 10 }
+    while: '${ ($output.done // false) == false }'
+    do:
+      - check:
+          output:
+            as: ${ { done: ($data.index >= 3) } }
+          set:
+            iteration: ${ $data.index }
+```
+
+---
+
+## fork
+
+Run branches in parallel.
+
+### All branches complete (fan-out)
+
+```yaml
+- fanOut:
+    fork:
+      compete: false
+      branches:
+        - branchA:
+            do:
+              - a:
+                  set: { result: a }
+        - branchB:
+            do:
+              - b:
+                  set: { result: b }
+```
+
+### First branch wins (race)
+
+```yaml
+- race:
+    fork:
+      compete: true
+      branches:
+        - fast:
+            do: [...]
+        - slow:
+            do: [...]
+```
+
+---
+
+## switch
+
+Conditional routing. Each case has `when` (expression) and `then` (flow directive).
+
+```yaml
+- router:
+    switch:
+      - electronic:
+          when: ${ $input.orderType == "electronic" }
+          then: processElectronic
+      - physical:
+          when: ${ $input.orderType == "physical" }
+          then: processPhysical
+      - default:
+          then: handleUnknown
+```
+
+Flow directives for `then`:
+- `continue` — proceed to next task in the list
+- `exit` — stop this scope, return to parent
+- `end` — terminate the entire workflow
+- `<taskName>` — redirect to a named task/child workflow
+
+---
+
+## wait
+
+Pause on a Temporal durable timer.
+
+### Duration form
+
+```yaml
+- pause:
+    wait:
+      minutes: 5
+      seconds: 30
+```
+
+Valid keys: `days`, `hours`, `minutes`, `seconds`, `milliseconds` (all plural).
+
+### Until form (absolute time via expression)
+
+```yaml
+- waitUntil:
+    wait:
+      until: ${ $data.scheduledTime }
+```
+
+The `until` value must be an RFC 3339 timestamp string.
+
+---
+
+## listen
+
+Wait for Temporal signals or respond to queries.
+
+### Signal (blocks until received)
+
+```yaml
+- awaitApproval:
+    listen:
+      to:
+        one:
+          with:
+            id: approve       # signal name in Temporal
+            type: signal
+```
+
+### Query (non-blocking read, responds with data)
+
+```yaml
+- queryState:
+    listen:
+      to:
+        one:
+          with:
+            id: get_state
+            type: query
+            data:
+              status: ${ $data.status }
+              progress: ${ $data.progress }
+```
+
+### With timeout
+
+```yaml
+- timedListen:
+    metadata:
+      timeout: 30s
+    listen:
+      to:
+        one:
+          with:
+            id: my-signal
+            type: signal
+```
+
+---
+
+## try
+
+Error handling with try/catch.
+
+```yaml
+- safeCall:
+    try:
+      - riskyStep:
+          call: http
+          with:
+            method: get
+            endpoint: https://might-fail.example.com
+    catch:
+      do:
+        - handleError:
+            set:
+              error: something went wrong
+```
+
+---
+
+## raise
+
+Throw an error to terminate the workflow.
+
+```yaml
+- fail:
+    raise:
+      error:
+        type: https://serverlessworkflow.io/spec/1.0.0/errors/communication
+        status: 400
+```
+
+---
+
+## run
+
+Execute child workflows or containers.
+
+### Child workflow
+
+```yaml
+- callChild:
+    run:
+      workflow:
+        type: child-workflow-name
+```
+
+### Container (Docker or Kubernetes)
+
+```yaml
+- runContainer:
+    run:
+      container:
+        image: alpine:latest
+        command: echo "hello"
+        environment:
+          FOO: bar
+```
+
+Container runtime is configured at worker level via `--container-runtime`.


### PR DESCRIPTION
## Summary

- Add a new `skills/zigflow-workflow/` skill that encodes the Zigflow DSL rules into a structured format for AI assistants
- Covers all 11 task types, expression syntax, determinism constraints, data-flow model and common mistakes
- Includes reference files for task types, metadata options and a quick-fix lookup table

## Motivation

Writing valid Zigflow workflow YAML requires knowledge of multiple rules that are easy to get wrong: determinism constraints, the difference between `output` and `export`, expression syntax, duration formats and valid task types. This skill encodes all of that into a single consumable unit so AI assistants (Claude Code, Cursor, etc.) can generate correct workflows without the user needing to repeatedly explain the DSL rules.

## What's included

| File | Purpose |
|------|---------|
| `SKILL.md` | Main skill: triggers, DSL structure, all task types, expressions, data flow, determinism, patterns, validation |
| `references/task-types.md` | Detailed syntax reference for each of the 11 task types |
| `references/common-mistakes.md` | Quick-fix lookup table mapping wrong patterns to correct ones |
| `references/metadata.md` | `document.metadata` options: activity options, schedules, heartbeat, search attributes |

## Test plan

- [x] Verify `SKILL.md` frontmatter parses correctly (name, version, description)
- [x] Spot-check that all YAML examples in the skill validate with `zigflow validate`
- [x] Confirm the skill triggers on relevant keywords (workflow, yaml, dsl, task, validate)
- [x] Verify no conflicts with existing documentation in `docs/`
