### PR TITLE
feat(activities)!: register HTTP, gRPC and Run activities by workflowType.taskName

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Shlomit Manor <33759493+ShlomitSibony@users.noreply.github.com> <33759493+ShlomitSibony@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Dimsi <dimosh3k@gmail.com>
 Hynek <dimosh3k@gmail.com>
 Maciek Bryński <maciek@brynski.pl>
 mrsimonemms <275848+mrsimonemms@users.noreply.github.com>
+Shlomit Manor <33759493+ShlomitSibony@users.noreply.github.com>
 Simon Emms <simon@simonemms.com>
 Sumit <sumit.seeftech@gmail.com>
 Yorick Smeets <yorick@energyessentials.nl>

--- a/docs/docs/dsl/tasks/call.md
+++ b/docs/docs/dsl/tasks/call.md
@@ -154,6 +154,23 @@ backoff.
 `Retry-After` delays are not capped by Zigflow. Use Temporal timeout settings,
 such as `ScheduleToCloseTimeout`, to enforce a maximum execution time.
 
+### SDK metrics {/*#sdk-metrics*/}
+
+Activity-dispatching tasks (`call: http`, `call: grpc`, and `run:` tasks
+of type Container, Script and Shell) are each registered on their worker
+under a name derived from the task's path from the workflow root. For a
+task at the top of a workflow's `do:` list, the registered name is
+`<workflowType>.<taskName>` (for example `call-http.getUser`). For
+nested tasks, the path includes each parent's name, so a task `step`
+inside a `for:` task `loop` registers as `<workflowType>.loop.step`.
+Try bodies use `try` and `catch` as path segments to disambiguate the
+two scopes.
+
+Temporal's SDK metrics use the registered name for the `activity_type`
+label, so individual tasks can be attributed in dashboards and alerts
+without colliding when sibling scopes happen to reuse a leaf name.
+`run.workflow` is a child workflow and is not affected.
+
 **Activity names are case-sensitive.** The `name` field in an activity call
 must exactly match the name the activity was registered with on the remote
 worker.

--- a/pkg/zigflow/tasks/activity_registration.go
+++ b/pkg/zigflow/tasks/activity_registration.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"sync"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/worker"
+)
+
+// Tracks (worker, name) pairs already registered so repeated Build
+// calls do not double-register. Temporal's RegisterActivityWithOptions
+// panics on duplicate names.
+var activityRegistry sync.Map
+
+type activityRegistryKey struct {
+	worker worker.Worker
+	name   string
+}
+
+// Registers fn on w under name, skipping if (w, name) was already seen.
+func registerActivityOnce(w worker.Worker, fn any, name string) {
+	if w == nil || name == "" {
+		return
+	}
+
+	key := activityRegistryKey{worker: w, name: name}
+	if _, loaded := activityRegistry.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+
+	w.RegisterActivityWithOptions(fn, activity.RegisterOptions{Name: name})
+}

--- a/pkg/zigflow/tasks/constants.go
+++ b/pkg/zigflow/tasks/constants.go
@@ -25,3 +25,43 @@ const (
 	constDefaultNamespace     = "default"
 	constScriptLanguagePython = "python"
 )
+
+// Path segments threaded through Try's try/catch bodies so a leaf-named
+// task appearing in both does not collide.
+const (
+	tryBodyPathSegment   = "try"
+	catchBodyPathSegment = "catch"
+)
+
+// activityNamingVersionChangeID is the Temporal workflow versioning marker
+// that gates the switch from the legacy fixed per-transport activity type
+// names to the per-task aliases introduced for metrics and observability.
+//
+// Executions started before this change have no version marker in their
+// history, so workflow.GetVersion returns workflow.DefaultVersion and they
+// keep scheduling the legacy name they originally recorded; new executions
+// record the marker and schedule the per-task alias. This keeps open
+// histories deterministic across the upgrade.
+//
+// This string is a durable contract written into workflow histories. It
+// must never change once released.
+const activityNamingVersionChangeID = "zigflow.per-task-activity-aliases"
+
+// activityNamingVersion is the version recorded for
+// activityNamingVersionChangeID on new executions.
+const activityNamingVersion = 1
+
+// Legacy fixed activity type names. These are the names Temporal derived
+// from the activity method names before per-task aliases existed, and they
+// remain registered on every worker via ActivitiesList for back-compat.
+// Open workflow histories scheduled activities under these names, so a
+// replaying execution must continue to schedule them. They must stay
+// aligned with the corresponding activities.* method names and must never
+// change.
+const (
+	legacyCallHTTPActivityName      = "CallHTTPActivity"
+	legacyCallGRPCActivityName      = "CallGRPCActivity"
+	legacyCallContainerActivityName = "CallContainerActivity"
+	legacyCallScriptActivityName    = "CallScriptActivity"
+	legacyCallShellActivityName     = "CallShellActivity"
+)

--- a/pkg/zigflow/tasks/task_builder.go
+++ b/pkg/zigflow/tasks/task_builder.go
@@ -18,6 +18,8 @@ package tasks
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	swUtils "github.com/serverlessworkflow/sdk-go/v3/impl/utils"
@@ -62,6 +64,104 @@ type builder[T model.Task] struct {
 	task           T
 	taskOpts       *TaskOpts
 	temporalWorker worker.Worker
+	// Path from the workflow root; disambiguates per-task activity names
+	// when sibling scopes reuse a leaf name.
+	taskPath []string
+}
+
+func (d *builder[T]) perTaskActivityName() string {
+	if d.doc == nil || d.doc.Document.Name == "" {
+		return d.name
+	}
+	segments := []string{d.doc.Document.Name}
+	if len(d.taskPath) == 0 {
+		segments = append(segments, d.name)
+	} else {
+		segments = append(segments, d.taskPath...)
+	}
+	return joinActivityNameSegments(segments)
+}
+
+// joinActivityNameSegments builds a per-task activity name by escaping each
+// segment and joining them with ".".
+//
+// A task key may legitimately contain dots (e.g. "a.b"). Joining raw
+// segments with "." would make such a key indistinguishable from the
+// separator, so two different task paths could collide on one activity name
+// (["a.b", "c"] and ["a", "b.c"] would both yield "a.b.c"). Escaping makes
+// the join unambiguous, so distinct task paths always produce distinct
+// activity names and valid task keys are preserved rather than rejected.
+func joinActivityNameSegments(segments []string) string {
+	escaped := make([]string, len(segments))
+	for i, segment := range segments {
+		escaped[i] = escapeActivityNameSegment(segment)
+	}
+	return strings.Join(escaped, ".")
+}
+
+// escapeActivityNameSegment makes a single segment safe to join with "."
+// into a per-task activity name. It escapes the escape character first and
+// then the separator, so the encoding is reversible and injective: an
+// unescaped "." in the joined name is always a separator, and a "\" always
+// introduces a literal "\" or ".". Segments that contain neither character
+// (the common case) are returned unchanged, keeping the clean
+// "<workflowType>.<task>" form.
+func escapeActivityNameSegment(segment string) string {
+	segment = strings.ReplaceAll(segment, `\`, `\\`)
+	return strings.ReplaceAll(segment, ".", `\.`)
+}
+
+func (d *builder[T]) setTaskPath(path []string) {
+	d.taskPath = path
+}
+
+// slices.Concat allocates a fresh slice so sibling iterations do not
+// share the parent's underlying array.
+func (d *builder[T]) childTaskPath(name string) []string {
+	return slices.Concat(d.taskPath, []string{name})
+}
+
+type taskPathSetter interface {
+	setTaskPath([]string)
+}
+
+func (d *builder[T]) registerActivityForTask(fn any) string {
+	name := d.perTaskActivityName()
+	registerActivityOnce(d.temporalWorker, fn, name)
+	return name
+}
+
+// Combines registerActivityForTask with the dispatch closure used by
+// CallHTTP/CallGRPC. RunTaskBuilder picks between sub-activities and
+// uses registerActivityForTask directly instead.
+//
+// legacyName is the fixed activity type name recorded by histories created
+// before per-task aliases existed; dispatchActivityName decides at runtime
+// which name to schedule so open executions keep replaying deterministically.
+func (d *builder[T]) buildActivityFunc(fn any, legacyName string) TemporalWorkflowFunc {
+	perTaskName := d.registerActivityForTask(fn)
+	return func(ctx workflow.Context, input any, state *utils.State) (any, error) {
+		return d.executeActivity(ctx, dispatchActivityName(ctx, legacyName, perTaskName), input, state)
+	}
+}
+
+// dispatchActivityName selects the activity type to schedule, using Temporal
+// workflow versioning so renaming activities to per-task aliases does not
+// break open histories.
+//
+// On a new execution GetVersion records a marker and returns the current
+// version, so the per-task alias is scheduled. On an execution that started
+// before the change there is no marker, GetVersion returns
+// workflow.DefaultVersion, and the legacy name the history already recorded
+// is scheduled again, keeping the replay deterministic. The worker registers
+// both names, so either resolves at runtime.
+func dispatchActivityName(ctx workflow.Context, legacyName, perTaskName string) string {
+	if workflow.GetVersion(
+		ctx, activityNamingVersionChangeID, workflow.DefaultVersion, activityNamingVersion,
+	) == workflow.DefaultVersion {
+		return legacyName
+	}
+	return perTaskName
 }
 
 func (d *builder[T]) executeActivity(ctx workflow.Context, activity, input any, state *utils.State) (output any, err error) {
@@ -153,42 +253,55 @@ func NewTaskBuilder(
 	doc *model.Workflow,
 	emitter *cloudevents.Events,
 	taskOpts *TaskOpts,
+	taskPath []string,
 ) (TaskBuilder, error) {
+	var b TaskBuilder
+	var err error
+
 	switch t := task.(type) {
 	case *model.CallFunction:
 		if t.Call == customCallFunctionActivity {
-			return NewCallActivityTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+			b, err = NewCallActivityTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		} else {
+			return nil, fmt.Errorf("unsupported call type '%s' for task '%s'", t.Call, taskName)
 		}
-		return nil, fmt.Errorf("unsupported call type '%s' for task '%s'", t.Call, taskName)
 	case *model.CallGRPC:
-		return NewCallGRPCTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewCallGRPCTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.CallHTTP:
-		return NewCallHTTPTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewCallHTTPTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.DoTask:
-		return NewDoTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewDoTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.ForTask:
-		return NewForTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewForTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.ForkTask:
-		return NewForkTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewForkTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.ListenTask:
-		return NewListenTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewListenTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.RaiseTask:
-		return NewRaiseTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewRaiseTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.RunTask:
-		return NewRunTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewRunTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.SetTask:
-		return NewSetTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewSetTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.SwitchTask:
-		return NewSwitchTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewSwitchTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.TryTask:
-		return NewTryTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewTryTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *model.WaitTask:
-		return NewWaitTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewWaitTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	case *models.WaitExtTask:
-		return NewWaitExtTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
+		b, err = NewWaitExtTaskBuilder(temporalWorker, t, taskName, doc, emitter, taskOpts)
 	default:
 		return nil, fmt.Errorf("unsupported task type '%T' for task '%s'", t, taskName)
 	}
+
+	if err != nil {
+		return nil, err
+	}
+	if setter, ok := b.(taskPathSetter); ok && taskPath != nil {
+		setter.setTaskPath(taskPath)
+	}
+	return b, nil
 }
 
 // Ensure the tasks meets the TaskBuilder type

--- a/pkg/zigflow/tasks/task_builder_call_grpc.go
+++ b/pkg/zigflow/tasks/task_builder_call_grpc.go
@@ -19,10 +19,8 @@ package tasks
 import (
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/zigflow/zigflow/pkg/cloudevents"
-	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
 	"go.temporal.io/sdk/worker"
-	"go.temporal.io/sdk/workflow"
 )
 
 func NewCallGRPCTaskBuilder(
@@ -59,8 +57,9 @@ func (t *CallGRPCTaskBuilder) PostLoad() error {
 	return nil
 }
 
+// Singleton whose bound method value is registered under per-task names.
+var callGRPCActivity = &activities.CallGRPC{}
+
 func (t *CallGRPCTaskBuilder) Build() (TemporalWorkflowFunc, error) {
-	return func(ctx workflow.Context, input any, state *utils.State) (output any, err error) {
-		return t.executeActivity(ctx, (*activities.CallGRPC).CallGRPCActivity, input, state)
-	}, nil
+	return t.buildActivityFunc(callGRPCActivity.CallGRPCActivity, legacyCallGRPCActivityName), nil
 }

--- a/pkg/zigflow/tasks/task_builder_call_grpc_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_grpc_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
 )
 
 func TestCallGRPCTaskBuilderPostLoadSetsHostDefault(t *testing.T) {
@@ -95,4 +97,49 @@ func TestCallGRPCTaskBuilderBuildDoesNotMutateTask(t *testing.T) {
 
 	assert.Equal(t, "", task.With.Service.Host, "Build() must not set Host default")
 	assert.Equal(t, 0, task.With.Service.Port, "Build() must not set Port default")
+}
+
+func newTestGRPCTask() *model.CallGRPC {
+	return &model.CallGRPC{
+		With: model.GRPCArguments{
+			Service: model.GRPCService{Host: "localhost", Port: 50051},
+		},
+	}
+}
+
+func TestCallGRPCTaskBuilderRegistersPerTaskActivityName(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-grpc-metrics"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-grpc-metrics.callBackend",
+		}).
+		Once()
+
+	b, err := NewCallGRPCTaskBuilder(w, newTestGRPCTask(), "callBackend", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	_, err = b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+func TestCallGRPCTaskBuilderRegistersOncePerWorker(t *testing.T) {
+	assertRegistersOncePerWorker(t, "wf-grpc-dedup", "invoke",
+		func(w *WorkflowRegistryMock, doc *model.Workflow, taskName string) (TaskBuilder, error) {
+			return NewCallGRPCTaskBuilder(w, newTestGRPCTask(), taskName, doc, testEvents, nil)
+		})
+}
+
+func TestCallGRPCTaskBuilderBuildWithoutWorker(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-grpc-nil-worker"}}
+
+	b, err := NewCallGRPCTaskBuilder(nil, newTestGRPCTask(), "step", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	fn, err := b.Build()
+	assert.NoError(t, err)
+	assert.NotNil(t, fn)
 }

--- a/pkg/zigflow/tasks/task_builder_call_http.go
+++ b/pkg/zigflow/tasks/task_builder_call_http.go
@@ -19,10 +19,8 @@ package tasks
 import (
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/zigflow/zigflow/pkg/cloudevents"
-	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
 	"go.temporal.io/sdk/worker"
-	"go.temporal.io/sdk/workflow"
 )
 
 func NewCallHTTPTaskBuilder(
@@ -49,8 +47,11 @@ type CallHTTPTaskBuilder struct {
 	builder[*model.CallHTTP]
 }
 
+// Singleton whose bound method value is registered under per-task names.
+// A bound value (not the unbound method expression) is required so
+// Temporal invokes the activity with the receiver supplied.
+var callHTTPActivity = &activities.CallHTTP{}
+
 func (t *CallHTTPTaskBuilder) Build() (TemporalWorkflowFunc, error) {
-	return func(ctx workflow.Context, input any, state *utils.State) (any, error) {
-		return t.executeActivity(ctx, (*activities.CallHTTP).CallHTTPActivity, input, state)
-	}, nil
+	return t.buildActivityFunc(callHTTPActivity.CallHTTPActivity, legacyCallHTTPActivityName), nil
 }

--- a/pkg/zigflow/tasks/task_builder_call_http_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_http_test.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
+	"go.temporal.io/sdk/activity"
 )
 
 func TestParseHTTPArguments(t *testing.T) {
@@ -91,4 +93,51 @@ func TestParseOutput(t *testing.T) {
 			assert.Equal(t, tc.expect, got)
 		})
 	}
+}
+
+func newTestHTTPTask() *model.CallHTTP {
+	return &model.CallHTTP{
+		Call: "http",
+		With: model.HTTPArguments{
+			Method:   "GET",
+			Endpoint: model.NewEndpoint("https://example.com"),
+		},
+	}
+}
+
+func TestCallHTTPTaskBuilderRegistersPerTaskActivityName(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-http-metrics"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-http-metrics.fetchData",
+		}).
+		Once()
+
+	b, err := NewCallHTTPTaskBuilder(w, newTestHTTPTask(), "fetchData", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	_, err = b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+func TestCallHTTPTaskBuilderRegistersOncePerWorker(t *testing.T) {
+	assertRegistersOncePerWorker(t, "wf-http-dedup", "authenticate",
+		func(w *WorkflowRegistryMock, doc *model.Workflow, taskName string) (TaskBuilder, error) {
+			return NewCallHTTPTaskBuilder(w, newTestHTTPTask(), taskName, doc, testEvents, nil)
+		})
+}
+
+func TestCallHTTPTaskBuilderBuildWithoutWorker(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-http-nil-worker"}}
+
+	b, err := NewCallHTTPTaskBuilder(nil, newTestHTTPTask(), "step", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	fn, err := b.Build()
+	assert.NoError(t, err)
+	assert.NotNil(t, fn)
 }

--- a/pkg/zigflow/tasks/task_builder_call_shared_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_shared_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
+)
+
+// assertRegistersOncePerWorker exercises the registration-dedup contract that
+// every activity-dispatching task builder must honour: repeated Build() calls
+// against the same worker register the per-task activity exactly once. Both
+// CallHTTP and CallGRPC tests share this helper because the assertion shape
+// is identical; new task builders should add a one-line test calling it.
+func assertRegistersOncePerWorker(
+	t *testing.T,
+	workflowName, taskName string,
+	newBuilder func(w *WorkflowRegistryMock, doc *model.Workflow, taskName string) (TaskBuilder, error),
+) {
+	t.Helper()
+
+	doc := &model.Workflow{Document: model.Document{Name: workflowName}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: workflowName + "." + taskName,
+		}).
+		Once()
+
+	b, err := newBuilder(w, doc, taskName)
+	assert.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		_, err = b.Build()
+		assert.NoError(t, err)
+	}
+
+	w.AssertExpectations(t)
+}

--- a/pkg/zigflow/tasks/task_builder_collision_test.go
+++ b/pkg/zigflow/tasks/task_builder_collision_test.go
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
+)
+
+func TestNestedSameLeafNameRegistersDistinctActivities(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-collision"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-collision.first.step",
+		}).
+		Once()
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-collision.second.step",
+		}).
+		Once()
+
+	first, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, []string{"first", testConstStep})
+	assert.NoError(t, err)
+	second, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, []string{"second", testConstStep})
+	assert.NoError(t, err)
+
+	_, err = first.Build()
+	assert.NoError(t, err)
+	_, err = second.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+func TestTryCatchSameLeafNameRegistersDistinctActivities(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-try"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-try.outer.try.step",
+		}).
+		Once()
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-try.outer.catch.step",
+		}).
+		Once()
+
+	tryPath := []string{"outer", tryBodyPathSegment, testConstStep}
+	catchPath := []string{"outer", catchBodyPathSegment, testConstStep}
+
+	tryStep, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, tryPath)
+	assert.NoError(t, err)
+	catchStep, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, catchPath)
+	assert.NoError(t, err)
+
+	_, err = tryStep.Build()
+	assert.NoError(t, err)
+	_, err = catchStep.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+func TestForkSameLeafNameRegistersDistinctActivities(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-fork"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-fork.dispatch.left.step",
+		}).
+		Once()
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-fork.dispatch.right.step",
+		}).
+		Once()
+
+	leftPath := []string{"dispatch", "left", testConstStep}
+	rightPath := []string{"dispatch", "right", testConstStep}
+
+	left, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, leftPath)
+	assert.NoError(t, err)
+	right, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, rightPath)
+	assert.NoError(t, err)
+
+	_, err = left.Build()
+	assert.NoError(t, err)
+	_, err = right.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+func TestDeeplyNestedPathProducesFullyQualifiedName(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-deep"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-deep.l1.l2.l3.step",
+		}).
+		Once()
+
+	path := []string{"l1", "l2", "l3", testConstStep}
+	b, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, path)
+	assert.NoError(t, err)
+
+	_, err = b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+// Regression guard: ForTaskBuilder.Build constructs its inner DoBuilder via
+// NewDoTaskBuilder directly (to pass DoTaskOpts{DisableRegisterWorkflow:true}),
+// bypassing the factory. Without an explicit setTaskPath on that inner builder,
+// the body's tasks register under collision-prone names — exactly the bug an
+// e2e run with two sibling For loops uncovered.
+func TestForBuildPropagatesTaskPathToInnerBody(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-for-build"}}
+
+	w := new(WorkflowRegistryMock)
+	w.On("RegisterWorkflowWithOptions", mock.Anything, mock.Anything).Maybe()
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-for-build.outer_loop.step",
+		}).
+		Once()
+
+	b := &ForTaskBuilder{
+		builder: builder[*model.ForTask]{
+			doc:            doc,
+			eventEmitter:   testEvents,
+			name:           "outer_loop",
+			taskPath:       []string{"outer_loop"},
+			temporalWorker: w,
+			task: &model.ForTask{
+				For: model.ForTaskConfiguration{In: "[]"},
+				Do: &model.TaskList{
+					&model.TaskItem{Key: testConstStep, Task: newTestHTTPTask()},
+				},
+			},
+		},
+	}
+
+	_, err := b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+// Dotted task keys must not collide once segments are escaped. Under naive
+// dot-joining []string{"a.b", "c"} and []string{"a", "b.c"} both produce
+// "a.b.c"; escaping the dot inside a segment keeps them distinct.
+func TestActivityNameSegmentsEscapeDottedKeys(t *testing.T) {
+	const wf = "wf"
+	first := joinActivityNameSegments([]string{wf, "a.b", "c"})
+	second := joinActivityNameSegments([]string{wf, "a", "b.c"})
+
+	assert.Equal(t, `wf.a\.b.c`, first)
+	assert.Equal(t, `wf.a.b\.c`, second)
+	assert.NotEqual(t, first, second, "dotted task keys must not collide on one activity name")
+}
+
+// Segments without dots or backslashes are joined verbatim so the common
+// case keeps the readable <workflowType>.<task> form.
+func TestActivityNameSegmentsPreserveCleanCommonCase(t *testing.T) {
+	const wf = "wf"
+	assert.Equal(t, "wf.fetchData", joinActivityNameSegments([]string{wf, "fetchData"}))
+	assert.Equal(t, "wf.group.sub.step", joinActivityNameSegments([]string{wf, "group", "sub", "step"}))
+}
+
+// End-to-end guard: two task paths that collide under naive dot-joining
+// must register two distinct per-task activity names. If escaping were
+// dropped both builds would register "wf-dotted.a.b.c"; the second
+// registration would dedup against the first and the second expectation
+// would go unmet.
+func TestDottedTaskPathsRegisterDistinctActivities(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-dotted"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: `wf-dotted.a\.b.c`,
+		}).
+		Once()
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: `wf-dotted.a.b\.c`,
+		}).
+		Once()
+
+	first, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, []string{"a.b", "c"})
+	assert.NoError(t, err)
+	second, err := NewTaskBuilder(testConstStep, newTestHTTPTask(), w, doc, testEvents, nil, []string{"a", "b.c"})
+	assert.NoError(t, err)
+
+	_, err = first.Build()
+	assert.NoError(t, err)
+	_, err = second.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+// Concrete constructors used directly by tests do not set taskPath;
+// perTaskActivityName falls back to "<workflowType>.<taskName>".
+func TestNilTaskPathFallsBackToBareTaskName(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-fallback"}}
+
+	w := new(WorkflowRegistryMock)
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-fallback.lonely",
+		}).
+		Once()
+
+	b, err := NewCallHTTPTaskBuilder(w, newTestHTTPTask(), "lonely", doc, testEvents, nil)
+	assert.NoError(t, err)
+
+	_, err = b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}

--- a/pkg/zigflow/tasks/task_builder_do.go
+++ b/pkg/zigflow/tasks/task_builder_do.go
@@ -104,7 +104,7 @@ func (t *DoTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 
 		// Build a task builder
 		l.Debug().Msg("Creating task builder")
-		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts)
+		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, t.childTaskPath(task.Key))
 		if err != nil {
 			return nil, fmt.Errorf("error creating task builder: %w", err)
 		}
@@ -146,7 +146,7 @@ func (t *DoTaskBuilder) PostLoad() error {
 
 		// Build a task builder
 		l.Debug().Msg("Creating prep task builder")
-		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts)
+		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, t.childTaskPath(task.Key))
 		if err != nil {
 			return fmt.Errorf("error creating task prep builder: %w", err)
 		}
@@ -162,7 +162,7 @@ func (t *DoTaskBuilder) PostLoad() error {
 
 func (t *DoTaskBuilder) Validate() error {
 	for _, task := range *t.task.Do {
-		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts)
+		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, t.childTaskPath(task.Key))
 		if err != nil {
 			return fmt.Errorf("error creating task validate builder: %w", err)
 		}

--- a/pkg/zigflow/tasks/task_builder_do_test.go
+++ b/pkg/zigflow/tasks/task_builder_do_test.go
@@ -687,7 +687,7 @@ func (m *WorkflowRegistryMock) RegisterActivity(a any) {
 
 // RegisterActivityWithOptions implements [worker.Worker].
 func (m *WorkflowRegistryMock) RegisterActivityWithOptions(a any, options activity.RegisterOptions) {
-	panic("unimplemented")
+	m.Called(a, options)
 }
 
 // RegisterDynamicActivity implements [worker.Worker].

--- a/pkg/zigflow/tasks/task_builder_for.go
+++ b/pkg/zigflow/tasks/task_builder_for.go
@@ -101,6 +101,9 @@ func (t *ForTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		log.Error().Str("task", t.childWorkflowName).Err(err).Msg("Error creating the for task builder")
 		return nil, fmt.Errorf("error creating the for task builder: %w", err)
 	}
+	// Direct construction bypasses NewTaskBuilder's path setter; thread it
+	// here so the body's tasks inherit the For's path.
+	innerBuilder.setTaskPath(t.taskPath)
 
 	innerFn, err := innerBuilder.Build()
 	if err != nil {
@@ -195,7 +198,10 @@ func (t *ForTaskBuilder) createBuilder() (TaskBuilder, error) {
 	// Register the ForTask's Do as a child workflow
 	t.childWorkflowName = utils.GenerateChildWorkflowName("for", t.GetTaskName())
 
-	builder, err := NewTaskBuilder(t.childWorkflowName, &model.DoTask{Do: t.task.Do}, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts)
+	builder, err := NewTaskBuilder(
+		t.childWorkflowName, &model.DoTask{Do: t.task.Do},
+		t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, t.taskPath,
+	)
 	if err != nil {
 		log.Error().Str("task", t.childWorkflowName).Err(err).Msg("Error creating the for task builder")
 		return nil, fmt.Errorf("error creating the for task builder: %w", err)

--- a/pkg/zigflow/tasks/task_builder_fork.go
+++ b/pkg/zigflow/tasks/task_builder_fork.go
@@ -133,26 +133,44 @@ func (t *ForkTaskBuilder) buildOrPostLoad() ([]*forkedTask, []TaskBuilder, error
 	builders := make([]TaskBuilder, 0)
 
 	for _, branch := range *t.task.Fork.Branches {
-		childWorkflowName := utils.GenerateChildWorkflowName("fork", t.GetTaskName(), branch.Key)
+		// Capture the original, user-visible branch key before the branch
+		// is (potentially) wrapped as a synthetic child workflow below.
+		// Per-task activity aliases must read as
+		// <workflowType>.<fork>.<branch>..., using this key rather than the
+		// synthetic child workflow name.
+		originalKey := branch.Key
+		childWorkflowName := utils.GenerateChildWorkflowName("fork", t.GetTaskName(), originalKey)
 
 		forkedTasks = append(forkedTasks, &forkedTask{
 			task:              branch,
 			childWorkflowName: childWorkflowName,
-			taskName:          branch.Key,
+			taskName:          originalKey,
 		})
 
+		// Multi-task branches are a do-task scope, so the branch key is an
+		// intermediate path segment and the body's tasks nest beneath it.
+		childPath := t.childTaskPath(originalKey)
+
 		if d := branch.AsDoTask(); d == nil {
-			// Single task - register this as a single task workflow
-			log.Debug().Str("task", branch.Key).Msg("Registering single task workflow")
+			// Single task - register this as a single task workflow. The
+			// wrapper still contains the original task item (keyed
+			// originalKey), which re-supplies the branch key as the leaf
+			// path segment, so hand the wrapper the parent path to avoid
+			// duplicating originalKey in the generated alias.
+			log.Debug().Str("task", originalKey).Msg("Registering single task workflow")
 			branch = &model.TaskItem{
 				Key: childWorkflowName,
 				Task: &model.DoTask{
 					Do: &model.TaskList{branch},
 				},
 			}
+			childPath = t.taskPath
 		}
 
-		builder, err := NewTaskBuilder(childWorkflowName, branch.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts)
+		builder, err := NewTaskBuilder(
+			childWorkflowName, branch.Task,
+			t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, childPath,
+		)
 		if err != nil {
 			log.Error().Err(err).Msg("Error creating the forked task builder")
 			return nil, nil, fmt.Errorf("error creating the forked task builder: %w", err)

--- a/pkg/zigflow/tasks/task_builder_fork_test.go
+++ b/pkg/zigflow/tasks/task_builder_fork_test.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/flow"
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
@@ -178,4 +180,100 @@ func TestForkTaskBuilderExecStillWrapsRealBranchFailure(t *testing.T) {
 	require.Error(t, workflowErr)
 	assert.Contains(t, workflowErr.Error(), "error forking task")
 	assert.NotContains(t, workflowErr.Error(), flow.ErrEnd.Error())
+}
+
+// testForkTaskName is the fork task's own name (and sole path segment) used
+// by the alias-derivation tests below.
+const testForkTaskName = "dispatch"
+
+// A single-task fork branch is wrapped in a synthetic child workflow before
+// being built. The generated per-task activity alias must still be derived
+// from the original, user-visible branch key ("branchA"), not from the
+// synthetic child workflow name ("workflow_fork_dispatch_branchA").
+//
+// Only the original-key alias is registered as an expectation; the mock
+// fails any RegisterActivityWithOptions call with a different name, so an
+// alias built from the synthetic name would fail the test rather than pass
+// silently.
+func TestForkSingleTaskBranchAliasUsesOriginalBranchKey(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-fork-single"}}
+
+	w := new(WorkflowRegistryMock)
+	// The wrapper child workflow registration is incidental here.
+	w.On("RegisterWorkflowWithOptions", mock.Anything, mock.Anything).Maybe()
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-fork-single.dispatch.branchA",
+		}).
+		Once()
+
+	forkTask := &model.ForkTask{
+		Fork: model.ForkTaskConfiguration{
+			Branches: &model.TaskList{
+				&model.TaskItem{Key: "branchA", Task: newTestHTTPTask()},
+			},
+		},
+	}
+
+	b := &ForkTaskBuilder{
+		builder: builder[*model.ForkTask]{
+			doc:            doc,
+			eventEmitter:   testEvents,
+			name:           testForkTaskName,
+			taskPath:       []string{testForkTaskName},
+			task:           forkTask,
+			temporalWorker: w,
+		},
+	}
+
+	_, err := b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
+}
+
+// A multi-task fork branch is a do-task scope: the branch key is an
+// intermediate path segment and the body's leaf tasks nest beneath it. This
+// pins the sibling behaviour the single-task case is kept consistent with.
+func TestForkMultiTaskBranchAliasNestsUnderBranchKey(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-fork-multi"}}
+
+	w := new(WorkflowRegistryMock)
+	w.On("RegisterWorkflowWithOptions", mock.Anything, mock.Anything).Maybe()
+	w.
+		On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+			Name: "wf-fork-multi.dispatch.branchB.leaf",
+		}).
+		Once()
+
+	forkTask := &model.ForkTask{
+		Fork: model.ForkTaskConfiguration{
+			Branches: &model.TaskList{
+				&model.TaskItem{
+					Key: "branchB",
+					Task: &model.DoTask{
+						Do: &model.TaskList{
+							&model.TaskItem{Key: "leaf", Task: newTestHTTPTask()},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b := &ForkTaskBuilder{
+		builder: builder[*model.ForkTask]{
+			doc:            doc,
+			eventEmitter:   testEvents,
+			name:           testForkTaskName,
+			taskPath:       []string{testForkTaskName},
+			task:           forkTask,
+			temporalWorker: w,
+		},
+	}
+
+	_, err := b.Build()
+	assert.NoError(t, err)
+
+	w.AssertExpectations(t)
 }

--- a/pkg/zigflow/tasks/task_builder_replay_test.go
+++ b/pkg/zigflow/tasks/task_builder_replay_test.go
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/utils"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+// RELEASE ORDERING NOTE
+//
+// The Temporal versioning fix in dispatchActivityName must ship in the SAME
+// release as the per-task activity alias change. The alias-without-marker
+// state must never be deployed on its own:
+//
+//   - Without the versioning fix, executions started under the alias change
+//     record per-task aliases (e.g. "wf.fetch") with NO version marker.
+//   - If the versioning fix is then deployed, those in-flight histories have
+//     no marker, so GetVersion returns DefaultVersion and the worker would
+//     schedule the LEGACY name on replay, mismatching the recorded alias and
+//     failing replay with a non-determinism error.
+//
+// Shipping both together means no execution ever runs in the
+// alias-without-marker state, so this hazard cannot occur. These tests cover
+// the reverse, supported direction: pre-alias histories (legacy name, no
+// marker) replaying cleanly after the change.
+
+const replayWorkflowName = "wf-replay"
+
+// These are the literal activity type names Temporal recorded in histories
+// before per-task aliases existed, derived from the activity method names via
+// the default ActivitiesList registration. They are written as literals here,
+// independently of the legacy* constants the production code schedules, so
+// these tests verify the constants agree with the real historical names
+// rather than merely agreeing with themselves.
+const (
+	historicalCallHTTPActivityType   = "CallHTTPActivity"
+	historicalCallGRPCActivityType   = "CallGRPCActivity"
+	historicalCallScriptActivityType = "CallScriptActivity"
+)
+
+// TestReplayUsesLegacyActivityTypeForOldHistories is the replay regression
+// guard for the per-task activity alias change. For each activity dispatch
+// path changed by this PR it replays a history that was recorded before the
+// change, when the activity was scheduled under its historical fixed type
+// name and no version marker existed.
+//
+// The replayed workflow is the current dispatch closure, which now calls
+// workflow.GetVersion. Because the crafted history has no version marker,
+// GetVersion must return workflow.DefaultVersion and the closure must
+// schedule the historical name again, matching the recorded
+// ActivityTaskScheduled event. If the closure scheduled the per-task alias
+// instead, replay would fail with a non-determinism error.
+//
+// The histories use literal historical names, so a case fails if: the wrong
+// legacy constant is used, legacyActivityName is not assigned (run paths), or
+// the path schedules the new alias during replay of an old history.
+func TestReplayUsesLegacyActivityTypeForOldHistories(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: replayWorkflowName}}
+
+	cases := []struct {
+		name string
+		// historicalActivityType is the literal type the old history
+		// recorded; the dispatch closure must reschedule exactly this.
+		historicalActivityType string
+		// newBuilder constructs the task builder under test with a nil
+		// worker (registration is skipped; only the dispatch closure, which
+		// is what we replay, is built as in production).
+		newBuilder func(t *testing.T) TaskBuilder
+	}{
+		{
+			name:                   "call-http",
+			historicalActivityType: historicalCallHTTPActivityType,
+			newBuilder: func(t *testing.T) TaskBuilder {
+				t.Helper()
+				b, err := NewCallHTTPTaskBuilder(nil, newTestHTTPTask(), "fetch", doc, testEvents, nil)
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name:                   "call-grpc",
+			historicalActivityType: historicalCallGRPCActivityType,
+			newBuilder: func(t *testing.T) TaskBuilder {
+				t.Helper()
+				b, err := NewCallGRPCTaskBuilder(nil, newTestGRPCTask(), "fetch", doc, testEvents, nil)
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name:                   "run-script",
+			historicalActivityType: historicalCallScriptActivityType,
+			newBuilder: func(t *testing.T) TaskBuilder {
+				t.Helper()
+				task := &model.RunTask{
+					Run: model.RunTaskConfiguration{
+						Await: utils.Ptr(true),
+						Script: &model.Script{
+							Language:   constScriptLanguagePython,
+							InlineCode: utils.Ptr("print(1)"),
+						},
+					},
+				}
+				b, err := NewRunTaskBuilder(nil, task, "fetch", doc, testEvents, nil)
+				require.NoError(t, err)
+				require.NoError(t, b.PostLoad())
+				return b
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn, err := tc.newBuilder(t).Build()
+			require.NoError(t, err)
+
+			workflowName := replayWorkflowName + "-" + tc.name
+
+			replayer := worker.NewWorkflowReplayer()
+			replayer.RegisterWorkflowWithOptions(
+				func(ctx workflow.Context, input any, state *utils.State) (any, error) {
+					ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+						StartToCloseTimeout: time.Minute,
+					})
+					return fn(ctx, input, state)
+				},
+				workflow.RegisterOptions{Name: workflowName},
+			)
+
+			history := legacyActivityHistory(t, workflowName, tc.historicalActivityType)
+
+			require.NoError(t, replayer.ReplayWorkflowHistory(nil, history),
+				"an old history that scheduled %q must still replay after the per-task alias change",
+				tc.historicalActivityType)
+		})
+	}
+}
+
+// legacyActivityHistory builds a minimal, marker-free history for a workflow
+// that scheduled a single activity under the given historical type name and
+// completed. The absence of a version marker is the crucial property: it is
+// what an execution started before the alias change looks like.
+func legacyActivityHistory(t *testing.T, workflowName, activityType string) *historypb.History {
+	t.Helper()
+
+	dc := converter.GetDefaultDataConverter()
+
+	// The workflow takes (input, state); state must be non-nil because the
+	// dispatch closures write the activity result into it on success.
+	startedInput, err := dc.ToPayloads(map[string]any{}, utils.NewState())
+	require.NoError(t, err)
+
+	activityResult, err := dc.ToPayloads(map[string]any{"ok": true})
+	require.NoError(t, err)
+
+	taskQueue := &taskqueuepb.TaskQueue{Name: "replay-task-queue"}
+
+	events := []*historypb.HistoryEvent{
+		{
+			EventId:   1,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
+					WorkflowType: &commonpb.WorkflowType{Name: workflowName},
+					TaskQueue:    taskQueue,
+					Input:        startedInput,
+				},
+			},
+		},
+		{
+			EventId:   2,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{
+				WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+					TaskQueue: taskQueue,
+				},
+			},
+		},
+		{
+			EventId:   3,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskStartedEventAttributes{
+				WorkflowTaskStartedEventAttributes: &historypb.WorkflowTaskStartedEventAttributes{},
+			},
+		},
+		{
+			EventId:   4,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{
+				WorkflowTaskCompletedEventAttributes: &historypb.WorkflowTaskCompletedEventAttributes{
+					ScheduledEventId: 2,
+					StartedEventId:   3,
+				},
+			},
+		},
+		{
+			// The activity scheduled under the LEGACY name. The replayer
+			// matches the command's activity type against this; the activity
+			// id matches the scheduled event id by SDK convention.
+			EventId:   5,
+			EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{
+				ActivityTaskScheduledEventAttributes: &historypb.ActivityTaskScheduledEventAttributes{
+					ActivityId:                   "5",
+					ActivityType:                 &commonpb.ActivityType{Name: activityType},
+					TaskQueue:                    taskQueue,
+					WorkflowTaskCompletedEventId: 4,
+				},
+			},
+		},
+		{
+			EventId:   6,
+			EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_STARTED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskStartedEventAttributes{
+				ActivityTaskStartedEventAttributes: &historypb.ActivityTaskStartedEventAttributes{
+					ScheduledEventId: 5,
+				},
+			},
+		},
+		{
+			EventId:   7,
+			EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
+			Attributes: &historypb.HistoryEvent_ActivityTaskCompletedEventAttributes{
+				ActivityTaskCompletedEventAttributes: &historypb.ActivityTaskCompletedEventAttributes{
+					ScheduledEventId: 5,
+					StartedEventId:   6,
+					Result:           activityResult,
+				},
+			},
+		},
+		{
+			EventId:   8,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{
+				WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+					TaskQueue: taskQueue,
+				},
+			},
+		},
+		{
+			EventId:   9,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskStartedEventAttributes{
+				WorkflowTaskStartedEventAttributes: &historypb.WorkflowTaskStartedEventAttributes{},
+			},
+		},
+		{
+			EventId:   10,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{
+				WorkflowTaskCompletedEventAttributes: &historypb.WorkflowTaskCompletedEventAttributes{
+					ScheduledEventId: 8,
+					StartedEventId:   9,
+				},
+			},
+		},
+		{
+			EventId:   11,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{
+				WorkflowExecutionCompletedEventAttributes: &historypb.WorkflowExecutionCompletedEventAttributes{
+					Result:                       activityResult,
+					WorkflowTaskCompletedEventId: 10,
+				},
+			},
+		},
+	}
+
+	return &historypb.History{Events: events}
+}

--- a/pkg/zigflow/tasks/task_builder_run.go
+++ b/pkg/zigflow/tasks/task_builder_run.go
@@ -59,21 +59,47 @@ func NewRunTaskBuilder(
 
 type RunTaskBuilder struct {
 	builder[*model.RunTask]
+	// activityName is set by Build() once we know which sub-activity
+	// (Container, Script, Shell) will run. Sub-factories use it as the
+	// dispatch name so SDK metrics carry activity_type=<workflowType>.<taskName>.
+	// Empty for the runWorkflow sub-factory (no activity registration).
+	activityName string
+	// legacyActivityName is the fixed activity type name the chosen
+	// sub-activity used before per-task aliases existed. Sub-factories pass
+	// both names to dispatchActivityName so open histories keep scheduling
+	// the legacy name during replay.
+	legacyActivityName string
 }
+
+// Singleton whose bound method values are registered under per-task names.
+var runActivityInstance = &activities.Run{}
 
 func (t *RunTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 	var factory TemporalWorkflowFunc
+	var activityFn any
+	var legacyName string
 	switch {
 	case t.task.Run.Container != nil:
+		activityFn = runActivityInstance.CallContainerActivity
+		legacyName = legacyCallContainerActivityName
 		factory = t.runContainer
 	case t.task.Run.Script != nil:
+		activityFn = runActivityInstance.CallScriptActivity
+		legacyName = legacyCallScriptActivityName
 		factory = t.runScript
 	case t.task.Run.Shell != nil:
+		activityFn = runActivityInstance.CallShellActivity
+		legacyName = legacyCallShellActivityName
 		factory = t.runShell
 	case t.task.Run.Workflow != nil:
 		factory = t.runWorkflow
 	default:
 		return nil, fmt.Errorf("unsupported run task: %s", t.GetTaskName())
+	}
+
+	if activityFn != nil {
+		t.activityName = t.registerActivityForTask(activityFn)
+		t.legacyActivityName = legacyName
 	}
 
 	return func(ctx workflow.Context, input any, state *utils.State) (any, error) {
@@ -188,15 +214,18 @@ func (t *RunTaskBuilder) runContainer(ctx workflow.Context, input any, state *ut
 		serviceAccount = t.taskOpts.Run.ServiceAccount
 	}
 
-	return t.executeCommand(ctx, (*activities.Run).CallContainerActivity, input, state, namespace, runtime, serviceAccount)
+	name := dispatchActivityName(ctx, t.legacyActivityName, t.activityName)
+	return t.executeCommand(ctx, name, input, state, namespace, runtime, serviceAccount)
 }
 
 func (t *RunTaskBuilder) runScript(ctx workflow.Context, input any, state *utils.State) (any, error) {
-	return t.executeCommand(ctx, (*activities.Run).CallScriptActivity, input, state)
+	name := dispatchActivityName(ctx, t.legacyActivityName, t.activityName)
+	return t.executeCommand(ctx, name, input, state)
 }
 
 func (t *RunTaskBuilder) runShell(ctx workflow.Context, input any, state *utils.State) (any, error) {
-	return t.executeCommand(ctx, (*activities.Run).CallShellActivity, input, state)
+	name := dispatchActivityName(ctx, t.legacyActivityName, t.activityName)
+	return t.executeCommand(ctx, name, input, state)
 }
 
 func (t *RunTaskBuilder) runWorkflow(ctx workflow.Context, input any, state *utils.State) (any, error) {

--- a/pkg/zigflow/tasks/task_builder_run_test.go
+++ b/pkg/zigflow/tasks/task_builder_run_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
 	"github.com/zigflow/zigflow/pkg/zigflow/flow"
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
@@ -391,8 +392,11 @@ func TestRunTaskBuilderRunScriptExecutesActivity(t *testing.T) {
 	assert.NoError(t, err)
 
 	state := utils.NewState()
+	// Per-task registration: Build() dispatches by per-task name; the
+	// testsuite needs the activity registered under that name to resolve.
+	env.RegisterActivityWithOptions(runActivities.CallScriptActivity, activity.RegisterOptions{Name: "script-task"})
 	env.OnActivity(
-		runActivities.CallScriptActivity,
+		"script-task",
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
@@ -564,11 +568,12 @@ func TestRunTaskBuilderRunContainerPassesRuntimeOptions(t *testing.T) {
 
 	state := utils.NewState()
 
+	env.RegisterActivityWithOptions(runActivities.CallContainerActivity, activity.RegisterOptions{Name: "container-task"})
 	// Matchers: ctx, task, input, state, namespace, runtime, serviceAccount.
 	// The runtime arg is the strongly typed activities.ContainerRuntime, so the
 	// matcher must use the same type rather than the raw string value.
 	env.OnActivity(
-		runActivities.CallContainerActivity,
+		"container-task",
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
@@ -619,8 +624,9 @@ func TestRunTaskBuilderRunContainerPassesEmptyRuntimeOptionsWhenTaskOptsNil(t *t
 
 	state := utils.NewState()
 
+	env.RegisterActivityWithOptions(runActivities.CallContainerActivity, activity.RegisterOptions{Name: "container-task"})
 	env.OnActivity(
-		runActivities.CallContainerActivity,
+		"container-task",
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
@@ -660,8 +666,9 @@ func TestRunTaskBuilderRunShellExecutesActivity(t *testing.T) {
 	assert.NoError(t, err)
 
 	state := utils.NewState()
+	env.RegisterActivityWithOptions(runActivities.CallShellActivity, activity.RegisterOptions{Name: "shell-task"})
 	env.OnActivity(
-		runActivities.CallShellActivity,
+		"shell-task",
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
@@ -681,4 +688,115 @@ func TestRunTaskBuilderRunShellExecutesActivity(t *testing.T) {
 	assert.Equal(t, "shell-success", result)
 
 	assert.Equal(t, "shell-success", state.Data["shell-task"])
+}
+
+func TestRunTaskBuilderRegistersPerTaskActivityName(t *testing.T) {
+	cases := []struct {
+		name        string
+		makeTask    func() *model.RunTask
+		taskName    string
+		expectedReg string
+	}{
+		{
+			name: "container variant",
+			makeTask: func() *model.RunTask {
+				return &model.RunTask{
+					Run: model.RunTaskConfiguration{
+						Await:     utils.Ptr(true),
+						Container: &model.Container{Image: "busybox:latest"},
+					},
+				}
+			},
+			taskName:    "runContainer",
+			expectedReg: "wf-run.runContainer",
+		},
+		{
+			name: "script variant",
+			makeTask: func() *model.RunTask {
+				return &model.RunTask{
+					Run: model.RunTaskConfiguration{
+						Await: utils.Ptr(true),
+						Script: &model.Script{
+							Language:   constScriptLanguagePython,
+							InlineCode: utils.Ptr("print(1)"),
+						},
+					},
+				}
+			},
+			taskName:    "runScript",
+			expectedReg: "wf-run.runScript",
+		},
+		{
+			name: "shell variant",
+			makeTask: func() *model.RunTask {
+				return &model.RunTask{
+					Run: model.RunTaskConfiguration{
+						Await: utils.Ptr(true),
+						Shell: &model.Shell{Command: "echo hello"},
+					},
+				}
+			},
+			taskName:    "runShell",
+			expectedReg: "wf-run.runShell",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := &model.Workflow{Document: model.Document{Name: "wf-run"}}
+
+			w := new(WorkflowRegistryMock)
+			w.
+				On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{
+					Name: tc.expectedReg,
+				}).
+				Once()
+
+			b, err := NewRunTaskBuilder(w, tc.makeTask(), tc.taskName, doc, testEvents, nil)
+			require.NoError(t, err)
+			require.NoError(t, b.PostLoad())
+
+			_, err = b.Build()
+			assert.NoError(t, err)
+			w.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRunTaskBuilderWorkflowVariantDoesNotRegisterActivity(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-run-child"}}
+	task := &model.RunTask{
+		Run: model.RunTaskConfiguration{
+			Await:    utils.Ptr(true),
+			Workflow: &model.RunWorkflow{Namespace: constDefaultNamespace, Name: "child", Version: testConstRunWorkflowVersion},
+		},
+	}
+
+	w := new(WorkflowRegistryMock)
+	// no .On("RegisterActivityWithOptions", ...): runWorkflow uses a child workflow, not an activity
+
+	b, err := NewRunTaskBuilder(w, task, "runWf", doc, testEvents, nil)
+	require.NoError(t, err)
+	require.NoError(t, b.PostLoad())
+
+	_, err = b.Build()
+	assert.NoError(t, err)
+	w.AssertExpectations(t)
+}
+
+func TestRunTaskBuilderBuildWithoutWorker(t *testing.T) {
+	doc := &model.Workflow{Document: model.Document{Name: "wf-run-nil-worker"}}
+	task := &model.RunTask{
+		Run: model.RunTaskConfiguration{
+			Await: utils.Ptr(true),
+			Shell: &model.Shell{Command: "echo hello"},
+		},
+	}
+
+	b, err := NewRunTaskBuilder(nil, task, "step", doc, testEvents, nil)
+	require.NoError(t, err)
+	require.NoError(t, b.PostLoad())
+
+	fn, err := b.Build()
+	assert.NoError(t, err)
+	assert.NotNil(t, fn)
 }

--- a/pkg/zigflow/tasks/task_builder_test.go
+++ b/pkg/zigflow/tasks/task_builder_test.go
@@ -183,7 +183,7 @@ func TestNewTaskBuilderFactory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			builder, err := NewTaskBuilder(tc.name, tc.task, nil, doc, testEvents, nil)
+			builder, err := NewTaskBuilder(tc.name, tc.task, nil, doc, testEvents, nil, []string{tc.name})
 			if tc.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, builder)

--- a/pkg/zigflow/tasks/task_builder_try.go
+++ b/pkg/zigflow/tasks/task_builder_try.go
@@ -69,7 +69,7 @@ func (t *TryTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 			return nil, fmt.Errorf("error building for workflow: %w", err)
 		}
 
-		if taskType == "try" {
+		if taskType == tryBodyPathSegment {
 			t.tryChildWorkflowName = name
 		} else {
 			t.catchChildWorkflowName = name
@@ -253,8 +253,8 @@ func (t *TryTaskBuilder) exec() (TemporalWorkflowFunc, error) {
 
 func (t *TryTaskBuilder) getTasks() map[string]*model.TaskList {
 	return map[string]*model.TaskList{
-		"try":   t.task.Try,
-		"catch": t.task.Catch.Do,
+		tryBodyPathSegment:   t.task.Try,
+		catchBodyPathSegment: t.task.Catch.Do,
 	}
 }
 
@@ -270,7 +270,11 @@ func (t *TryTaskBuilder) createBuilder(
 
 	childWorkflowName = utils.GenerateChildWorkflowName(taskType, t.GetTaskName())
 
-	b, err := NewTaskBuilder(childWorkflowName, &model.DoTask{Do: list}, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts)
+	childPath := t.childTaskPath(taskType)
+	b, err := NewTaskBuilder(
+		childWorkflowName, &model.DoTask{Do: list},
+		t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, childPath,
+	)
 	if err != nil {
 		l.Error().Msg("Error creating the for task builder")
 		err = fmt.Errorf("error creating the for task builder: %w", err)

--- a/pkg/zigflow/workflow_builder_test.go
+++ b/pkg/zigflow/workflow_builder_test.go
@@ -38,9 +38,10 @@ func (stubWorker) RegisterWorkflowWithOptions(_ any, _ workflow.RegisterOptions)
 func (stubWorker) RegisterWorkflow(_ any)                                        {}
 func (stubWorker) RegisterActivity(_ any)                                        { panic("unimplemented") }
 
-func (stubWorker) RegisterActivityWithOptions(_ any, _ activity.RegisterOptions) {
-	panic("unimplemented")
-}
+// Per-task activity registration in CallHTTP/CallGRPC/Run task builders
+// calls this at Build time; accept and discard so build/normalisation
+// tests can run without a real worker.
+func (stubWorker) RegisterActivityWithOptions(_ any, _ activity.RegisterOptions) {}
 
 func (stubWorker) RegisterDynamicActivity(_ any, _ activity.DynamicRegisterOptions) {
 	panic("unimplemented")


### PR DESCRIPTION
## Description

`call: http`, `call: grpc` and `run:` tasks currently all register a single Go-level activity per type (`CallHTTPActivity`, `CallGRPCActivity`, `CallContainerActivity`, `CallScriptActivity`, `CallShellActivity`), so Temporal's SDK metrics emit a fixed `activity_type` for every call regardless of which YAML task ran. In a workflow with several such tasks the metric labels are indistinguishable, so dashboards and alerts cannot attribute duration, error rate or retry counts to a specific task.

This PR additionally registers each task's activity under a name derived from the task's path through the workflow tree and dispatches via the string name. Temporal's SDK metrics then carry a per-task `activity_type` label natively, with no custom metric code, no new metric names and no changes inside the activity body.

For a task at the top of a workflow's `do:` list, the name is `<workflowType>.<taskName>` (for example `call-http.getUser`). For nested tasks, the path includes each parent's name — `step` inside a `for:` task `loop` registers as `<workflowType>.loop.step`. This is necessary for correctness as well as observability: task names are only required to be unique within their own scope, so before the path was threaded, two nested subtrees containing a leaf-named `step` would register under the same name and the dedup helper would silently drop the second registration, causing dispatch to route to the wrong activity implementation (raised by @mrsimonemms in review).

### Approach

- Registration happens in the task builder's `Build` method. `DoTaskBuilder.Build` already recurses through nested `do`/`for`/`try`/`fork` blocks calling each child's `Build`, so registration at builder construction naturally walks the whole task tree without a separate YAML walker.
- Two helpers on the base `builder[T]` keep this generic across task types:
  - `registerActivityForTask(fn)` computes `<workflowType>.<dot-joined-path>` and registers `fn` on the worker; returns the name.
  - `buildActivityFunc(fn)` is a thin wrapper that registers and returns a `TemporalWorkflowFunc` dispatching by that name; HTTP and gRPC `Build` methods become one-liners.
- `RunTaskBuilder` picks one of Container/Script/Shell sub-activities based on YAML and uses `registerActivityForTask` directly (`buildActivityFunc` does not fit the multi-sub-activity shape). `run.workflow` is unchanged because it is a child workflow, not an activity.
- Each task builder gains a `taskPath []string` on the base, threaded by the `NewTaskBuilder` factory via a small `taskPathSetter` interface. Containers compute child paths when constructing children:
  - `Do`: `t.childTaskPath(task.Key)` per child
  - `Fork`: `t.childTaskPath(branch.Key)` per branch
  - `For`: passes its own path to the synthetic body wrapper
  - `Try`: `t.childTaskPath("try")` / `t.childTaskPath("catch")` to disambiguate the two bodies
- `ForTaskBuilder.Build` constructs its inner body via `NewDoTaskBuilder` directly (to pass `DoTaskOpts{DisableRegisterWorkflow: true}`), so it bypasses the factory's path setter; the path is applied explicitly after construction. A regression test covers this case.
- A small `registerActivityOnce` helper backed by a `sync.Map` keyed on `(worker, name)` dedups repeated `Build` invocations across `PostLoad`/`Validate`/`Build` phases. Temporal's `RegisterActivityWithOptions` panics on duplicate registrations, so dedup is required for correctness.
- Path is always rooted at the parent workflow's document, so synthetic For/Try/Fork child workflows share the parent namespace; independent `run.workflow` invocations get their own namespace via their own `NewWorkflow` registration.

### Compatibility

**Workflow execution: compatible.** Existing YAML workflows run identically. No user-facing change required.

**Go-level activity registration: compatible.** The original `&CallHTTP{}`, `&CallGRPC{}` and `&Run{}` registrations in `cmd/run/workers.go` are left untouched, so external code dispatching by Go function reference (or by the legacy string name `CallHTTPActivity` / `CallGRPCActivity` / `CallContainerActivity` / `CallScriptActivity` / `CallShellActivity`) continues to resolve.

**Prometheus metric labels: BREAKING CHANGE for consumers.** The `activity_type` label on Temporal SDK metrics changes from a fixed per-transport value (e.g. `CallHTTPActivity`) to a per-task value (`<workflowType>.<task-path>`). Dashboards, alerts or recording rules filtering on the legacy single-value labels will go empty after this lands.

This change is the whole point of the PR — the legacy labels are exactly the observability bug being fixed. Anyone with downstream consumers should migrate their queries to:

```promql
# Before
temporal_activity_execution_latency_seconds_count{activity_type="CallHTTPActivity"}

# After (match any per-task name in a workflow)
temporal_activity_execution_latency_seconds_count{
  activity_type=~".+\\..+",
  workflow_type="<your workflow>"
}

# Or aggregate across all tasks of one workflow
sum by (workflow_type) (
  rate(temporal_activity_execution_latency_seconds_count[5m])
)
```

### Test code compatibility

Tests that previously mocked these activities by Go function reference (e.g. `env.OnActivity(runActivities.CallShellActivity, ...)`) need to switch to registering under the per-task name and mocking by string. See the updated tests in `task_builder_run_test.go` for the pattern.

### Cardinality

YAML task paths are static identifiers in workflow definitions. The set of distinct `<workflowType>.<dot-joined-path>` per worker is bounded and known at worker startup, so label cardinality stays the same order as the number of HTTP/gRPC/Run tasks across loaded workflows. Well within safe Prometheus territory.

### Scope

Covers `call: http`, `call: grpc` and `run:` (Container, Script, Shell). `run.workflow` is intentionally untouched (child workflow, not an activity).

### End-to-end verification

Ran a local Temporal `start-dev` server, started the worker built from this branch with `--metrics-listen-address`, triggered each workflow to `WORKFLOW_EXECUTION_STATUS_COMPLETED`, then scraped `/metrics`. (The Temporal SDK's Prometheus reporter sanitises `.` and `-` in label values to `_`.)

**`call: http`** (top-level):

```
temporal_activity_execution_latency_seconds_count{activity_type="demo_multi_http_getFirstPost",  ...} 1
temporal_activity_execution_latency_seconds_count{activity_type="demo_multi_http_getSecondPost", ...} 1
```

**`call: grpc`** (top-level, two tasks calling `Command1` with different `input` arguments):

```
temporal_activity_execution_latency_seconds_count{activity_type="validate_grpc_firstGrpc",  workflow_type="validate_grpc",  ...} 1
temporal_activity_execution_latency_seconds_count{activity_type="validate_grpc_secondGrpc", workflow_type="validate_grpc",  ...} 1
```

**`run:`** (top-level, two `run.script` tasks):

```
temporal_activity_execution_latency_seconds_count{activity_type="validate_run_firstScript",  workflow_type="validate_run",  ...} 1
temporal_activity_execution_latency_seconds_count{activity_type="validate_run_secondScript", workflow_type="validate_run",  ...} 1
```

**Collision case** (two sibling `for:` loops each containing a leaf-named `step` task — one `call: http`, the other `run.shell`):

Before the path fix, the workflow failed with a nil-pointer dereference because both `step` tasks registered as `collision-test.step`; the second registration was silently dropped and the shell `step` dispatched to the HTTP activity, which panicked on shell-specific input. After the fix, the workflow completes and the metrics carry distinct path-qualified labels:

```
temporal_activity_execution_latency_seconds_count{activity_type="collision_test_first_loop_step",  workflow_type="workflow_for_first_loop"}  1
temporal_activity_execution_latency_seconds_count{activity_type="collision_test_second_loop_step", workflow_type="workflow_for_second_loop"} 1
```

Distinct labels per scope, correct activity dispatched per call site.

## Related Issue(s)

Fixes #442

## How to test

- `go test ./pkg/zigflow/tasks/...` — new tests cover per-task name registration, dedup across multiple `Build` invocations and nil-worker safety used by `newWorkflowPrepare`, for HTTP, gRPC and Run (Container, Script, Shell) variants. The `run.workflow` variant is also covered to confirm no activity is registered for child workflows. `task_builder_collision_test.go` adds focused coverage for nested-Do, Try `try`/`catch`, Fork branches, deep nesting, and the For-Build direct-construction edge case.
- End to end: run a workflow with two `call: http` (or `call: grpc`, or `run:`) tasks and Prometheus metrics enabled (`temporal.WithPrometheusMetrics(...)`). Distinct `activity_type` labels should appear for each task. For the collision case, two sibling `for:` loops each containing a same-leaf-name task produce distinct path-qualified labels.