### PR TITLE
feat(mcp): add definition to get_schema for single lookup

### DIFF
--- a/docs/docs/cli/mcp-server.md
+++ b/docs/docs/cli/mcp-server.md
@@ -70,6 +70,10 @@ Returns the Zigflow DSL JSON Schema for the current version. The `output` field
 accepts `"json"` (the default) or `"yaml"`. Use this to understand valid workflow
 structure before generating or validating a definition.
 
+Set the optional `def` field to return a single schema definition from `$defs`,
+for example `{ "def": "taskList" }`. The name must match a `$defs` key exactly.
+Unknown definitions return a tool error.
+
 ### validate_workflow
 
 Validates a workflow YAML string and returns structured errors. The `yaml` field

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -326,7 +326,8 @@ assistants and agents.
 
 Tools:
 
-- `get_schema` retrieves the Zigflow workflow JSON or YAML schema.
+- `get_schema` retrieves the Zigflow workflow JSON or YAML schema. Pass `def`
+  to retrieve one `$defs` entry, for example `{ "def": "taskList" }`.
 - `list_examples` lists the bundled example workflows.
 - `get_example` retrieves a bundled example workflow by name.
 - `validate_workflow` validates a workflow YAML string and returns structured,

--- a/pkg/mcp/get_schema.go
+++ b/pkg/mcp/get_schema.go
@@ -19,6 +19,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -32,7 +33,9 @@ const (
 )
 
 type GetSchemaInput struct {
-	Output string `json:"output" jsonschema:"Output format (json or yaml),enum=json,enum=yaml,default=json"`
+	//nolint:lll // Struct tag contains schema description used by MCP tooling.
+	Definition string `json:"def,omitempty" jsonschema:"Optional schema definition name. If omitted, returns the complete schema document. If provided, returns only the requested definition from $defs."`
+	Output     string `json:"output,omitempty" jsonschema:"Output format (json or yaml),enum=json,enum=yaml,default=json"`
 }
 
 type GetSchemaError struct {
@@ -55,6 +58,8 @@ func (m *MCP) GetSchema(
 		format = outputFormatJSON
 	}
 
+	targetDefinition := strings.TrimSpace(input.Definition)
+
 	if format != outputFormatJSON && format != outputFormatYAML {
 		return nil, GetSchemaOutput{Errors: []GetSchemaError{{
 			Stage:   stageInput,
@@ -68,6 +73,14 @@ func (m *MCP) GetSchema(
 	}
 
 	var res []byte
+	if targetDefinition != "" {
+		if def, ok := s.Defs[targetDefinition]; ok {
+			s = def
+		} else {
+			return nil, GetSchemaOutput{}, fmt.Errorf("definition (%s) is not set", targetDefinition)
+		}
+	}
+
 	switch format {
 	case outputFormatYAML:
 		res, err = yaml.Marshal(s)

--- a/pkg/mcp/get_schema_test.go
+++ b/pkg/mcp/get_schema_test.go
@@ -44,7 +44,7 @@ func TestGetSchema_EmptyOutputDefaultsToJSON(t *testing.T) {
 
 func TestGetSchema_JSONOutput(t *testing.T) {
 	m := newTestMCP()
-	_, out, err := m.GetSchema(context.Background(), nil, GetSchemaInput{Output: "json"})
+	_, out, err := m.GetSchema(context.Background(), nil, GetSchemaInput{Output: outputFormatJSON})
 	require.NoError(t, err)
 	require.Empty(t, out.Errors)
 	require.NotEmpty(t, out.Schema)
@@ -58,7 +58,7 @@ func TestGetSchema_JSONOutput(t *testing.T) {
 
 func TestGetSchema_YAMLOutput(t *testing.T) {
 	m := newTestMCP()
-	_, out, err := m.GetSchema(context.Background(), nil, GetSchemaInput{Output: "yaml"})
+	_, out, err := m.GetSchema(context.Background(), nil, GetSchemaInput{Output: outputFormatYAML})
 	require.NoError(t, err)
 	require.Empty(t, out.Errors)
 	require.NotEmpty(t, out.Schema)
@@ -69,6 +69,51 @@ func TestGetSchema_YAMLOutput(t *testing.T) {
 	// $id key is present in the raw schema string since yaml.Unmarshal does not
 	// map $ prefixed keys into a plain Go map reliably.
 	assert.Contains(t, out.Schema, "schema.yaml", "schema ID must use yaml format")
+}
+
+func TestGetSchema_DefinitionOutput(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		unmarshal func([]byte, interface{}) error
+	}{
+		{"json", outputFormatJSON, json.Unmarshal},
+		{"yaml", outputFormatYAML, yaml.Unmarshal},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMCP()
+			_, out, err := m.GetSchema(context.Background(), nil, GetSchemaInput{
+				Definition: "taskList",
+				Output:     tc.output,
+			})
+			require.NoError(t, err)
+			require.Empty(t, out.Errors)
+			require.NotEmpty(t, out.Schema)
+
+			var parsed map[string]interface{}
+			require.NoError(t, tc.unmarshal([]byte(out.Schema), &parsed),
+				"schema definition must be valid %s", tc.output)
+
+			assert.Equal(t, "TaskList", parsed["title"])
+			assert.Equal(t, "array", parsed["type"])
+			assert.NotContains(t, parsed, "$defs", "definition lookup must return the requested definition only")
+			assert.NotContains(t, parsed, "$id", "definition lookup must not return the complete schema document")
+		})
+	}
+}
+
+func TestGetSchema_UnknownDefinition_ReturnsToolError(t *testing.T) {
+	m := newTestMCP()
+	_, out, err := m.GetSchema(context.Background(), nil, GetSchemaInput{
+		Definition: "not-set",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "definition (not-set) is not set")
+	assert.Empty(t, out.Errors)
+	assert.Empty(t, out.Schema)
 }
 
 func TestGetSchema_InvalidOutput_InputError(t *testing.T) {

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -175,17 +175,27 @@ func New(server *mcp.Server, version string) *MCP {
 		version: version,
 	}
 
+	idempotentAnnotations := &mcp.ToolAnnotations{
+		ReadOnlyHint:    true,
+		DestructiveHint: new(false),
+		IdempotentHint:  true,
+		OpenWorldHint:   new(false),
+	}
+
 	mcp.AddTool(server, &mcp.Tool{
 		Name:  "get_schema",
 		Title: "Get Schema",
 		Description: "Returns the Zigflow workflow JSON schema for the current version. Use this to understand valid " +
-			"workflow structure before generating or validating YAML.",
+			"workflow structure before generating or validating YAML. If a schema definition name is provided, only " +
+			"that definition is returned.",
+		Annotations: idempotentAnnotations,
 	}, m.GetSchema)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_example",
 		Title:       "Get Example",
 		Description: "Returns a Zigflow example by name, including its YAML content and metadata.",
+		Annotations: idempotentAnnotations,
 	}, m.GetExample)
 
 	mcp.AddTool(server, &mcp.Tool{
@@ -193,12 +203,14 @@ func New(server *mcp.Server, version string) *MCP {
 		Title: "List Examples",
 		Description: "Lists the bundled Zigflow workflow examples with short descriptions and tags. " +
 			"Use this to discover available examples before calling get_example.",
+		Annotations: idempotentAnnotations,
 	}, m.ListExamples)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "validate_workflow",
 		Title:       "Validate Workflow",
 		Description: "Validates a Zigflow workflow YAML string and returns structured errors by stage.",
+		Annotations: idempotentAnnotations,
 	}, m.ValidateWorkflow)
 
 	return m


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Implements the ability to get a specific schema definition in the MCP server

## Related issue
<!-- Most changes should be discussed in an issue before implementation. -->
<!-- Link the issue using Fixes #..., Closes #... or Relates to #... -->
<!-- If no issue exists, explain why. -->

Fixes #475

## How to test

<!-- Provide the steps used to verify this change -->

## Checklist

* [x] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
* [x] All tests pass
* [x] Tests have been added or updated where behaviour changed
* [x] Documentation has been updated where needed
