### PR TITLE
fix: normalise temporal metadata times for runtime expressions

### DIFF
--- a/pkg/utils/state.go
+++ b/pkg/utils/state.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"maps"
 
 	swUtils "github.com/serverlessworkflow/sdk-go/v3/impl/utils"
@@ -51,6 +52,24 @@ func (s *State) AddData(data map[string]any) *State {
 	return s
 }
 
+// jsonNormalize converts a metadata map to JSON-native types (string, number,
+// bool, []any, map[string]any) so it is safe to evaluate with gojq, which
+// panics on any other Go type. The map is round-tripped through JSON, so each
+// value is rendered the way gojq will see it. The transform is pure and
+// deterministic, so it is replay-safe; on marshal/unmarshal error the original
+// map is returned unchanged.
+func jsonNormalize(m map[string]any) map[string]any {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return m
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return m
+	}
+	return out
+}
+
 func (s *State) AddActivityInfo(ctx context.Context) *State {
 	info := activity.GetInfo(ctx)
 
@@ -78,7 +97,7 @@ func (s *State) AddActivityInfo(ctx context.Context) *State {
 	}
 
 	s.AddData(map[string]any{
-		"activity": activityData,
+		"activity": jsonNormalize(activityData),
 	})
 
 	return s
@@ -116,7 +135,7 @@ func (s *State) AddWorkflowInfo(ctx workflow.Context) *State {
 	}
 
 	s.AddData(map[string]any{
-		"workflow": workflowData,
+		"workflow": jsonNormalize(workflowData),
 	})
 
 	return s

--- a/pkg/utils/state_test.go
+++ b/pkg/utils/state_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// Regression test for the gojq "invalid type: time.Time" panic: Temporal
+// metadata carries time.Time / time.Duration values, which gojq cannot handle.
+// jsonNormalize must convert them to JSON-native types so runtime expressions
+// can reference them (e.g. $data.workflow.workflow_start_time).
+func TestWorkflowMetadataTimeFieldsAreJQUsable(t *testing.T) {
+	ts := time.Date(2026, 6, 25, 20, 56, 48, 0, time.UTC)
+	state := NewState()
+	state.AddData(map[string]any{
+		"workflow": jsonNormalize(map[string]any{
+			"workflow_start_time":        ts,
+			"workflow_execution_timeout": 5 * time.Minute,
+		}),
+	})
+
+	// Plain selection must yield the RFC3339 string, not a Go time.Time.
+	got, err := EvaluateString("${ $data.workflow.workflow_start_time }", nil, state)
+	if err != nil {
+		t.Fatalf("selecting workflow_start_time: %v", err)
+	}
+	if got != "2026-06-25T20:56:48Z" {
+		t.Fatalf("workflow_start_time = %#v, want \"2026-06-25T20:56:48Z\"", got)
+	}
+
+	// A string operation is the real-world failure mode; before the fix this
+	// panicked gojq. It must now succeed.
+	str, err := EvaluateString("${ $data.workflow.workflow_start_time | tostring }", nil, state)
+	if err != nil {
+		t.Fatalf("tostring on workflow_start_time: %v", err)
+	}
+	if str != "2026-06-25T20:56:48Z" {
+		t.Fatalf("tostring(workflow_start_time) = %#v", str)
+	}
+
+	// time.Duration must also be usable (normalised to a number), not panic.
+	if _, err := EvaluateString("${ $data.workflow.workflow_execution_timeout }", nil, state); err != nil {
+		t.Fatalf("selecting workflow_execution_timeout: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #498

## Problem

`$data.workflow` and `$data.activity` expose Temporal metadata fields that are Go `time.Time` / `time.Duration` values (`workflow_start_time`, `scheduled_time`, `started_time`, `deadline`, and the timeout fields). gojq only understands JSON-native types, so any expression that touches them panics with `invalid type: time.Time`. Because it's a Go panic inside gojq (not a jq error), `(expr)? // fallback` can't guard it, and the workflow task retry-loops.

Repro:
```yaml
do:
  - probe:
      set:
        x: ${ $data.workflow.workflow_start_time | tostring }
```

## Fix

`jsonNormalize` the `workflow` / `activity` metadata maps when they're built in `state.go` (once per state, off the per-expression hot path). `time.Time` → RFC3339 string (via its `MarshalJSON`), `time.Duration` → int64 nanoseconds. The transform is pure/deterministic, so it stays replay-safe, and it future-proofs against any other non-JSON metadata field. On marshal error the map is returned unchanged.

## Test

Added `TestWorkflowMetadataTimeFieldsAreJQUsable` (regression): selecting `workflow_start_time` now yields the RFC3339 string and `| tostring` no longer panics; `workflow_execution_timeout` is usable as a number. `go test ./pkg/utils/` passes.

Validated against `v0.13.0`.