### PR TITLE
feat: add now to the activity and workflow info for logging

### DIFF
--- a/docs/docs/dsl/tasks/intro.md
+++ b/docs/docs/dsl/tasks/intro.md
@@ -91,21 +91,30 @@ The `$data` object also receives the workflow and activity info.
 
 This can be accessed from `${ $data.workflow }`.
 
-- attempt
-- binary_checksum
-- continued_execution_run_id
-- cron_schedule
-- first_run_id
-- namespace
-- original_run_id
-- parent_workflow_namespace
-- priority_key
-- task_queue_name
-- workflow_execution_id
-- workflow_execution_run_id
-- workflow_execution_timeout
-- workflow_start_time
-- workflow_type_name
+| Name | Type | Example |
+| ---- | ---- | ------- |
+| `attempt` | int32 | `1` |
+| `binary_checksum` | string | `a1b2c3d4e5f6` |
+| `continued_execution_run_id` | string | `""` (may be empty) |
+| `cron_schedule` | string | `"0 * * * *"` (may be empty) |
+| `first_run_id` | string | `9f8e7d6c-5b4a-3210-fedc-ba9876543210` |
+| `namespace` | string | `default` |
+| `now` | string (RFC3339) | `2026-07-02T14:30:00Z` |
+| `original_run_id` | string | `9f8e7d6c-5b4a-3210-fedc-ba9876543210` |
+| `parent_workflow_namespace` | string | `""` (may be empty) |
+| `priority_key` | int | `0` |
+| `task_queue_name` | string | `zigflow` |
+| `workflow_execution_id` | string | `order-12345` |
+| `workflow_execution_run_id` | string | `1a2b3c4d-5e6f-7890-abcd-ef1234567890` |
+| `workflow_execution_timeout` | number (seconds) | `3600` |
+| `workflow_start_time` | string (RFC3339) | `2026-07-02T14:00:00Z` |
+| `workflow_type_name` | string | `MyWorkflow` |
+
+:::info
+`continued_execution_run_id`, `cron_schedule` and `parent_workflow_namespace`
+are only set for continued, cron or child workflow executions. They are empty
+strings otherwise.
+:::
 
 #### Activity
 
@@ -116,22 +125,25 @@ an activity.
 
 This can be accessed from `${ $data.activity }`.
 
-- activity_id
-- activity_type_name
-- attempt
-- deadline
-- heartbeat_token
-- is_local_activity
-- priority_key
-- schedule_to_close_timeout
-- scheduled_time
-- start_to_close_timeout
-- started_time
-- task_queue
-- task_token
-- workflow_namespace
-- workflow_execution_id
-- workflow_execution_run_id
+| Name | Type | Example |
+| ---- | ---- | ------- |
+| `activity_id` | string | `5` |
+| `activity_type_name` | string | `CallActivity` |
+| `attempt` | int32 | `1` |
+| `deadline` | string (RFC3339) | `2026-07-02T14:35:00Z` |
+| `heartbeat_token` | number (seconds) | `10` |
+| `is_local_activity` | bool | `false` |
+| `now` | string (RFC3339) | `2026-07-02T14:30:00Z` |
+| `priority_key` | int | `0` |
+| `schedule_to_close_timeout` | number (seconds) | `60` |
+| `scheduled_time` | string (RFC3339) | `2026-07-02T14:30:00Z` |
+| `start_to_close_timeout` | number (seconds) | `30` |
+| `started_time` | string (RFC3339) | `2026-07-02T14:30:01Z` |
+| `task_queue` | string | `zigflow` |
+| `task_token` | string | `CiQx...` |
+| `workflow_namespace` | string | `default` |
+| `workflow_execution_id` | string | `order-12345` |
+| `workflow_execution_run_id` | string | `1a2b3c4d-5e6f-7890-abcd-ef1234567890` |
 
 ## Flow Directive
 

--- a/pkg/utils/state.go
+++ b/pkg/utils/state.go
@@ -26,6 +26,11 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+const (
+	stateNow      = "now"
+	stateWorkflow = "workflow"
+)
+
 type State struct {
 	CANStartFrom *string        `json:"canStartFrom,omitempty"` // Continue-as-new from here
 	Context      any            `json:"context"`                // Output data exported to later tasks output
@@ -62,6 +67,7 @@ func (s *State) AddActivityInfo(ctx context.Context) *State {
 		"deadline":                  info.Deadline.UTC().Format(time.RFC3339),
 		"heartbeat_token":           info.HeartbeatTimeout.Seconds(),
 		"is_local_activity":         info.IsLocalActivity,
+		stateNow:                    time.Now().UTC().Format(time.RFC3339),
 		"priority_key":              info.Priority.PriorityKey,
 		"schedule_to_close_timeout": info.ScheduleToCloseTimeout.Seconds(),
 		"scheduled_time":            info.ScheduledTime.UTC().Format(time.RFC3339),
@@ -117,8 +123,20 @@ func (s *State) AddWorkflowInfo(ctx workflow.Context) *State {
 	}
 
 	s.AddData(map[string]any{
-		"workflow": workflowData,
+		stateWorkflow: workflowData,
 	})
+
+	return s
+}
+
+func (s *State) AddWorkflowNow(ctx workflow.Context) *State {
+	e, ok := s.Data[stateWorkflow].(map[string]any)
+	if !ok {
+		s.AddWorkflowInfo(ctx)
+		e = s.Data[stateWorkflow].(map[string]any)
+	}
+
+	e[stateNow] = workflow.Now(ctx).UTC().Format(time.RFC3339)
 
 	return s
 }

--- a/pkg/utils/state_test.go
+++ b/pkg/utils/state_test.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+// addWorkflowNowTestWorkflow exercises AddWorkflowNow the way task execution
+// does: once after AddWorkflowInfo, then again later in the run, mimicking
+// it being called at each task's execution point.
+func addWorkflowNowTestWorkflow(ctx workflow.Context) (map[string]string, error) {
+	s := NewState()
+	s.AddWorkflowInfo(ctx)
+	s.AddWorkflowNow(ctx)
+
+	first, _ := s.Data[stateWorkflow].(map[string]any)
+	firstNow, _ := first[stateNow].(string)
+
+	if err := workflow.Sleep(ctx, time.Second); err != nil {
+		return nil, err
+	}
+
+	s.AddWorkflowNow(ctx)
+	second, _ := s.Data[stateWorkflow].(map[string]any)
+	secondNow, _ := second[stateNow].(string)
+
+	return map[string]string{
+		"first_now":  firstNow,
+		"second_now": secondNow,
+	}, nil
+}
+
+func TestAddWorkflowNow_SetsRFC3339Timestamp(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	env.ExecuteWorkflow(addWorkflowNowTestWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result map[string]string
+	require.NoError(t, env.GetWorkflowResult(&result))
+
+	firstNow, ok := result["first_now"]
+	require.True(t, ok, "$data.workflow.now should be present after AddWorkflowNow")
+	_, err := time.Parse(time.RFC3339, firstNow)
+	assert.NoError(t, err, "$data.workflow.now must be RFC3339-formatted")
+
+	secondNow, ok := result["second_now"]
+	require.True(t, ok, "$data.workflow.now should still be present on a later call")
+	_, err = time.Parse(time.RFC3339, secondNow)
+	assert.NoError(t, err, "$data.workflow.now must be RFC3339-formatted")
+
+	// The test environment auto-skips time across the Sleep, so calling
+	// AddWorkflowNow again should reflect a later (or equal) instant,
+	// confirming repeated calls keep the field fresh.
+	assert.GreaterOrEqual(t, secondNow, firstNow)
+}
+
+func TestAddWorkflowNow_BeforeAddWorkflowInfo(t *testing.T) {
+	// AddWorkflowNow is normally called after AddWorkflowInfo, but it must
+	// not panic if the ordering is violated, and it should end up seeding
+	// the full workflow info map (not just "now").
+	workflowFn := func(ctx workflow.Context) (map[string]any, error) {
+		s := NewState()
+		s.AddWorkflowNow(ctx)
+
+		wf, ok := s.Data[stateWorkflow].(map[string]any)
+		require.True(t, ok)
+
+		return wf, nil
+	}
+
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var wf map[string]any
+	require.NoError(t, env.GetWorkflowResult(&wf))
+
+	now, ok := wf[stateNow].(string)
+	require.True(t, ok, "$data.workflow.now should be present")
+	_, err := time.Parse(time.RFC3339, now)
+	assert.NoError(t, err)
+
+	// Confirm AddWorkflowInfo's fields were seeded too, not just "now".
+	_, ok = wf["workflow_execution_id"]
+	assert.True(t, ok, "AddWorkflowNow should seed the rest of $data.workflow when missing")
+}
+
+func TestState_GetAsMap_ExposesWorkflowNow(t *testing.T) {
+	// Runtime expressions read the state via GetAsMap ($data.workflow.now),
+	// so verify the field survives that path, not just the raw Data map.
+	workflowFn := func(ctx workflow.Context) (map[string]any, error) {
+		s := NewState()
+		s.AddWorkflowInfo(ctx)
+		s.AddWorkflowNow(ctx)
+		return s.GetAsMap(), nil
+	}
+
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var asMap map[string]any
+	require.NoError(t, env.GetWorkflowResult(&asMap))
+
+	data, ok := asMap["$data"].(map[string]any)
+	require.True(t, ok)
+
+	wf, ok := data[stateWorkflow].(map[string]any)
+	require.True(t, ok, "$data.workflow should be present")
+
+	now, ok := wf[stateNow].(string)
+	require.True(t, ok, "$data.workflow.now should be present")
+
+	_, err := time.Parse(time.RFC3339, now)
+	assert.NoError(t, err, "$data.workflow.now must be RFC3339-formatted")
+}
+
+func addActivityInfoTestActivity(ctx context.Context) (map[string]any, error) {
+	s := NewState()
+	s.AddActivityInfo(ctx)
+
+	activityData, _ := s.Data["activity"].(map[string]any)
+	return activityData, nil
+}
+
+func TestAddActivityInfo_SetsRFC3339Now(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestActivityEnvironment()
+	env.RegisterActivity(addActivityInfoTestActivity)
+
+	val, err := env.ExecuteActivity(addActivityInfoTestActivity)
+	require.NoError(t, err)
+
+	var activityData map[string]any
+	require.NoError(t, val.Get(&activityData))
+
+	now, ok := activityData[stateNow].(string)
+	require.True(t, ok, "$data.activity.now should be present")
+
+	_, err = time.Parse(time.RFC3339, now)
+	assert.NoError(t, err, "$data.activity.now must be RFC3339-formatted")
+}

--- a/pkg/zigflow/tasks/task_builder_do.go
+++ b/pkg/zigflow/tasks/task_builder_do.go
@@ -291,6 +291,10 @@ func (t *DoTaskBuilder) iterateTasks(
 
 	for i, task := range tasks {
 		taskID := fmt.Sprintf("%s-%d", task.GetTaskName(), i)
+
+		logger.Debug("Set current workflow time", "taskID", taskID, "workflow", t.name)
+		state = state.AddWorkflowNow(ctx)
+
 		if t.shouldContinueAsNew(ctx) {
 			logger.Debug("Task continue-as-new", "taskID", taskID, "workflow", t.name)
 			return t.continueAsNew(ctx, t.name, taskID, input, state)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds `workflow.now` and `activity.now` to the `$data`. The workflow time iterates through with every invocation of a task so, whilst it may not be _EXACTLY_ now, it's close enough and [deterministic](https://pkg.go.dev/go.temporal.io/sdk/workflow#Now).

## Related issue
<!-- Most changes should be discussed in an issue before implementation. -->
<!-- Link the issue using Fixes #..., Closes #... or Relates to #... -->
<!-- If no issue exists, explain why. -->

From https://github.com/zigflow/zigflow/issues/498#issuecomment-4867573588

## How to test

<!-- Provide the steps used to verify this change -->

## Checklist

* [x] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
* [x] All tests pass
* [x] Tests have been added or updated where behaviour changed
* [x] Documentation has been updated where needed
