### PR TITLE
fix(chart): emit GA TWC CRD kinds (Connection, WorkerDeployment)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,2 @@
 Shlomit Manor <33759493+ShlomitSibony@users.noreply.github.com> <33759493+ShlomitSibony@users.noreply.github.com>
+404prefrontalcortexnotfound <404prefrontalcortexnotfound@users.noreply.github.com> <106208474+404prefrontalcortexnotfound@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@
 # This file lists all contributors to the repository.
 # See scripts/generate-authors.sh to make modifications.
 
+404prefrontalcortexnotfound <404prefrontalcortexnotfound@users.noreply.github.com>
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Dimsi <dimosh3k@gmail.com>
 Hynek <dimosh3k@gmail.com>

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -151,7 +151,7 @@ tasks:
       - |
         minikube profile list | grep minikube | grep OK || minikube start
       - kubectl apply -f ./dev/k8s/
-      # Install Temporal Worker Controler - https://github.com/temporalio/temporal-worker-controller
+      # Install Temporal Worker Controller - https://github.com/temporalio/temporal-worker-controller
       - helm upgrade
           --cleanup-on-fail
           --create-namespace
@@ -168,7 +168,7 @@ tasks:
           --install
           --namespace zigflow
           --rollback-on-failure
-          --version ^0.24.0
+          --version ^0.26.0
           --wait
           temporal-worker-controller-crds oci://docker.io/temporalio/temporal-worker-controller-crds
       - helm upgrade
@@ -178,7 +178,7 @@ tasks:
           --namespace zigflow
           --rollback-on-failure
           --set replicas=1
-          --version ^0.24.0
+          --version ^0.26.0
           --wait
           temporal-worker-controller oci://docker.io/temporalio/temporal-worker-controller
 

--- a/charts/zigflow/templates/_helpers.tpl
+++ b/charts/zigflow/templates/_helpers.tpl
@@ -90,7 +90,7 @@ workload pods do not inherit the worker's control-plane RBAC.
 {{- end }}
 
 {{/*
-Render the shared Pod template used by both Deployment and TemporalWorkerDeployment.
+Render the shared Pod template used by both Deployment and WorkerDeployment.
 */}}
 {{- define "zigflow.podTemplate" -}}
 template:

--- a/charts/zigflow/templates/autoscaling.yaml
+++ b/charts/zigflow/templates/autoscaling.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "zigflow.labels" . | nindent 4 }}
 spec:
-  temporalWorkerDeploymentRef:
+  workerDeploymentRef:
     name: {{ include "zigflow.fullname" . }}
   template:
     apiVersion: autoscaling/v2

--- a/charts/zigflow/templates/controller.yaml
+++ b/charts/zigflow/templates/controller.yaml
@@ -8,7 +8,7 @@
 {{- end }}
 
 apiVersion: temporal.io/v1alpha1
-kind: TemporalConnection
+kind: Connection
 metadata:
   name: {{ include "zigflow.fullname" . }}
   labels:
@@ -26,7 +26,7 @@ spec:
   {{- end }}
 ---
 apiVersion: temporal.io/v1alpha1
-kind: TemporalWorkerDeployment
+kind: WorkerDeployment
 metadata:
   name: {{ include "zigflow.fullname" . }}
   labels:

--- a/charts/zigflow/tests/controller_test.yaml
+++ b/charts/zigflow/tests/controller_test.yaml
@@ -1,0 +1,55 @@
+suite: controller (TWC) rendering
+
+release:
+  name: zigflow
+
+tests:
+  - it: does not render TWC resources when the controller is disabled
+    set:
+      controller.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+    template: templates/controller.yaml
+
+  - it: renders the GA TWC kinds (Connection and WorkerDeployment, not the pre-v1.7.0 deprecated kinds)
+    set:
+      controller.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: temporal.io/v1alpha1
+      - documentIndex: 0
+        isKind:
+          of: Connection
+      - documentIndex: 1
+        equal:
+          path: apiVersion
+          value: temporal.io/v1alpha1
+      - documentIndex: 1
+        isKind:
+          of: WorkerDeployment
+      - documentIndex: 1
+        equal:
+          path: spec.workerOptions.connectionRef.name
+          value: zigflow
+    template: templates/controller.yaml
+
+  - it: references the WorkerDeployment via workerDeploymentRef in autoscaling mode
+    set:
+      controller.enabled: true
+      autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: WorkerResourceTemplate
+      - equal:
+          path: spec.workerDeploymentRef.name
+          value: zigflow
+      - notExists:
+          path: spec.temporalWorkerDeploymentRef
+    template: templates/autoscaling.yaml

--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -315,8 +315,13 @@ For standard production deployments, the default `Deployment` mode is sufficient
 Zigflow does not install Temporal Worker Controller, its CRDs or cert-manager.
 You must install and manage these yourself before enabling TWC in the chart:
 
-- Temporal Worker Controller and its CRDs
+- Temporal Worker Controller and its CRDs, chart version `0.26.0` or newer
+  (controller `v1.7.0` or newer)
 - [cert-manager](https://cert-manager.io/) (required by TWC)
+
+Zigflow renders GA TWC resources (`Connection`, `WorkerDeployment` and
+`workerDeploymentRef`). Earlier TWC chart versions only support the deprecated
+pre-GA resource names and will fail to apply this chart's TWC mode.
 
 Zigflow only renders the CRDs that TWC consumes. It does not install or manage TWC.
 
@@ -335,14 +340,14 @@ controller:
 
 When enabled, the chart renders:
 
-- `TemporalConnection`: connection configuration consumed by TWC
-- `TemporalWorkerDeployment`: worker definition with rollout and sunset settings
+- `Connection`: connection configuration consumed by TWC
+- `WorkerDeployment`: worker definition with rollout and sunset settings
 
 No standard Kubernetes `Deployment` is created.
 
 ### Connection and authentication
 
-The `TemporalConnection` resource configures how TWC connects to Temporal.
+The `Connection` resource configures how TWC connects to Temporal.
 This is separate from the `config` map used for Zigflow's own connection settings.
 
 **No authentication (cluster-local Temporal):**


### PR DESCRIPTION
**Problem** — temporal-worker-controller v1.7.0 (the GA release) renamed `TemporalConnection` → `Connection` and `TemporalWorkerDeployment` → `WorkerDeployment`, and blocks creation of the deprecated kinds via a CRD CEL transition rule (`oldSelf.hasValue()`), e.g.:

```
TemporalConnection is deprecated and cannot be created. Use Connection instead.
```

With `controller.enabled: true`, the chart still renders the deprecated kinds (and the autoscaling template still references the worker via `temporalWorkerDeploymentRef`), so the chart's controller mode cannot install at all against any GA TWC. Reproduce with:

```
helm template zigflow charts/zigflow --set controller.enabled=true \
  | kubectl apply --dry-run=server -f -
```

against any cluster running TWC >= v1.7.0 — both custom resources are rejected at admission.

**Change** —
- `templates/controller.yaml`: emit `Connection` and `WorkerDeployment`
- `templates/autoscaling.yaml`: `temporalWorkerDeploymentRef` → `workerDeploymentRef` (the GA field name; the old name remains only as a deprecated alias in the CRD)
- `templates/_helpers.tpl`: comment updated to match
- `docs/docs/deployment/kubernetes.md`: same renames in prose
- `tests/controller_test.yaml`: new helm-unittest suite asserting the GA kinds, the connection reference, the renamed field, the absence of the deprecated field, and that nothing renders when controller mode is off

**Why it's safe** — I diffed the old and new CRD schemas from the official TWC CRDs chart: the rename is kind-only (`Connection` adds two optional TLS fields; `WorkerDeployment`'s schema is identical), so no other template fields change. With controller mode disabled (the default), the rendered output is byte-identical before and after this change. `helm lint` passes and the new suite passes 7/7.

**Tested** — Against a Kubernetes cluster running TWC v1.8.0: a server-side dry-run of the current chart's render is rejected at admission with the deprecation messages, and the fixed render is accepted. I then deployed the fixed chart end-to-end: the controller reconciled both resources, reported `ConnectionHealthy: True` and `Ready: Rollout complete`, and the chart's inline hello-world workflow executed to completion through Temporal.

**Impact on existing users** — Controller mode now targets TWC >= v1.7.0 (GA). Users pinned to pre-GA TWC (< v1.7.0) would need to upgrade the controller — but since the current chart cannot install against any GA TWC at all, and pre-v1.7.0 was pre-GA, this aligns the chart with the supported controller.
