### PR TITLE
fix: clone the state data before http activity

### DIFF
--- a/pkg/zigflow/activities/http.go
+++ b/pkg/zigflow/activities/http.go
@@ -83,7 +83,7 @@ func (c *CallHTTP) CallHTTPActivity(ctx context.Context, task *model.CallHTTP, i
 	stopHeartbeat := metadata.StartActivityHeartbeat(ctx, task.GetBase())
 	defer stopHeartbeat()
 
-	state = state.AddActivityInfo(ctx)
+	state = state.Clone().AddActivityInfo(ctx)
 
 	info := activity.GetInfo(ctx)
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
HTTP is only activity that doesn't run `state.Clone()` before adding the activity info.

## Related issue
<!-- Most changes should be discussed in an issue before implementation. -->
<!-- Link the issue using Fixes #..., Closes #... or Relates to #... -->
<!-- If no issue exists, explain why. -->

Fixes #

## How to test

<!-- Provide the steps used to verify this change -->

## Checklist

* [ ] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
* [x] All tests pass
* [x] Tests have been added or updated where behaviour changed
* [x] Documentation has been updated where needed
