### PR TITLE
Execute for and try blocks inline

### DIFF
--- a/docs/docs/concepts/error-handling-and-retries.md
+++ b/docs/docs/concepts/error-handling-and-retries.md
@@ -70,20 +70,30 @@ Set `maximumAttempts: 1` to disable retries entirely for a task.
 
 Use the `try` task to catch failures and handle them gracefully.
 
-The `try` block runs as a child workflow. If any task inside it fails, the
-`catch` block runs instead.
+The `try` and `catch` blocks run inline in the parent workflow. If any task
+inside `try` fails, the `catch` block runs instead.
 
-When a task in the `try` block fails, Zigflow executes the `catch` workflow. The
-caught error is injected into the catch workflow's `$data` state. By default it
-is available as `$data.error`, or under a custom key when `catch.as` is
-specified.
+Each activity inside `try` keeps its own retry policy. Zigflow runs `catch` only
+after the failing activity exhausts its retries. The inline `try` block does not
+have an additional workflow-level retry policy.
 
-The output of the `try` task is whatever the `catch` block returns.
+When a task in the `try` block fails, Zigflow executes the `catch` block. The
+caught error is injected into the catch block's `$data` state. By default it is
+available as `$data.error`, or under a custom key when `catch.as` is specified.
+
+On success, the output of the `try` task is whatever the `try` block returns.
+If `catch` runs, its result becomes the output instead.
+
+An inner `then: end` directive is control flow rather than a failure. In `try`
+it bypasses `catch`, and in either block it propagates out to end the enclosing
+workflow.
 
 ### Accessing the error
 
-The catch workflow runs with its normal workflow state. Zigflow adds the caught
-error to `$data` under the key defined by `catch.as`, which defaults to `error`.
+The catch block starts with a fresh clone of the parent state. Zigflow adds the
+caught error to `$data` under the key defined by `catch.as`, which defaults to
+`error`. The failed try block uses a separate clone, so partial state changes
+from `try` are not visible in `catch`.
 
 ```yaml
 - tryHttp:
@@ -139,9 +149,9 @@ $data.err
 
 When a custom key is used, `$data.error` is not populated.
 
-The error is scoped to the catch workflow. It is not automatically propagated
-into the parent workflow state after the catch block completes. To carry it
-forward, output or export it from a task in the catch block.
+The error is scoped to the catch block. It is not automatically propagated into
+the parent workflow state after the catch block completes. To carry it forward,
+output or export it from a task in the catch block.
 
 ### The error object
 
@@ -158,12 +168,18 @@ activity:
 childWorkflow:
 ```
 
-The exact fields depend on the underlying Temporal error, so do not rely on any
-single field always being present.
+Caught errors include `message` and `nonRetryable`. The `type` field is included
+when the underlying error provides a named type. Other fields depend on the
+underlying Temporal error.
+
+The `childWorkflow` field appears only when the failure came from an actual
+child workflow, such as an explicit `run.workflow` task. A failure from an
+ordinary task in the inline `try` block does not include child workflow
+metadata.
 
 :::warning Migration note
-Prior versions described the caught error as being passed to the catch workflow
-as input. The current behaviour stores the error in `$data` under the key
+Prior versions described the caught error as being passed to the catch block as
+input. The current behaviour stores the error in `$data` under the key
 defined by `catch.as`, defaulting to `error`.
 :::
 

--- a/docs/docs/dsl/tasks/for.md
+++ b/docs/docs/dsl/tasks/for.md
@@ -16,7 +16,7 @@ integer count.
 | for.in | `string` | `yes` | A [runtime expression](/docs/dsl/tasks/intro#runtime-expressions) used to get the collection to enumerate. |
 | for.at | `string` | `no` | The name of the variable used to store the index of the current item being enumerated.<br />Defaults to `index`. |
 | while | `string` | `no` | A [runtime expression](/docs/dsl/tasks/intro#runtime-expressions) that represents the condition, if any, that must be met for the iteration to continue.<br />The result of each iteration is stored in `$data.<taskName>`, allowing the while expression to conditionally stop the loop. |
-| do | [`map[string, task]`](/docs/dsl/tasks/intro) | `yes` | The [task(s)](/docs/dsl/tasks/intro) to perform for each item in the collection. These will be run as a [child workflow](https://docs.temporal.io/child-workflows) |
+| do | [`map[string, task]`](/docs/dsl/tasks/intro) | `yes` | The [task(s)](/docs/dsl/tasks/intro) to perform inline in the parent workflow for each item in the collection. |
 
 ## Example
 
@@ -88,11 +88,34 @@ do:
 
 ## Gotchas
 
-**Each iteration runs as a child workflow.** A loop over a large collection
-creates many child workflow executions. Temporal's history limits apply.
+**Each iteration runs inline in the parent workflow.** Commands from the loop
+body contribute to the parent's Temporal history. A large collection or a body
+with many tasks can therefore grow one workflow execution's history quickly.
+Zigflow does not attempt Continue-As-New while it is inside the loop body. Keep
+collection sizes bounded, or use an explicit child workflow when a separate
+history is required. Inner tasks and iterations still emit their lifecycle
+events, but the loop body does not emit `workflow.started` or
+`workflow.completed` events.
 
-**The `while` condition is evaluated after each iteration.** It cannot prevent
-the first iteration from running.
+**Iteration state is isolated from the parent workflow.** Zigflow clones the
+state for the loop and for each iteration. Loop variables and `$data` changes
+made by the body do not leak into the parent or later iterations. Zigflow makes
+the previous result available as `$data.<taskName>`. `$context` exports and
+`$output` also pass from one iteration to the next, but they are not copied
+directly to the parent. The For task's final result, `output` and `export`
+control what the parent receives.
+
+**Inner tasks keep their own retry settings.** Activity options on tasks inside
+the loop, together with document defaults, determine retries. Activity options
+on the enclosing For task are not inherited by the loop body.
+
+**`then: end` ends the enclosing workflow.** An end directive inside the loop
+body propagates out of the inline scope. It does not stop only the current
+iteration.
+
+**The `while` condition is evaluated before each iteration.** It can prevent
+the first iteration from running. On later iterations, `$output` contains the
+previous iteration's result.
 
 **Iteration results are stored under `$data.<taskName>`.** The `while`
 expression can access this key to implement early termination.

--- a/docs/docs/dsl/tasks/try.md
+++ b/docs/docs/dsl/tasks/try.md
@@ -13,7 +13,7 @@ calls and handling external service errors.
 
 | Name | Type | Required | Description |
 | --- | :---: | :---: | --- |
-| try | [`map[string, task]`](/docs/dsl/tasks/intro) | `yes` | The task(s) to perform. This will be run as a [child workflow](https://docs.temporal.io/child-workflows). |
+| try | [`map[string, task]`](/docs/dsl/tasks/intro) | `yes` | The task(s) to perform inline in the parent workflow. |
 | catch | [`catch`](#catch) | `yes` | Configures the errors to catch and how to handle them. |
 
 ## Example
@@ -62,14 +62,13 @@ This outputs:
 
 ### Catch
 
-Defines the configuration of a catch clause, which a concept used to catch
-errors.
+Defines the configuration of a catch clause used to handle errors.
 
 #### Properties {/*#catch-properties*/}
 
 | Name | Type | Required | Description |
 | --- | :---: | :---: | --- |
-| do | [`map[string, task]`](/docs/dsl/tasks/intro) | `yes` | The definition of the task(s) to run when catching an error. This will be run as a [child workflow](https://docs.temporal.io/child-workflows). |
+| do | [`map[string, task]`](/docs/dsl/tasks/intro) | `yes` | The task(s) to run inline in the parent workflow when catching an error. |
 | as | `string` | `no` | The key under `$data` where the caught error is stored. Defaults to `error`. |
 
 ## Gotchas
@@ -78,9 +77,27 @@ errors.
 To handle different error types differently, inspect the error object inside
 the `catch` block.
 
-**The `try` block runs as a child workflow.** Its history and retries are
-independent from the parent workflow. The retry policy configured on inner
-tasks still applies before the `catch` block runs.
+**The `try` and `catch` blocks run inline in the parent workflow.** Their
+commands contribute to the parent's Temporal history. They do not have
+independent child workflow histories or retry policies. Zigflow does not
+attempt Continue-As-New while it is inside either block. Inner tasks still emit
+task lifecycle events, but the blocks do not emit `workflow.started` or
+`workflow.completed` events.
+
+**Inner tasks keep their own retry settings.** An activity inside `try` uses its
+own activity options and document defaults. The `catch` block runs only after
+those retries are exhausted.
+
+**Both blocks use isolated state.** The `try` and `catch` blocks each start from
+a fresh clone of the parent state. Partial state changes from a failed `try`
+block are not visible in `catch`. Zigflow adds the caught error to the catch
+clone, under `$data.error` by default. Inner state changes do not leak directly
+to the parent. The Try task's result, `output` and `export` control what the
+parent receives.
+
+**`then: end` is not a caught error.** An end directive in `try` bypasses
+`catch` and terminates the enclosing workflow. An end directive in `catch`
+propagates in the same way.
 
 ## Related pages
 

--- a/docs/docs/examples/error-handling.md
+++ b/docs/docs/examples/error-handling.md
@@ -43,7 +43,7 @@ do:
 
 | Part | Purpose |
 | --- | --- |
-| `try` | Runs inner tasks as a child workflow |
+| `try` | Runs inner tasks inline in the parent workflow |
 | `catch.do` | Runs if any task inside `try` fails |
 | `setError` | Sets a fallback value when an error is caught |
 
@@ -51,9 +51,18 @@ do:
 filtering by error type. To handle different errors differently,
 inspect the error object inside the `catch` block.
 
-**The `try` block runs as a child workflow.** Inner tasks are
-retried according to their configured retry policy before the
-`catch` block is entered.
+**The `try` and `catch` blocks run inline in the parent workflow.** They do not
+create child workflows. Inner activities are retried according to their own
+configured retry policies before the `catch` block is entered.
+
+Both blocks use isolated state. The `catch` block starts from the parent state
+with the caught error added as `$data.error`. It does not see partial state
+changes from the failed `try` block. Use output or export values from `catch`
+when later tasks need them.
+
+If you inspect the caught error, `childWorkflow` metadata is present only when
+an explicit child workflow failed. A normal failure from an inline task does
+not include it.
 
 ## Raising errors explicitly
 
@@ -109,7 +118,7 @@ Use the `raise` task to fail a workflow with a structured error:
 
 ## Common mistakes
 
-**Not all retries are exhausted before `catch` runs.**
+**Expecting `catch` to run before retries are exhausted.**
 The default retry policy applies inside `try`. The `catch` block
 only runs after all retries are exhausted.
 

--- a/examples/for-loop/e2e_test.go
+++ b/examples/for-loop/e2e_test.go
@@ -65,6 +65,7 @@ func TestForLoopE2E(t *testing.T) {
 	var got map[string]any
 	require.NoError(t, we.Get(runCtx, &got), "get workflow result")
 	t.Logf("workflow output: %v", got)
+	e2etest.AssertNoChildWorkflowStarts(runCtx, t, c, we)
 
 	// Each loop exports its result under its own key; assert all are present.
 	for _, key := range []string{"forTaskMap", "forTaskArray", "forTaskNumber", "forTaskStateCarryOver"} {

--- a/examples/try-catch/e2e_test.go
+++ b/examples/try-catch/e2e_test.go
@@ -66,6 +66,7 @@ func TestTryCatchE2E(t *testing.T) {
 	var got map[string]any
 	require.NoError(t, we.Get(runCtx, &got), "get workflow result")
 	t.Logf("workflow output: %v", got)
+	e2etest.AssertNoChildWorkflowStarts(runCtx, t, c, we)
 
 	assert.Equal(t, "some error", got["err"], "catch block should set err")
 }

--- a/internal/e2etest/history.go
+++ b/internal/e2etest/history.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2etest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+)
+
+// AssertNoChildWorkflowStarts checks the completed parent history for child
+// workflow start commands.
+func AssertNoChildWorkflowStarts(
+	ctx context.Context,
+	t *testing.T,
+	c client.Client,
+	run client.WorkflowRun,
+) {
+	t.Helper()
+
+	history := c.GetWorkflowHistory(
+		ctx,
+		run.GetID(),
+		run.GetRunID(),
+		false,
+		enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+	)
+
+	childTypes := make([]string, 0)
+	for history.HasNext() {
+		event, err := history.Next()
+		require.NoError(t, err, "read workflow history")
+
+		attributes := event.GetStartChildWorkflowExecutionInitiatedEventAttributes()
+		if attributes != nil {
+			childTypes = append(childTypes, attributes.GetWorkflowType().GetName())
+		}
+	}
+
+	assert.Empty(t, childTypes, "parent history should not contain child workflow starts")
+}

--- a/pkg/zigflow/tasks/task_builder_collision_test.go
+++ b/pkg/zigflow/tasks/task_builder_collision_test.go
@@ -135,11 +135,11 @@ func TestDeeplyNestedPathProducesFullyQualifiedName(t *testing.T) {
 	w.AssertExpectations(t)
 }
 
-// Regression guard: ForTaskBuilder.Build constructs its inner DoBuilder via
-// NewDoTaskBuilder directly (to pass DoTaskOpts{DisableRegisterWorkflow:true}),
-// bypassing the factory. Without an explicit setTaskPath on that inner builder,
-// the body's tasks register under collision-prone names — exactly the bug an
-// e2e run with two sibling For loops uncovered.
+// Regression guard: ForTaskBuilder.Build constructs its inline DoBuilder via
+// NewDoTaskBuilder directly, bypassing the factory. Without an explicit
+// setTaskPath on that inner builder, the body's tasks register under
+// collision-prone names, exactly the bug an e2e run with two sibling For loops
+// uncovered.
 func TestForBuildPropagatesTaskPathToInnerBody(t *testing.T) {
 	doc := &model.Workflow{Document: model.Document{Name: "wf-for-build"}}
 

--- a/pkg/zigflow/tasks/task_builder_do.go
+++ b/pkg/zigflow/tasks/task_builder_do.go
@@ -87,6 +87,40 @@ type workflowFunc struct {
 }
 
 func (t *DoTaskBuilder) Build() (TemporalWorkflowFunc, error) {
+	tasks, hasNoDo, err := t.buildTasks(false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute the workflow
+	wf := t.workflowExecutor(tasks)
+
+	if !t.opts.DisableRegisterWorkflow {
+		if hasNoDo {
+			log.Debug().Str("name", t.GetTaskName()).Msg("Registering workflow")
+			t.temporalWorker.RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{
+				Name: t.GetTaskName(),
+			})
+		}
+	}
+
+	return wf, nil
+}
+
+// buildInline compiles a Do task as an inline scope within its enclosing
+// workflow. Unlike workflowExecutor, it does not create workflow lifecycle
+// events, increment workflow telemetry, translate flow.ErrEnd across a
+// workflow boundary or continue as new from within the nested scope.
+func (t *DoTaskBuilder) buildInline() (TemporalWorkflowFunc, error) {
+	tasks, _, err := t.buildTasks(true)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.inlineExecutor(tasks), nil
+}
+
+func (t *DoTaskBuilder) buildTasks(inline bool) ([]workflowFunc, bool, error) {
 	tasks := make([]workflowFunc, 0)
 
 	var hasNoDo bool
@@ -106,14 +140,26 @@ func (t *DoTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		l.Debug().Msg("Creating task builder")
 		builder, err := NewTaskBuilder(task.Key, task.Task, t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, t.childTaskPath(task.Key))
 		if err != nil {
-			return nil, fmt.Errorf("error creating task builder: %w", err)
+			return nil, false, fmt.Errorf("error creating task builder: %w", err)
 		}
 
 		// Build the task and store it for use
 		l.Debug().Msg("Building task")
-		fn, err := builder.Build()
+		var fn TemporalWorkflowFunc
+		if inline && addTasks {
+			if doBuilder, ok := builder.(*DoTaskBuilder); ok {
+				fn, err = doBuilder.buildInline()
+			} else {
+				fn, err = builder.Build()
+			}
+		} else {
+			// A nested Do after executable tasks is a named workflow
+			// declaration. Build it normally so redirects and explicit child
+			// calls can still target the registered workflow.
+			fn, err = builder.Build()
+		}
 		if err != nil {
-			return nil, fmt.Errorf("error building task: %w", err)
+			return nil, false, fmt.Errorf("error building task: %w", err)
 		}
 		if fn != nil && addTasks {
 			l.Debug().Msg("Adding task to workflow")
@@ -125,19 +171,7 @@ func (t *DoTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		}
 	}
 
-	// Execute the workflow
-	wf := t.workflowExecutor(tasks)
-
-	if !t.opts.DisableRegisterWorkflow {
-		if hasNoDo {
-			log.Debug().Str("name", t.GetTaskName()).Msg("Registering workflow")
-			t.temporalWorker.RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{
-				Name: t.GetTaskName(),
-			})
-		}
-	}
-
-	return wf, nil
+	return tasks, hasNoDo, nil
 }
 
 func (t *DoTaskBuilder) PostLoad() error {
@@ -232,9 +266,9 @@ func (t *DoTaskBuilder) workflowExecutor(tasks []workflowFunc) TemporalWorkflowF
 		// Iterate through the tasks to create the workflow. An `end` flow
 		// directive propagates outward as flow.ErrEnd. At the true root
 		// workflow boundary this is a clean termination, not a failure.
-		// At nested child workflow boundaries (e.g. redirect targets,
-		// for-loop iteration bodies) we re-emit ErrEnd as a serialisable
-		// Temporal ApplicationError so the parent workflow can detect it
+		// At actual child workflow boundaries (e.g. redirect targets) we
+		// re-emit ErrEnd as a serialisable Temporal ApplicationError so the
+		// parent workflow can detect it
 		// and continue propagating "end" upward until it reaches the
 		// root. Without this, ErrEnd would be silently swallowed by every
 		// child workflow boundary and `then: end` could only end the
@@ -265,6 +299,22 @@ func (t *DoTaskBuilder) workflowExecutor(tasks []workflowFunc) TemporalWorkflowF
 	}
 }
 
+func (t *DoTaskBuilder) inlineExecutor(tasks []workflowFunc) TemporalWorkflowFunc {
+	return func(ctx workflow.Context, input any, state *utils.State) (any, error) {
+		// A real child workflow starts without the enclosing task's activity
+		// options. Reset them before running inline so task-specific and document
+		// defaults keep the same inheritance semantics as before.
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{})
+		ctx = workflow.WithTaskQueue(ctx, "")
+
+		if err := t.iterateTasksInline(ctx, tasks, input, state); err != nil {
+			return state.Output, err
+		}
+
+		return state.Output, nil
+	}
+}
+
 func (t *DoTaskBuilder) continueAsNew(
 	ctx workflow.Context, wfn, taskID string, input any, state *utils.State,
 ) error {
@@ -286,6 +336,18 @@ func (t *DoTaskBuilder) continueAsNew(
 func (t *DoTaskBuilder) iterateTasks(
 	ctx workflow.Context, tasks []workflowFunc, input any, state *utils.State,
 ) error {
+	return t.iterateTasksWithContinueAsNew(ctx, tasks, input, state, true)
+}
+
+func (t *DoTaskBuilder) iterateTasksInline(
+	ctx workflow.Context, tasks []workflowFunc, input any, state *utils.State,
+) error {
+	return t.iterateTasksWithContinueAsNew(ctx, tasks, input, state, false)
+}
+
+func (t *DoTaskBuilder) iterateTasksWithContinueAsNew(
+	ctx workflow.Context, tasks []workflowFunc, input any, state *utils.State, allowContinueAsNew bool,
+) error {
 	var nextTargetName *string
 	logger := workflow.GetLogger(ctx)
 
@@ -295,7 +357,7 @@ func (t *DoTaskBuilder) iterateTasks(
 		logger.Debug("Set current workflow time", "taskID", taskID, "workflow", t.name)
 		state = state.AddWorkflowNow(ctx)
 
-		if t.shouldContinueAsNew(ctx) {
+		if allowContinueAsNew && t.shouldContinueAsNew(ctx) {
 			logger.Debug("Task continue-as-new", "taskID", taskID, "workflow", t.name)
 			return t.continueAsNew(ctx, t.name, taskID, input, state)
 		}
@@ -589,8 +651,8 @@ func (t *DoTaskBuilder) applyRedirectResult(task workflowFunc, res any, state *u
 
 // isRootWorkflow reports whether ctx belongs to the topmost workflow in
 // the current execution. Child workflows started via
-// workflow.ExecuteChildWorkflow (redirect targets, for-loop iteration
-// bodies, etc.) have ParentWorkflowExecution set; the original workflow
+// workflow.ExecuteChildWorkflow (redirect targets, forks and explicit
+// workflow calls) have ParentWorkflowExecution set; the original workflow
 // started by the client does not.
 func isRootWorkflow(ctx workflow.Context) bool {
 	return workflow.GetInfo(ctx).ParentWorkflowExecution == nil

--- a/pkg/zigflow/tasks/task_builder_do_test.go
+++ b/pkg/zigflow/tasks/task_builder_do_test.go
@@ -19,17 +19,22 @@ package tasks
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/flow"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
+
+const testConstTaskNested = "nested"
 
 func TestDoTaskBuilderWorkflowExecutor(t *testing.T) {
 	t.Helper()
@@ -363,6 +368,210 @@ func TestDoTaskBuilderIterateTasksContinueAsNew(t *testing.T) {
 	}
 }
 
+func TestDoTaskBuilderInlineExecutorDoesNotContinueAsNew(t *testing.T) {
+	builder := newTestDoTaskBuilder("inline-no-continue-as-new")
+	state := utils.NewState()
+	runOrder := make([]string, 0, 1)
+	tasks := []workflowFunc{
+		newSimpleWorkflowFunc(testConstTaskOne, &model.TaskBase{}, &runOrder),
+	}
+	inline := builder.inlineExecutor(tasks)
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.SetContinueAsNewSuggested(true)
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		return inline(ctx, nil, state)
+	}, workflow.RegisterOptions{Name: builder.GetTaskName()})
+
+	env.ExecuteWorkflow(builder.GetTaskName())
+
+	assert.NoError(t, env.GetWorkflowError())
+	assert.Equal(t, []string{testConstTaskOne}, runOrder)
+	assert.Nil(t, state.CANStartFrom)
+}
+
+func TestDoTaskBuilderBuildInlineRecursesIntoNestedDo(t *testing.T) {
+	task := &model.DoTask{Do: &model.TaskList{
+		&model.TaskItem{Key: testConstTaskNested, Task: &model.DoTask{Do: &model.TaskList{
+			&model.TaskItem{Key: testConstTaskOne, Task: &model.SetTask{
+				TaskBase: model.TaskBase{
+					Then: &model.FlowDirective{Value: string(model.FlowDirectiveEnd)},
+				},
+				Set: model.NewObjectOrRuntimeExpr(map[string]any{testConstValue: testConstDone}),
+			}},
+		}}},
+	}}
+	builder, err := NewDoTaskBuilder(nil, task, "inline-nested-do", testWorkflow, testEvents, nil)
+	require.NoError(t, err)
+	inline, err := builder.buildInline()
+	require.NoError(t, err)
+
+	state := utils.NewState()
+	var gotOutput any
+	var gotErr error
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.SetContinueAsNewSuggested(true)
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		gotOutput, gotErr = inline(ctx, nil, state)
+		return nil, nil
+	}, workflow.RegisterOptions{Name: builder.GetTaskName()})
+
+	env.ExecuteWorkflow(builder.GetTaskName())
+
+	require.NoError(t, env.GetWorkflowError())
+	assert.ErrorIs(t, gotErr, flow.ErrEnd)
+	assert.False(t, workflow.IsContinueAsNewError(gotErr))
+	assert.Equal(t, map[string]any{testConstValue: testConstDone}, gotOutput)
+	assert.Nil(t, state.CANStartFrom)
+}
+
+func TestDoTaskBuilderInlineExecutorPropagatesEnd(t *testing.T) {
+	builder := newTestDoTaskBuilder("inline-end")
+	state := utils.NewState()
+	taskBuilder := newFakeTaskBuilder(testConstTaskOne, &model.TaskBase{
+		Then: &model.FlowDirective{Value: string(model.FlowDirectiveEnd)},
+	})
+	tasks := []workflowFunc{
+		{
+			TaskBuilder: taskBuilder,
+			Name:        taskBuilder.GetTaskName(),
+			Func: func(workflow.Context, any, *utils.State) (any, error) {
+				return map[string]any{testConstValue: testConstDone}, nil
+			},
+		},
+	}
+	inline := builder.inlineExecutor(tasks)
+
+	var gotErr error
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		output, err := inline(ctx, nil, state)
+		gotErr = err
+		return output, nil
+	}, workflow.RegisterOptions{Name: builder.GetTaskName()})
+
+	env.ExecuteWorkflow(builder.GetTaskName())
+
+	assert.NoError(t, env.GetWorkflowError())
+	assert.ErrorIs(t, gotErr, flow.ErrEnd)
+	assert.Equal(t, map[string]any{testConstValue: testConstDone}, state.Output)
+}
+
+func TestDoTaskBuilderInlineExecutorResetsActivityOptions(t *testing.T) {
+	builder := newTestDoTaskBuilder("inline-activity-options")
+	state := utils.NewState()
+	taskBuilder := newFakeTaskBuilder(testConstTaskOne, &model.TaskBase{})
+	var observed workflow.ActivityOptions
+	tasks := []workflowFunc{
+		{
+			TaskBuilder: taskBuilder,
+			Name:        taskBuilder.GetTaskName(),
+			Func: func(ctx workflow.Context, _ any, _ *utils.State) (any, error) {
+				observed = workflow.GetActivityOptions(ctx)
+				return nil, nil
+			},
+		},
+	}
+	inline := builder.inlineExecutor(tasks)
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			ScheduleToCloseTimeout: 2 * time.Hour,
+			TaskQueue:              "outer-activity-queue",
+		})
+		return inline(ctx, nil, state)
+	}, workflow.RegisterOptions{Name: builder.GetTaskName()})
+
+	env.ExecuteWorkflow(builder.GetTaskName())
+
+	assert.NoError(t, env.GetWorkflowError())
+	assert.Zero(t, observed.ScheduleToCloseTimeout)
+	assert.Empty(t, observed.TaskQueue)
+	assert.Equal(t, testConstTaskOne, observed.Summary)
+}
+
+func TestDoTaskBuilderInlineExecutorPreservesExplicitChildTasks(t *testing.T) {
+	runInline := func(t *testing.T, task workflowFunc, childName string) {
+		t.Helper()
+
+		builder := newTestDoTaskBuilder("inline-explicit-child")
+		inline := builder.inlineExecutor([]workflowFunc{task})
+		state := utils.NewState()
+		childStarts := make([]string, 0, 1)
+
+		var s testsuite.WorkflowTestSuite
+		env := s.NewTestWorkflowEnvironment()
+		env.SetOnChildWorkflowStartedListener(
+			func(info *workflow.Info, _ workflow.Context, _ converter.EncodedValues) {
+				childStarts = append(childStarts, info.WorkflowType.Name)
+			},
+		)
+		env.RegisterWorkflowWithOptions(
+			func(workflow.Context, any, *utils.State) (map[string]any, error) {
+				return map[string]any{testConstValue: testConstDone}, nil
+			},
+			workflow.RegisterOptions{Name: childName},
+		)
+		env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+			return inline(ctx, nil, state)
+		}, workflow.RegisterOptions{Name: builder.GetTaskName()})
+
+		env.ExecuteWorkflow(builder.GetTaskName())
+
+		require.NoError(t, env.GetWorkflowError())
+		assert.Equal(t, []string{childName}, childStarts)
+	}
+
+	t.Run("run workflow", func(t *testing.T) {
+		const childName = "inline-run-child"
+		task := &model.RunTask{Run: model.RunTaskConfiguration{
+			Await: utils.Ptr(true),
+			Workflow: &model.RunWorkflow{
+				Namespace: constDefaultNamespace,
+				Name:      childName,
+				Version:   testConstRunWorkflowVersion,
+			},
+		}}
+		builder, err := NewRunTaskBuilder(nil, task, "nested-run", testWorkflow, testEvents, nil)
+		require.NoError(t, err)
+		fn, err := builder.Build()
+		require.NoError(t, err)
+
+		runInline(t, workflowFunc{TaskBuilder: builder, Name: builder.GetTaskName(), Func: fn}, childName)
+	})
+
+	t.Run("fork", func(t *testing.T) {
+		const childName = "inline-fork-child"
+		task := &model.ForkTask{Fork: model.ForkTaskConfiguration{
+			Branches: &model.TaskList{},
+		}}
+		builder, err := NewForkTaskBuilder(nil, task, "nested-fork", testWorkflow, testEvents, nil)
+		require.NoError(t, err)
+		fn, err := builder.exec([]*forkedTask{{
+			task:              &model.TaskItem{Key: "branch"},
+			childWorkflowName: childName,
+			taskName:          "branch",
+		}})
+		require.NoError(t, err)
+
+		runInline(t, workflowFunc{TaskBuilder: builder, Name: builder.GetTaskName(), Func: fn}, childName)
+	})
+
+	t.Run("named redirect", func(t *testing.T) {
+		const childName = "inline-redirect-child"
+		runOrder := make([]string, 0, 1)
+		task := newSwitchWorkflowFunc(flow.RedirectError{Target: childName}, &runOrder)
+
+		runInline(t, task, childName)
+		assert.Equal(t, []string{testConstTaskSwitch}, runOrder)
+	})
+}
+
 func TestDoTaskBuilderIterateTasksSkipsCompletedTasks(t *testing.T) {
 	t.Helper()
 
@@ -498,7 +707,7 @@ func TestDoTaskBuilderBuildSkipsNestedDoAfterNonDoTask(t *testing.T) {
 				},
 			},
 			{
-				Key: "nested",
+				Key: testConstTaskNested,
 				Task: &model.DoTask{
 					Do: &model.TaskList{
 						{
@@ -517,7 +726,7 @@ func TestDoTaskBuilderBuildSkipsNestedDoAfterNonDoTask(t *testing.T) {
 
 	temporalWorker.
 		On("RegisterWorkflowWithOptions", mock.Anything, workflow.RegisterOptions{
-			Name: "nested",
+			Name: testConstTaskNested,
 		}).
 		Once()
 	temporalWorker.

--- a/pkg/zigflow/tasks/task_builder_for.go
+++ b/pkg/zigflow/tasks/task_builder_for.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 
 	ceSDK "github.com/cloudevents/sdk-go/v2"
 	"github.com/open-workflow-specification/sdk-go/v4/model"
@@ -54,28 +55,10 @@ func NewForTaskBuilder(
 
 var errForkIterationStop = fmt.Errorf("fork iteration stop")
 
-// forChildResult is returned by the for-loop's child workflow and carries
-// intra-loop state only. Neither field is promoted to the parent workflow state.
-//
-// Output is the per-iteration result. It is stored in workingState.Output so
-// that the next iteration's while condition can read $output. The loop's final
-// aggregated result is returned from exec() and handled by the surrounding task
-// pipeline, not taken from this field.
-//
-// Context carries any value written by an export directive inside the iteration.
-// It is stored in workingState.Context so that the next iteration can read
-// $context. It is NOT copied to the parent state after the loop completes:
-// workingState.Context is loop-private, and copying it would cause inner-loop
-// exports to leak into the surrounding workflow context.
-type forChildResult struct {
-	Output  any `json:"output"`
-	Context any `json:"context"`
-}
-
 type ForTaskBuilder struct {
 	builder[*model.ForTask]
 
-	childWorkflowName string
+	body TemporalWorkflowFunc
 }
 
 func (t *ForTaskBuilder) Build() (TemporalWorkflowFunc, error) {
@@ -84,48 +67,28 @@ func (t *ForTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		return nil, nil
 	}
 
-	t.childWorkflowName = utils.GenerateChildWorkflowName("for", t.GetTaskName())
-
-	// Build the inner DoTask with registration disabled so we can register our
-	// own wrapper that returns forChildResult instead of bare state.Output.
+	// Compile the body once, then run it directly for each iteration.
 	innerBuilder, err := NewDoTaskBuilder(
 		t.temporalWorker,
 		&model.DoTask{Do: t.task.Do},
-		t.childWorkflowName,
+		t.GetTaskName(),
 		t.doc,
 		t.eventEmitter,
 		t.taskOpts,
-		DoTaskOpts{DisableRegisterWorkflow: true},
 	)
 	if err != nil {
-		log.Error().Str("task", t.childWorkflowName).Err(err).Msg("Error creating the for task builder")
+		log.Error().Str("task", t.GetTaskName()).Err(err).Msg("Error creating the for task builder")
 		return nil, fmt.Errorf("error creating the for task builder: %w", err)
 	}
 	// Direct construction bypasses NewTaskBuilder's path setter; thread it
 	// here so the body's tasks inherit the For's path.
 	innerBuilder.setTaskPath(t.taskPath)
 
-	innerFn, err := innerBuilder.Build()
+	t.body, err = innerBuilder.buildInline()
 	if err != nil {
-		log.Error().Str("task", t.childWorkflowName).Err(err).Msg("Error building for workflow")
-		return nil, fmt.Errorf("error building for workflow: %w", err)
+		log.Error().Str("task", t.GetTaskName()).Err(err).Msg("Error building for task body")
+		return nil, fmt.Errorf("error building for task body: %w", err)
 	}
-
-	// Register a wrapper child workflow that returns the iteration output and
-	// exported context so the loop can propagate inter-iteration state.
-	t.temporalWorker.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, state *utils.State) (forChildResult, error) {
-			output, err := innerFn(ctx, input, state)
-			if err != nil {
-				return forChildResult{}, err
-			}
-			return forChildResult{
-				Output:  output,
-				Context: state.Context,
-			}, nil
-		},
-		workflow.RegisterOptions{Name: t.childWorkflowName},
-	)
 
 	return t.exec()
 }
@@ -140,8 +103,8 @@ func (t *ForTaskBuilder) PostLoad() error {
 	}
 
 	if err := builder.PostLoad(); err != nil {
-		log.Error().Str("task", t.childWorkflowName).Err(err).Msg("Error building for workflow postload")
-		return fmt.Errorf("error building for workflow postload: %w", err)
+		log.Error().Str("task", t.GetTaskName()).Err(err).Msg("Error post loading for task body")
+		return fmt.Errorf("error post loading for task body: %w", err)
 	}
 
 	return nil
@@ -157,7 +120,7 @@ func (t *ForTaskBuilder) Validate() error {
 	}
 
 	if err := builder.Validate(); err != nil {
-		return fmt.Errorf("error validating for workflow: %w", err)
+		return fmt.Errorf("error validating for task body: %w", err)
 	}
 
 	return nil
@@ -195,15 +158,12 @@ func (t *ForTaskBuilder) createBuilder() (TaskBuilder, error) {
 		return nil, nil
 	}
 
-	// Register the ForTask's Do as a child workflow
-	t.childWorkflowName = utils.GenerateChildWorkflowName("for", t.GetTaskName())
-
 	builder, err := NewTaskBuilder(
-		t.childWorkflowName, &model.DoTask{Do: t.task.Do},
+		t.GetTaskName(), &model.DoTask{Do: t.task.Do},
 		t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, t.taskPath,
 	)
 	if err != nil {
-		log.Error().Str("task", t.childWorkflowName).Err(err).Msg("Error creating the for task builder")
+		log.Error().Str("task", t.GetTaskName()).Err(err).Msg("Error creating the for task builder")
 		return nil, fmt.Errorf("error creating the for task builder: %w", err)
 	}
 
@@ -232,9 +192,8 @@ func (t *ForTaskBuilder) exec() (TemporalWorkflowFunc, error) {
 			// flow.ErrEnd is special: an iteration deliberately requested
 			// that the workflow terminate, and the iterator has already
 			// surfaced its effective output. Propagate that output to the
-			// do-task layer so subsequent processTaskOutput / Export logic
-			// (and ultimately workflowExecutor's NewEndApplicationError
-			// payload) reflect the iteration's work rather than losing it.
+			// do-task layer so subsequent output/export handling and the final
+			// workflow result reflect the iteration's work rather than losing it.
 			if errors.Is(err, flow.ErrEnd) {
 				state.Output = output
 				return output, err
@@ -271,7 +230,13 @@ func (t *ForTaskBuilder) iterate(ctx workflow.Context, workingState *utils.State
 	case map[string]any:
 		logger.Debug("Iterating data as object", "task", t.GetTaskName())
 		output := map[string]any{}
-		for key, value := range v {
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			value := v[key]
 			res, err := t.iterator(ctx, key, value, workingState)
 			if done, endRes, endErr := t.classifyIterationOutcome(res, err); done {
 				if endErr != nil {
@@ -397,8 +362,8 @@ func (t *ForTaskBuilder) iterationCount(data any) (count int, ok bool, err error
 // - the last iteration result under the loop task name via addIterationResult
 //
 // Instead, iterator creates an iterState clone that includes the loop-local
-// variables and is passed to the child workflow. Only Context and Output are
-// propagated back from the child into workingState.
+// variables and is passed to the inline body. Only Context and Output are
+// propagated back from the body into workingState.
 func (t *ForTaskBuilder) iterator(ctx workflow.Context, key, value any, workingState *utils.State) (any, error) {
 	logger := workflow.GetLogger(ctx)
 
@@ -432,48 +397,33 @@ func (t *ForTaskBuilder) iterator(ctx workflow.Context, key, value any, workingS
 		return nil, errForkIterationStop
 	}
 
-	// Clear output so the child starts with a clean slate.
+	// Clear output so the body starts with a clean slate.
 	// Context is deliberately preserved in iterState so that exports from the
 	// previous iteration are visible to tasks inside this iteration via $context.
 	iterState.Output = nil
 
-	// Run the tasks
-	opts := workflow.ChildWorkflowOptions{
-		// key may be an integer or a string - use %v to let Go figure out how to represent it
-		WorkflowID: fmt.Sprintf("%s_for_%v", workflow.GetInfo(ctx).WorkflowExecution.ID, key),
-	}
-	childCtx := workflow.WithChildOptions(ctx, opts)
+	logger.Info("Running for iteration", "task", t.GetTaskName(), "key", key)
 
-	logger.Info("Triggering forked child workflow", "name", t.childWorkflowName)
-
-	var res forChildResult
-	if err := workflow.ExecuteChildWorkflow(childCtx, t.childWorkflowName, iterState.Input, iterState).Get(ctx, &res); err != nil {
-		// A `then: end` directive inside the iteration body crosses the
-		// child workflow boundary as a typed Temporal ApplicationError
-		// carrying the iteration's effective output. Surface it as
-		// flow.ErrEnd here so the for-task signals end to its enclosing
-		// scope rather than reporting a generic failure, and update
-		// workingState.Output with the carried payload so the for-task
-		// returns the iteration's effective output rather than losing it.
-		if endPayload, isEnd := flow.DecodeEndApplicationError(err); isEnd {
-			logger.Info("For iteration signalled end; propagating to caller",
-				"workflow", t.childWorkflowName, "carriedOutput", endPayload.Output)
-			workingState.Output = endPayload.Output
-			return endPayload.Output, flow.ErrEnd
+	res, err := t.body(ctx, iterState.Input, iterState)
+	if err != nil {
+		if errors.Is(err, flow.ErrEnd) {
+			logger.Info("For iteration signalled end; propagating to caller", "task", t.GetTaskName())
+			workingState.Output = res
+			return res, err
 		}
-		logger.Error("Error calling for workflow", "error", err, "workflow", t.childWorkflowName)
-		return nil, fmt.Errorf("error calling for workflow: %w", err)
+		logger.Error("Error running for iteration", "error", err, "task", t.GetTaskName())
+		return nil, fmt.Errorf("error running for iteration: %w", err)
 	}
 
 	// Propagate only Context and Output back into workingState so that the
 	// next iteration's while check and $context references see current values.
-	// Data mutations made inside the child workflow are intentionally discarded:
-	// they are child-internal. The only Data update that crosses iteration
+	// Data mutations made inside the body are intentionally discarded: they are
+	// iteration-internal. The only Data update that crosses iteration
 	// boundaries is the one made by addIterationResult during loop iteration.
-	workingState.Context = res.Context
-	workingState.Output = res.Output
+	workingState.Context = iterState.Context
+	workingState.Output = res
 
-	return res.Output, nil
+	return res, nil
 }
 
 // checkWhile decides if we should stop the iteration

--- a/pkg/zigflow/tasks/task_builder_for_test.go
+++ b/pkg/zigflow/tasks/task_builder_for_test.go
@@ -27,9 +27,18 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/flow"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
+
+func testInlineForBody(fn func(*utils.State) (any, error)) TemporalWorkflowFunc {
+	return func(_ workflow.Context, _ any, state *utils.State) (any, error) {
+		output, err := fn(state)
+		state.Output = output
+		return output, err
+	}
+}
 
 func TestForTaskBuilderAddIterationResult(t *testing.T) {
 	tests := []struct {
@@ -284,18 +293,13 @@ func TestForTaskBuilderIterator(t *testing.T) {
 				},
 			},
 		},
-		childWorkflowName: utils.GenerateChildWorkflowName("for", "iterate"),
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			return map[string]any{testConstChildValue: st.Data[testConstValue]}, nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-		return forChildResult{
-			Output:  map[string]any{testConstChildValue: st.Data[testConstValue]},
-			Context: nil,
-		}, nil
-	}, workflow.RegisterOptions{Name: builder.childWorkflowName})
 
 	state.AddData(map[string]any{
 		testConstItems: []any{testConstItemValue},
@@ -321,10 +325,63 @@ func TestForTaskBuilderIterator(t *testing.T) {
 	assert.Nil(t, state.Data[testConstIdx])
 }
 
+func TestForTaskBuilderBuildRunsIterationsInline(t *testing.T) {
+	events, readEventTypes := newRecordingEvents(t)
+	task := &model.ForTask{
+		For: model.ForTaskConfiguration{In: testConstForRefDataItems},
+		Do: &model.TaskList{
+			&model.TaskItem{
+				Key: testConstStep,
+				Task: &model.SetTask{
+					Set: model.NewObjectOrRuntimeExpr(map[string]any{
+						testConstProcessed: "${ $data.item }",
+					}),
+				},
+			},
+		},
+	}
+
+	builder, err := NewForTaskBuilder(nil, task, "inline-for", testWorkflow, events, nil)
+	require.NoError(t, err)
+
+	fn, err := builder.Build()
+	require.NoError(t, err)
+
+	state := utils.NewState()
+	state.AddData(map[string]any{testConstItems: []any{"a", "b", "c"}})
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	childStarts := 0
+	env.SetOnChildWorkflowStartedListener(
+		func(*workflow.Info, workflow.Context, converter.EncodedValues) {
+			childStarts++
+		},
+	)
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		return fn(ctx, nil, state)
+	}, workflow.RegisterOptions{Name: "inline-for-outer"})
+
+	env.ExecuteWorkflow("inline-for-outer")
+	require.NoError(t, env.GetWorkflowError())
+	assert.Zero(t, childStarts)
+
+	var result []any
+	require.NoError(t, env.GetWorkflowResult(&result))
+	assert.Len(t, result, 3)
+
+	eventTypes := readEventTypes()
+	assert.Contains(t, eventTypes, "dev.zigflow.task.started")
+	assert.Contains(t, eventTypes, "dev.zigflow.task.completed")
+	assert.Contains(t, eventTypes, "dev.zigflow.iteration.completed")
+	assert.NotContains(t, eventTypes, "dev.zigflow.workflow.started")
+	assert.NotContains(t, eventTypes, "dev.zigflow.workflow.completed")
+}
+
 // TestForIteratorContextPropagates verifies that $context set by an export in
 // iteration N is visible as state.Context when iterator() is called for N+1.
 func TestForIteratorContextPropagates(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "ctx-prop")
+	var receivedContexts []any
 
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
@@ -336,25 +393,15 @@ func TestForIteratorContextPropagates(t *testing.T) {
 				Do:  &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			receivedContexts = append(receivedContexts, st.Context)
+			st.Context = map[string]any{testConstLast: st.Data[constDefaultItemVar]}
+			return st.Data[constDefaultItemVar], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	// The mock returns a context that records which items have been visited.
-	// The second invocation receives the context set by the first invocation.
-	var receivedContexts []any
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			receivedContexts = append(receivedContexts, st.Context)
-			return forChildResult{
-				Output:  st.Data[constDefaultItemVar],
-				Context: map[string]any{testConstLast: st.Data[constDefaultItemVar]},
-			}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 
@@ -383,7 +430,7 @@ func TestForIteratorContextPropagates(t *testing.T) {
 // TestForIteratorWhileSeesOutput verifies that the while condition for iteration
 // N+1 sees the output produced by iteration N.
 func TestForIteratorWhileSeesOutput(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "while-out")
+	callCount := 0
 
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
@@ -397,22 +444,16 @@ func TestForIteratorWhileSeesOutput(t *testing.T) {
 				Do:    &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(*utils.State) (any, error) {
+			callCount++
+			// The first iteration returns continue=false so the second iteration's
+			// while check should stop the loop.
+			return map[string]any{testConstFlowContinue: false}, nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	callCount := 0
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			callCount++
-			// The first iteration returns continue=false so the second iteration's
-			// while check should stop the loop.
-			return forChildResult{Output: map[string]any{testConstFlowContinue: false}, Context: nil}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	// Pre-seed output so the first while check (before any iteration runs) passes.
@@ -449,15 +490,13 @@ func TestForIteratorWhileSeesOutput(t *testing.T) {
 	assert.NoError(t, env.GetWorkflowError())
 	// The while condition stopped the loop at the second iteration call.
 	assert.Equal(t, 2, stoppedAt)
-	// Child workflow was only invoked once (first iteration ran; second was stopped by while).
+	// The inline body was only invoked once (first iteration ran; second was stopped by while).
 	assert.Equal(t, 1, callCount)
 }
 
 // TestForExecArrayAccumulatesResults verifies that the for task still returns an
 // array of per-iteration results when iterating over an array for.in value.
 func TestForExecArrayAccumulatesResults(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "accum")
-
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -472,21 +511,13 @@ func TestForExecArrayAccumulatesResults(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			return map[string]any{testConstProcessed: st.Data[constDefaultItemVar]}, nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{
-				Output:  map[string]any{testConstProcessed: st.Data[constDefaultItemVar]},
-				Context: nil,
-			}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstItems: []any{"x", "y", "z"}})
@@ -514,8 +545,6 @@ func TestForExecArrayAccumulatesResults(t *testing.T) {
 // TestForExecObjectAccumulatesResults verifies the object for.in variant still
 // returns a map keyed by the original object keys.
 func TestForExecObjectAccumulatesResults(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "obj-accum")
-
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -530,21 +559,13 @@ func TestForExecObjectAccumulatesResults(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			return st.Data[testConstVal], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{
-				Output:  st.Data[testConstVal],
-				Context: nil,
-			}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstItems: map[string]any{"a": 1, "b": 2}})
@@ -562,15 +583,56 @@ func TestForExecObjectAccumulatesResults(t *testing.T) {
 	var result map[string]any
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
-	// JSON round-trip through the Temporal child workflow boundary converts integers to float64.
+	// The workflow result still crosses Temporal's serialisation boundary.
 	assert.Equal(t, map[string]any{"a": float64(1), "b": float64(2)}, result)
+	// Inside the workflow, inline execution preserves the native integer values.
+	assert.Equal(t, map[string]any{"a": 1, "b": 2}, state.Output)
+}
+
+func TestForExecObjectUsesDeterministicKeyOrder(t *testing.T) {
+	iterationOrder := make([]string, 0, 3)
+	b := &ForTaskBuilder{
+		builder: builder[*model.ForTask]{
+			doc:          testWorkflow,
+			eventEmitter: testEvents,
+			name:         "obj-order",
+			task: &model.ForTask{
+				For: model.ForTaskConfiguration{
+					Each: testConstVal,
+					At:   "key",
+					In:   testConstForRefDataItems,
+				},
+				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
+			},
+		},
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			key := st.Data["key"].(string)
+			iterationOrder = append(iterationOrder, key)
+			return key, nil
+		}),
+	}
+
+	state := utils.NewState()
+	state.AddData(map[string]any{
+		testConstItems: map[string]any{"z": 1, "a": 2, "m": 3},
+	})
+	execFn, err := b.exec()
+	require.NoError(t, err)
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		return execFn(ctx, nil, state)
+	}, workflow.RegisterOptions{Name: "obj-order-outer"})
+
+	env.ExecuteWorkflow("obj-order-outer")
+	require.NoError(t, env.GetWorkflowError())
+	assert.Equal(t, []string{"a", "m", "z"}, iterationOrder)
 }
 
 // TestForExecNumericAccumulatesResults verifies the numeric for.in variant still
 // returns a slice with one entry per iteration index.
 func TestForExecNumericAccumulatesResults(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "num-accum")
-
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -585,18 +647,13 @@ func TestForExecNumericAccumulatesResults(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			return st.Data[testConstIdx], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{Output: st.Data[testConstIdx], Context: nil}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstCount: 3})
@@ -614,8 +671,10 @@ func TestForExecNumericAccumulatesResults(t *testing.T) {
 	var result []any
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
-	// JSON round-trip through the Temporal child workflow boundary converts integers to float64.
+	// The workflow result still crosses Temporal's serialisation boundary.
 	assert.Equal(t, []any{float64(0), float64(1), float64(2)}, result)
+	// Inside the workflow, inline execution preserves the native integer values.
+	assert.Equal(t, []any{0, 1, 2}, state.Output)
 }
 
 // TestForExecNumericFloat64Whole verifies that the numeric for.in variant
@@ -624,8 +683,7 @@ func TestForExecNumericAccumulatesResults(t *testing.T) {
 // may arrive as float64 after a JSON round trip even when they were authored
 // as integer literals, so this case must be supported.
 func TestForExecNumericFloat64Whole(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "num-float64-whole")
-
+	callCount := 0
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -640,20 +698,14 @@ func TestForExecNumericFloat64Whole(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			callCount++
+			return st.Data[testConstIdx], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	callCount := 0
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			callCount++
-			return forChildResult{Output: st.Data[testConstIdx], Context: nil}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	// A float64 whole number must be accepted and treated as an iteration count.
@@ -672,17 +724,16 @@ func TestForExecNumericFloat64Whole(t *testing.T) {
 	var result []any
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
-	// JSON round-trip through the Temporal child workflow boundary converts integers to float64.
 	assert.Equal(t, []any{float64(0), float64(1), float64(2), float64(3), float64(4)}, result)
-	assert.Equal(t, 5, callCount, "child workflow must be invoked once per iteration")
+	assert.Equal(t, []any{0, 1, 2, 3, 4}, state.Output)
+	assert.Equal(t, 5, callCount, "inline body must be invoked once per iteration")
 }
 
 // TestForExecNumericFloat64Zero verifies that a float64 zero results in no
 // iterations rather than an error. Zero is a whole number so the trunc check
 // must accept it.
 func TestForExecNumericFloat64Zero(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "num-float64-zero")
-
+	callCount := 0
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -697,20 +748,14 @@ func TestForExecNumericFloat64Zero(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			callCount++
+			return st.Data[testConstIdx], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	callCount := 0
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			callCount++
-			return forChildResult{Output: st.Data[testConstIdx], Context: nil}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstCount: float64(0)})
@@ -729,7 +774,7 @@ func TestForExecNumericFloat64Zero(t *testing.T) {
 	assert.NoError(t, env.GetWorkflowResult(&result))
 
 	assert.Equal(t, []any{}, result, "zero count must produce no iterations")
-	assert.Equal(t, 0, callCount, "child workflow must not be invoked when count is zero")
+	assert.Equal(t, 0, callCount, "inline body must not be invoked when count is zero")
 }
 
 // TestForExecNumericFloat64Fractional verifies that a for.in expression
@@ -737,8 +782,7 @@ func TestForExecNumericFloat64Zero(t *testing.T) {
 // error that names the offending value. Silent truncation would violate the
 // determinism and explicit-validation principles of the engine.
 func TestForExecNumericFloat64Fractional(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "num-float64-frac")
-
+	callCount := 0
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -753,20 +797,14 @@ func TestForExecNumericFloat64Fractional(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			callCount++
+			return st.Data[testConstIdx], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	callCount := 0
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			callCount++
-			return forChildResult{Output: st.Data[testConstIdx], Context: nil}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstCount: 5.5})
@@ -791,8 +829,6 @@ func TestForExecNumericFloat64Fractional(t *testing.T) {
 // (item, index or custom names) are not present in the parent state's Data
 // after the for loop completes.
 func TestForExecLoopVarsDoNotLeakToParent(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "leak-check")
-
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -807,18 +843,13 @@ func TestForExecLoopVarsDoNotLeakToParent(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			return st.Data[constDefaultItemVar], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{Output: st.Data[constDefaultItemVar], Context: nil}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstItems: []any{"a", "b"}})
@@ -845,8 +876,6 @@ func TestForExecLoopVarsDoNotLeakToParent(t *testing.T) {
 // workingState.Context is loop-private and must not overwrite the surrounding
 // workflow context. Loop-internal Data changes must also not appear in parent Data.
 func TestForExecContextDoesNotLeakToParent(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "ctx-leak")
-
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -861,21 +890,14 @@ func TestForExecContextDoesNotLeakToParent(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(st *utils.State) (any, error) {
+			st.Context = map[string]any{testConstLast: st.Data[constDefaultItemVar]}
+			return st.Data[constDefaultItemVar], nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{
-				Output:  st.Data[constDefaultItemVar],
-				Context: map[string]any{testConstLast: st.Data[constDefaultItemVar]},
-			}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstItems: []any{"x", "y"}})
@@ -902,8 +924,6 @@ func TestForExecContextDoesNotLeakToParent(t *testing.T) {
 // iteration's internal $output. The per-iteration $output lives only in
 // workingState and is used solely for while evaluation between iterations.
 func TestForExecOutputIsAggregatedResult(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "no-out-leak")
-
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -918,18 +938,13 @@ func TestForExecOutputIsAggregatedResult(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(*utils.State) (any, error) {
+			return "iteration-output", nil
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{Output: "iteration-output", Context: nil}, nil
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstItems: []any{"a"}})
@@ -956,8 +971,6 @@ func TestForExecOutputIsAggregatedResult(t *testing.T) {
 // happens after a clean loop exit so that retries and catch handlers see
 // the original state.
 func TestForExecErrorLeavesParentStateUnchanged(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "err-unchanged")
-
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -972,18 +985,13 @@ func TestForExecErrorLeavesParentStateUnchanged(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(*utils.State) (any, error) {
+			return nil, fmt.Errorf("simulated iteration failure")
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{}, fmt.Errorf("simulated iteration failure")
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.Context = map[string]any{"original": true}
@@ -998,7 +1006,7 @@ func TestForExecErrorLeavesParentStateUnchanged(t *testing.T) {
 	}, workflow.RegisterOptions{Name: "err-unchanged-outer"})
 
 	env.ExecuteWorkflow("err-unchanged-outer")
-	// The workflow must have failed due to the child error.
+	// The workflow must have failed due to the body error.
 	assert.Error(t, env.GetWorkflowError())
 
 	// Context, Output, and Data must all be unchanged.
@@ -1016,16 +1024,9 @@ func TestForExecErrorLeavesParentStateUnchanged(t *testing.T) {
 		"loop-local variable must not leak into parent Data when an iteration fails")
 }
 
-// TestForIteratorChildEndsPropagatesErrEnd proves that a for-loop iteration
-// body emitting `then: end` causes the for-task to surface flow.ErrEnd to
-// its caller. The iteration's child workflow returns the typed Temporal
-// end ApplicationError (the way a nested DoTaskBuilder.workflowExecutor
-// emits ErrEnd across the child boundary); iterator() must decode that
-// error rather than wrapping it as a generic iteration failure, so the
-// enclosing scope can keep propagating end upward.
-func TestForIteratorChildEndsPropagatesErrEnd(t *testing.T) {
-	childWorkflowName := utils.GenerateChildWorkflowName("for", "iter-end")
-
+// TestForIteratorBodyEndsPropagatesErrEnd proves that an inline for-loop body
+// emitting `then: end` causes the for-task to surface flow.ErrEnd unchanged.
+func TestForIteratorBodyEndsPropagatesErrEnd(t *testing.T) {
 	b := &ForTaskBuilder{
 		builder: builder[*model.ForTask]{
 			doc:          testWorkflow,
@@ -1040,18 +1041,13 @@ func TestForIteratorChildEndsPropagatesErrEnd(t *testing.T) {
 				Do: &model.TaskList{&model.TaskItem{Key: testConstStep, Task: &model.DoTask{}}},
 			},
 		},
-		childWorkflowName: childWorkflowName,
+		body: testInlineForBody(func(*utils.State) (any, error) {
+			return "final-output", flow.ErrEnd
+		}),
 	}
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(
-		func(ctx workflow.Context, input any, st *utils.State) (forChildResult, error) {
-			return forChildResult{}, flow.NewEndApplicationError(nil)
-		},
-		workflow.RegisterOptions{Name: childWorkflowName},
-	)
 
 	state := utils.NewState()
 	state.AddData(map[string]any{testConstItems: []any{"only-item"}})
@@ -1064,7 +1060,6 @@ func TestForIteratorChildEndsPropagatesErrEnd(t *testing.T) {
 
 	err := env.GetWorkflowError()
 	require.Error(t, err)
-	// The error surfaced to the for-task's caller must mention ErrEnd so
-	// the surrounding scope can recognise the directive.
 	assert.Contains(t, err.Error(), flow.ErrEnd.Error())
+	assert.Equal(t, "final-output", state.Output)
 }

--- a/pkg/zigflow/tasks/task_builder_try.go
+++ b/pkg/zigflow/tasks/task_builder_try.go
@@ -19,6 +19,7 @@ package tasks
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/rs/zerolog/log"
@@ -52,43 +53,36 @@ func NewTryTaskBuilder(
 
 type TryTaskBuilder struct {
 	builder[*model.TryTask]
-
-	tryChildWorkflowName   string
-	catchChildWorkflowName string
 }
 
 func (t *TryTaskBuilder) Build() (TemporalWorkflowFunc, error) {
+	bodies := make(map[string]TemporalWorkflowFunc, len(t.getTasks()))
 	for taskType, list := range t.getTasks() {
-		name, builder, err := t.createBuilder(taskType, list)
+		builder, err := t.createBuilder(taskType, list)
 		if err != nil {
-			return nil, fmt.Errorf("erroring registering %s tasks for %s: %w", taskType, t.GetTaskName(), err)
+			return nil, fmt.Errorf("error creating %s tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
 
-		if _, err = builder.Build(); err != nil {
-			log.Error().Str("task", t.GetTaskName()).Str("taskType", taskType).Msg("Error building for workflow")
-			return nil, fmt.Errorf("error building for workflow: %w", err)
-		}
-
-		if taskType == tryBodyPathSegment {
-			t.tryChildWorkflowName = name
-		} else {
-			t.catchChildWorkflowName = name
+		bodies[taskType], err = builder.buildInline()
+		if err != nil {
+			log.Error().Str("task", t.GetTaskName()).Str("taskType", taskType).Msg("Error building inline tasks")
+			return nil, fmt.Errorf("error building inline %s tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
 	}
 
-	return t.exec()
+	return t.exec(bodies[tryBodyPathSegment], bodies[catchBodyPathSegment])
 }
 
 func (t *TryTaskBuilder) PostLoad() error {
 	for taskType, list := range t.getTasks() {
-		_, builder, err := t.createBuilder(taskType, list)
+		builder, err := t.createBuilder(taskType, list)
 		if err != nil {
-			return fmt.Errorf("erroring registering %s post load tasks for %s: %w", taskType, t.GetTaskName(), err)
+			return fmt.Errorf("error creating %s post load tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
 
 		if err = builder.PostLoad(); err != nil {
-			log.Error().Str("task", t.GetTaskName()).Str("taskType", taskType).Msg("Error building for workflow")
-			return fmt.Errorf("error building for post load workflow: %w", err)
+			log.Error().Str("task", t.GetTaskName()).Str("taskType", taskType).Msg("Error running post load for inline tasks")
+			return fmt.Errorf("error running post load for inline %s tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
 	}
 
@@ -97,9 +91,9 @@ func (t *TryTaskBuilder) PostLoad() error {
 
 func (t *TryTaskBuilder) Validate() error {
 	for taskType, list := range t.getTasks() {
-		_, builder, err := t.createBuilder(taskType, list)
+		builder, err := t.createBuilder(taskType, list)
 		if err != nil {
-			return fmt.Errorf("error registering %s validate tasks for %s: %w", taskType, t.GetTaskName(), err)
+			return fmt.Errorf("error creating %s validate tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
 		if err := builder.Validate(); err != nil {
 			return fmt.Errorf("error validating %s tasks for %s: %w", taskType, t.GetTaskName(), err)
@@ -109,7 +103,18 @@ func (t *TryTaskBuilder) Validate() error {
 }
 
 func (t *TryTaskBuilder) buildCatchError(err error) map[string]any {
-	out := map[string]any{}
+	out := map[string]any{
+		"message":      err.Error(),
+		"nonRetryable": false,
+	}
+
+	errType := reflect.TypeOf(err)
+	for errType.Kind() == reflect.Pointer {
+		errType = errType.Elem()
+	}
+	if errType.Name() != "" {
+		out["type"] = errType.Name()
+	}
 
 	if childErr, ok := errors.AsType[*temporal.ChildWorkflowExecutionError](err); ok {
 		out["childWorkflow"] = map[string]any{
@@ -181,31 +186,19 @@ func (t *TryTaskBuilder) buildCatchError(err error) map[string]any {
 	return out
 }
 
-func (t *TryTaskBuilder) exec() (TemporalWorkflowFunc, error) {
+func (t *TryTaskBuilder) exec(tryFn, catchFn TemporalWorkflowFunc) (TemporalWorkflowFunc, error) {
 	return func(ctx workflow.Context, input any, state *utils.State) (output any, err error) {
 		logger := workflow.GetLogger(ctx)
 
-		opts := workflow.ChildWorkflowOptions{
-			WorkflowID: fmt.Sprintf("%s_try", workflow.GetInfo(ctx).WorkflowExecution.ID),
-		}
-		childCtx := workflow.WithChildOptions(ctx, opts)
-
-		var res map[string]any
-		if err := workflow.ExecuteChildWorkflow(childCtx, t.tryChildWorkflowName, state.Input, state).Get(ctx, &res); err != nil {
-			// A `then: end` directive inside the try body crosses the
-			// child workflow boundary as a typed Temporal ApplicationError.
-			// That is a deliberate workflow termination, not a failure to
-			// be caught: surface it as flow.ErrEnd so the do-task pipeline
-			// can keep propagating end upward, and preserve the carried
-			// output from the child so the root completion reflects it.
-			// Crucially, this skips the catch handler.
-			if endPayload, isEnd := flow.DecodeEndApplicationError(err); isEnd {
-				logger.Info("Try child workflow signalled end; propagating without running catch",
-					"tryWorkflow", t.tryChildWorkflowName, "carriedOutput", endPayload.Output)
-				return endPayload.Output, flow.ErrEnd
+		tryState := state.Clone()
+		res, err := tryFn(ctx, tryState.Input, tryState)
+		if err != nil {
+			if errors.Is(err, flow.ErrEnd) {
+				logger.Info("Try tasks signalled end; propagating without running catch")
+				return res, err
 			}
 
-			logger.Warn("Workflow failed, catching the error", "tryWorkflow", t.tryChildWorkflowName, "catchWorkflow", t.catchChildWorkflowName)
+			logger.Warn("Try tasks failed, catching the error")
 
 			// Expose the caught error to the catch tasks so they can
 			// interrogate it. The Open Workflow Specification names this
@@ -225,25 +218,14 @@ func (t *TryTaskBuilder) exec() (TemporalWorkflowFunc, error) {
 				errKey: t.buildCatchError(err),
 			})
 
-			// The try workflow has failed - let's run the catch workflow
-			opts := workflow.ChildWorkflowOptions{
-				WorkflowID: fmt.Sprintf("%s_catch", workflow.GetInfo(ctx).WorkflowExecution.ID),
-			}
-
-			childCtx := workflow.WithChildOptions(ctx, opts)
-
-			if err := workflow.ExecuteChildWorkflow(childCtx, t.catchChildWorkflowName, catchState.Input, catchState).Get(ctx, &res); err != nil {
-				// The catch handler itself may emit `then: end`. Propagate
-				// that as flow.ErrEnd rather than wrapping it as a generic
-				// catch-workflow failure.
-				if endPayload, isEnd := flow.DecodeEndApplicationError(err); isEnd {
-					logger.Info("Catch child workflow signalled end; propagating",
-						"catchWorkflow", t.catchChildWorkflowName, "carriedOutput", endPayload.Output)
-					return endPayload.Output, flow.ErrEnd
+			res, err = catchFn(ctx, catchState.Input, catchState)
+			if err != nil {
+				if errors.Is(err, flow.ErrEnd) {
+					logger.Info("Catch tasks signalled end; propagating")
+					return res, err
 				}
-				// Everything has failed
-				logger.Error("Error calling try workflow", "error", err)
-				return nil, fmt.Errorf("error calling catch workflow: %w", err)
+				logger.Error("Catch tasks failed", "error", err)
+				return nil, err
 			}
 		}
 
@@ -260,28 +242,27 @@ func (t *TryTaskBuilder) getTasks() map[string]*model.TaskList {
 
 func (t *TryTaskBuilder) createBuilder(
 	taskType string, list *model.TaskList,
-) (childWorkflowName string, builder TaskBuilder, err error) {
+) (*DoTaskBuilder, error) {
 	l := log.With().Str("task", t.GetTaskName()).Str("taskType", taskType).Logger()
 
 	if len(*list) == 0 {
-		err = fmt.Errorf("no tasks detected for %s in %s", taskType, t.GetTaskName())
-		return
+		return nil, fmt.Errorf("no tasks detected for %s in %s", taskType, t.GetTaskName())
 	}
 
-	childWorkflowName = utils.GenerateChildWorkflowName(taskType, t.GetTaskName())
-
-	childPath := t.childTaskPath(taskType)
-	b, err := NewTaskBuilder(
-		childWorkflowName, &model.DoTask{Do: list},
-		t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, childPath,
+	b, err := NewDoTaskBuilder(
+		t.temporalWorker,
+		&model.DoTask{Do: list},
+		fmt.Sprintf("%s.%s", t.GetTaskName(), taskType),
+		t.doc,
+		t.eventEmitter,
+		t.taskOpts,
 	)
 	if err != nil {
-		l.Error().Msg("Error creating the for task builder")
-		err = fmt.Errorf("error creating the for task builder: %w", err)
-		return
+		l.Error().Msg("Error creating the try task builder")
+		return nil, fmt.Errorf("error creating the try task builder: %w", err)
 	}
 
-	builder = b
+	b.setTaskPath(t.childTaskPath(taskType))
 
-	return
+	return b, nil
 }

--- a/pkg/zigflow/tasks/task_builder_try_test.go
+++ b/pkg/zigflow/tasks/task_builder_try_test.go
@@ -25,10 +25,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/flow"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
+
+type namedTryError struct{}
+
+func (namedTryError) Error() string { return "plain" }
 
 func TestTryTaskBuilderGetTasks(t *testing.T) {
 	task := &model.TryTask{
@@ -53,6 +58,86 @@ func TestTryTaskBuilderGetTasks(t *testing.T) {
 	assert.Equal(t, task.Catch.Do, got["catch"])
 }
 
+func TestTryTaskBuilderBuildExecutesBodiesInline(t *testing.T) {
+	tests := []struct {
+		name    string
+		tryTask model.Task
+		want    map[string]any
+	}{
+		{
+			name: "try succeeds",
+			tryTask: &model.SetTask{
+				Set: model.NewObjectOrRuntimeExpr(map[string]any{testConstValue: "try"}),
+			},
+			want: map[string]any{testConstValue: "try"},
+		},
+		{
+			name: "catch handles failure",
+			tryTask: &model.RaiseTask{
+				Raise: model.RaiseTaskConfiguration{
+					Error: model.RaiseTaskError{Definition: &model.Error{
+						Type:   model.NewUriTemplate(model.ErrorTypeRuntime),
+						Title:  model.NewStringOrRuntimeExpr("try failed"),
+						Detail: model.NewStringOrRuntimeExpr("boom"),
+					}},
+				},
+			},
+			want: map[string]any{testConstHandledKey: true},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			events, readEventTypes := newRecordingEvents(t)
+			task := &model.TryTask{
+				Try: &model.TaskList{
+					&model.TaskItem{Key: "try-step", Task: tc.tryTask},
+				},
+				Catch: &model.TryTaskCatch{Do: &model.TaskList{
+					&model.TaskItem{Key: "catch-step", Task: &model.SetTask{
+						Set: model.NewObjectOrRuntimeExpr(map[string]any{testConstHandledKey: true}),
+					}},
+				}},
+			}
+			builder := &TryTaskBuilder{builder: builder[*model.TryTask]{
+				doc:            testWorkflow,
+				eventEmitter:   events,
+				name:           "try-inline",
+				task:           task,
+				temporalWorker: new(WorkflowRegistryMock),
+			}}
+
+			fn, err := builder.Build()
+			require.NoError(t, err)
+
+			state := utils.NewState()
+			childStarts := 0
+			var s testsuite.WorkflowTestSuite
+			env := s.NewTestWorkflowEnvironment()
+			env.SetOnChildWorkflowStartedListener(func(*workflow.Info, workflow.Context, converter.EncodedValues) {
+				childStarts++
+			})
+			env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+				return fn(ctx, nil, state)
+			}, workflow.RegisterOptions{Name: "try-inline"})
+
+			env.ExecuteWorkflow("try-inline")
+			require.NoError(t, env.GetWorkflowError())
+			var result map[string]any
+			require.NoError(t, env.GetWorkflowResult(&result))
+			assert.Equal(t, tc.want, result)
+			assert.Zero(t, childStarts)
+			assert.Empty(t, state.Data, "inline body mutations must remain isolated from the parent state")
+
+			eventTypes := readEventTypes()
+			assert.Contains(t, eventTypes, "dev.zigflow.task.started")
+			assert.Contains(t, eventTypes, "dev.zigflow.task.completed")
+			assert.NotContains(t, eventTypes, "dev.zigflow.workflow.started")
+			assert.NotContains(t, eventTypes, "dev.zigflow.workflow.completed")
+		})
+	}
+}
+
 func TestTryTaskBuilderExecRunsCatchOnError(t *testing.T) {
 	builder := &TryTaskBuilder{
 		builder: builder[*model.TryTask]{
@@ -64,27 +149,22 @@ func TestTryTaskBuilderExecRunsCatchOnError(t *testing.T) {
 				},
 			},
 		},
-		tryChildWorkflowName:   "try-child",
-		catchChildWorkflowName: "catch-child",
 	}
 
-	fn, err := builder.exec()
+	fn, err := builder.exec(
+		func(workflow.Context, any, *utils.State) (any, error) {
+			return nil, errors.New("boom")
+		},
+		func(workflow.Context, any, *utils.State) (any, error) {
+			return map[string]any{testConstHandledKey: true}, nil
+		},
+	)
 	assert.NoError(t, err)
 
 	state := utils.NewState()
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, errors.New("boom")
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return map[string]any{
-			testConstHandledKey: true,
-		}, nil
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
 
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
 		return fn(ctx, nil, state)
@@ -98,12 +178,41 @@ func TestTryTaskBuilderExecRunsCatchOnError(t *testing.T) {
 	assert.Equal(t, map[string]any{testConstHandledKey: true}, result)
 }
 
-// TestTryTaskBuilderExecPropagatesEndFromTryChild proves that a
-// `then: end` directive inside the try child workflow is NOT treated
-// as a catchable failure. The carried output must survive the boundary
-// and exec must surface flow.ErrEnd to the do-task pipeline so the
-// overall workflow ends cleanly, not run the catch handler.
-func TestTryTaskBuilderExecPropagatesEndFromTryChild(t *testing.T) {
+func TestTryTaskBuilderExecCatchStartsFromParentState(t *testing.T) {
+	builder := &TryTaskBuilder{builder: builder[*model.TryTask]{
+		task: &model.TryTask{Catch: &model.TryTaskCatch{}},
+	}}
+	parentState := utils.NewState().AddData(map[string]any{"parent": true})
+	var caughtData map[string]any
+	fn, err := builder.exec(
+		func(_ workflow.Context, _ any, state *utils.State) (any, error) {
+			state.AddData(map[string]any{"try-only": true})
+			return nil, namedTryError{}
+		},
+		func(_ workflow.Context, _ any, state *utils.State) (any, error) {
+			caughtData = state.Data
+			return map[string]any{testConstHandledKey: true}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		return fn(ctx, nil, parentState)
+	}, workflow.RegisterOptions{Name: "try-state-isolation"})
+	env.ExecuteWorkflow("try-state-isolation")
+	require.NoError(t, env.GetWorkflowError())
+
+	assert.Equal(t, true, caughtData["parent"])
+	assert.NotContains(t, caughtData, "try-only")
+	assert.NotContains(t, parentState.Data, "try-only")
+	assert.NotContains(t, parentState.Data, "error")
+}
+
+// TestTryTaskBuilderExecPropagatesEndFromTry proves that `then: end` inside
+// the inline try body is not treated as a catchable failure.
+func TestTryTaskBuilderExecPropagatesEndFromTry(t *testing.T) {
 	builder := &TryTaskBuilder{
 		builder: builder[*model.TryTask]{
 			name: "try-task-end",
@@ -114,31 +223,30 @@ func TestTryTaskBuilderExecPropagatesEndFromTryChild(t *testing.T) {
 				},
 			},
 		},
-		tryChildWorkflowName:   "try-child-end",
-		catchChildWorkflowName: "catch-child-end",
 	}
 
-	fn, err := builder.exec()
-	require.NoError(t, err)
-
 	state := utils.NewState()
-	childOutput := map[string]any{testConstValue: "end-time-output"}
+	tryOutput := map[string]any{testConstValue: "end-time-output"}
 	catchRan := false
+	fn, err := builder.exec(
+		func(workflow.Context, any, *utils.State) (any, error) {
+			return tryOutput, flow.ErrEnd
+		},
+		func(workflow.Context, any, *utils.State) (any, error) {
+			catchRan = true
+			return map[string]any{testConstHandledKey: true}, nil
+		},
+	)
+	require.NoError(t, err)
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
 
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, flow.NewEndApplicationError(childOutput)
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		catchRan = true
-		return map[string]any{testConstHandledKey: true}, nil
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
-
+	var output any
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return fn(ctx, nil, state)
+		var err error
+		output, err = fn(ctx, nil, state)
+		return nil, err
 	}, workflow.RegisterOptions{Name: "try-exec-end"})
 
 	env.ExecuteWorkflow("try-exec-end")
@@ -147,15 +255,13 @@ func TestTryTaskBuilderExecPropagatesEndFromTryChild(t *testing.T) {
 	wErr := env.GetWorkflowError()
 	require.Error(t, wErr)
 	assert.Contains(t, wErr.Error(), flow.ErrEnd.Error())
-	assert.False(t, catchRan, "catch handler must not run when the try child workflow signalled end")
+	assert.Equal(t, tryOutput, output)
+	assert.False(t, catchRan, "catch handler must not run when the try body signalled end")
 }
 
-// TestTryTaskBuilderExecPropagatesEndFromCatchChild is the symmetric
-// case: when the try child fails for a real reason and the catch
-// handler itself emits `then: end`, that end must propagate as
-// flow.ErrEnd rather than being wrapped as a generic catch-workflow
-// failure.
-func TestTryTaskBuilderExecPropagatesEndFromCatchChild(t *testing.T) {
+// TestTryTaskBuilderExecPropagatesEndFromCatch is the symmetric case: when
+// the inline catch body emits `then: end`, that end propagates unchanged.
+func TestTryTaskBuilderExecPropagatesEndFromCatch(t *testing.T) {
 	builder := &TryTaskBuilder{
 		builder: builder[*model.TryTask]{
 			name: "try-task-catch-end",
@@ -166,29 +272,28 @@ func TestTryTaskBuilderExecPropagatesEndFromCatchChild(t *testing.T) {
 				},
 			},
 		},
-		tryChildWorkflowName:   "try-child-real-fail",
-		catchChildWorkflowName: "catch-child-end",
 	}
-
-	fn, err := builder.exec()
-	require.NoError(t, err)
 
 	state := utils.NewState()
 	catchOutput := map[string]any{testConstValue: "catch-end-output"}
+	fn, err := builder.exec(
+		func(workflow.Context, any, *utils.State) (any, error) {
+			return nil, errors.New("boom from try")
+		},
+		func(workflow.Context, any, *utils.State) (any, error) {
+			return catchOutput, flow.ErrEnd
+		},
+	)
+	require.NoError(t, err)
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
 
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, errors.New("boom from try")
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, flow.NewEndApplicationError(catchOutput)
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
-
+	var output any
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return fn(ctx, nil, state)
+		var err error
+		output, err = fn(ctx, nil, state)
+		return nil, err
 	}, workflow.RegisterOptions{Name: "try-exec-catch-end"})
 
 	env.ExecuteWorkflow("try-exec-catch-end")
@@ -196,13 +301,14 @@ func TestTryTaskBuilderExecPropagatesEndFromCatchChild(t *testing.T) {
 	wErr := env.GetWorkflowError()
 	require.Error(t, wErr)
 	assert.Contains(t, wErr.Error(), flow.ErrEnd.Error())
+	assert.Equal(t, catchOutput, output)
 	assert.NotContains(t, wErr.Error(), "error calling catch workflow",
-		"catch-emitted end must not be wrapped as a catch-workflow failure")
+		"catch-emitted end must not be wrapped as a child-workflow failure")
 }
 
-// runCatchAndCaptureState executes a try task whose try child fails, then
-// returns the $data the catch child workflow actually observed alongside the
-// parent state the exec function was handed. The catch child records the data
+// runCatchAndCaptureState executes a try task whose inline try body fails, then
+// returns the $data the inline catch body actually observed alongside the
+// parent state the exec function was handed. The catch body records the data
 // it receives into a closure-captured map so the test can assert on the exact
 // caught-error contract exposed under $data.
 func runCatchAndCaptureState(t *testing.T, catchAs string, tryErr error) (caughtData map[string]any, parentState *utils.State) {
@@ -219,26 +325,23 @@ func runCatchAndCaptureState(t *testing.T, catchAs string, tryErr error) (caught
 				},
 			},
 		},
-		tryChildWorkflowName:   "try-child-capture",
-		catchChildWorkflowName: "catch-child-capture",
 	}
 
-	fn, err := builder.exec()
+	fn, err := builder.exec(
+		func(workflow.Context, any, *utils.State) (any, error) {
+			return nil, tryErr
+		},
+		func(_ workflow.Context, _ any, st *utils.State) (any, error) {
+			caughtData = st.Data
+			return map[string]any{testConstHandledKey: true}, nil
+		},
+	)
 	require.NoError(t, err)
 
 	parentState = utils.NewState()
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, tryErr
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		caughtData = st.Data
-		return map[string]any{testConstHandledKey: true}, nil
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
 
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
 		return fn(ctx, nil, parentState)
@@ -250,27 +353,21 @@ func runCatchAndCaptureState(t *testing.T, catchAs string, tryErr error) (caught
 	return caughtData, parentState
 }
 
-// TestTryTaskBuilderExecExposesErrorUnderDefaultKey proves the catch child
-// workflow sees the caught error under $data.error when catch.as is unset.
+// TestTryTaskBuilderExecExposesErrorUnderDefaultKey proves the inline catch
+// body sees the caught error under $data.error when catch.as is unset.
 func TestTryTaskBuilderExecExposesErrorUnderDefaultKey(t *testing.T) {
 	caughtData, _ := runCatchAndCaptureState(t, "", temporal.NewApplicationError("kaboom", "MyAppError"))
 
 	caughtErr, ok := caughtData["error"].(map[string]any)
-	require.True(t, ok, "catch child must see the caught error under $data.error")
+	require.True(t, ok, "catch body must see the caught error under $data.error")
 
-	// The error crosses a real child workflow boundary, so it carries both the
-	// child workflow metadata and the unwrapped ApplicationError fields.
 	assert.Equal(t, "MyAppError", caughtErr["type"])
 	assert.Equal(t, "kaboom", caughtErr["message"])
-	assert.Contains(t, caughtErr, "childWorkflow")
-	childMeta, ok := caughtErr["childWorkflow"].(map[string]any)
-	require.True(t, ok)
-	assert.NotEmpty(t, childMeta["workflowType"])
-	assert.NotEmpty(t, childMeta["workflowID"])
+	assert.NotContains(t, caughtErr, "childWorkflow")
 }
 
-// TestTryTaskBuilderExecExposesErrorUnderCustomKey proves the catch child
-// workflow sees the caught error under $data.<catch.as> when it is configured,
+// TestTryTaskBuilderExecExposesErrorUnderCustomKey proves the inline catch
+// body sees the caught error under $data.<catch.as> when it is configured,
 // and that the default "error" key is not used in that case.
 func TestTryTaskBuilderExecExposesErrorUnderCustomKey(t *testing.T) {
 	const customKey = "failure"
@@ -278,7 +375,7 @@ func TestTryTaskBuilderExecExposesErrorUnderCustomKey(t *testing.T) {
 	caughtData, _ := runCatchAndCaptureState(t, customKey, temporal.NewApplicationError("kaboom", "MyAppError"))
 
 	caughtErr, ok := caughtData[customKey].(map[string]any)
-	require.True(t, ok, "catch child must see the caught error under the custom $data key")
+	require.True(t, ok, "catch body must see the caught error under the custom $data key")
 	assert.Equal(t, "MyAppError", caughtErr["type"])
 	assert.Equal(t, "kaboom", caughtErr["message"])
 
@@ -296,6 +393,45 @@ func TestTryTaskBuilderExecDoesNotLeakErrorIntoParentState(t *testing.T) {
 	assert.NotContains(t, parentState.Data, "error",
 		"caught error must not leak back into the parent state after catch completes")
 	assert.Empty(t, parentState.Data, "parent state data must be untouched by catch error injection")
+}
+
+func TestTryTaskBuilderExecIncludesMetadataForExplicitChildFailure(t *testing.T) {
+	const childWorkflowName = "try-explicit-failing-child"
+
+	builder := &TryTaskBuilder{builder: builder[*model.TryTask]{
+		task: &model.TryTask{Catch: &model.TryTaskCatch{}},
+	}}
+	var caughtErr map[string]any
+	fn, err := builder.exec(
+		func(ctx workflow.Context, _ any, _ *utils.State) (any, error) {
+			return nil, workflow.ExecuteChildWorkflow(ctx, childWorkflowName).Get(ctx, nil)
+		},
+		func(_ workflow.Context, _ any, state *utils.State) (any, error) {
+			caughtErr, _ = state.Data["error"].(map[string]any)
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflowWithOptions(func(workflow.Context) error {
+		return temporal.NewApplicationError("child failed", "ExplicitChildError")
+	}, workflow.RegisterOptions{Name: childWorkflowName})
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		return fn(ctx, nil, utils.NewState())
+	}, workflow.RegisterOptions{Name: "try-explicit-child-catch"})
+
+	env.ExecuteWorkflow("try-explicit-child-catch")
+	require.NoError(t, env.GetWorkflowError())
+	require.NotNil(t, caughtErr)
+	assert.Equal(t, "ExplicitChildError", caughtErr["type"])
+	assert.Equal(t, "child failed", caughtErr["message"])
+
+	childMetadata, ok := caughtErr["childWorkflow"].(map[string]any)
+	require.True(t, ok, "an actual child workflow failure must retain child metadata")
+	assert.Equal(t, childWorkflowName, childMetadata["workflowType"])
+	assert.NotEmpty(t, childMetadata["workflowID"])
 }
 
 // TestBuildCatchError gives direct, deterministic coverage of the Temporal
@@ -329,9 +465,12 @@ func TestBuildCatchError(t *testing.T) {
 		assert.NotContains(t, out, "details")
 	})
 
-	t.Run("non-application error yields empty map", func(t *testing.T) {
-		out := tb.buildCatchError(errors.New("plain"))
+	t.Run("generic error fields", func(t *testing.T) {
+		out := tb.buildCatchError(namedTryError{})
 
-		assert.Empty(t, out)
+		assert.Equal(t, "namedTryError", out["type"])
+		assert.Equal(t, "plain", out["message"])
+		assert.Equal(t, false, out["nonRetryable"])
+		assert.NotContains(t, out, "childWorkflow")
 	})
 }


### PR DESCRIPTION
## Summary

- execute `for` iteration bodies and `try`/`catch` blocks inline in the parent workflow
- remove their synthetic child workflow names, wrappers, and error serialisation round-trips
- preserve loop aggregation, state isolation, error enrichment, `then: end`, and explicit child-producing tasks
- document parent-history growth and the absence of Continue-As-New inside inline blocks
- add unit and end-to-end history assertions proving synthetic child starts are absent

## Why

The previous child-per-block implementation amplified reads and write-lock contention on hot parent executions. Running these structural blocks inline removes that fan-in while keeping explicit children such as `fork`, `run.workflow`, and named redirects unchanged.

Fixes #525.

## Behavioural impact

- no DSL, CLI, configuration, Temporal version marker, or public Go API is added
- commands inside `for`, `try`, and `catch` now contribute to the parent history
- inline scopes do not attempt Continue-As-New and do not inherit activity options from the enclosing structural task
- `childWorkflow` catch metadata is emitted only for failures from actual explicit child workflows

## Validation

- `go test ./... -count=1`
- `pre-commit run --all-files`
- documentation lint and production build
- central end-to-end suite using loopback-normalised Docker Compose endpoints
- focused `for-loop` and `try-catch` end-to-end suites, including parent-history assertions

The stock `task e2e` wrapper remains environment-sensitive on macOS/Colima because Docker Compose reports `0.0.0.0` endpoints. The full example sweep also encounters an unrelated HTTPS mock certificate trust failure in `batch-processing`; the affected `for-loop` and `try-catch` suites pass.
