### PR TITLE
BREAKING: Create standard error types starting with zigflow.dev domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Breaking changes should be rare and must be discussed in advance.
 ## Specification compatibility
 
 Zigflow is influenced by and aims to remain broadly compatible with the
-[Open Workflow Specification](https://serverlessworkflow.io).
+[Open Workflow Specification](https://open-workflow-specification.org).
 
 Where possible, new features and behavioural changes **should** align
 with the Open Workflow Specification (formerly Serverless Workflow) to

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **Declarative YAML workflows on Temporal. No SDK boilerplate.**
 
 Zigflow lets you define and run [Temporal](https://temporal.io) workflows using
-YAML, built on the [CNCF Open Workflow Specification](https://serverlessworkflow.io)
+YAML, built on the [CNCF Open Workflow Specification](https://open-workflow-specification.org)
 (formerly Serverless Workflow). You write a workflow definition; Zigflow
 compiles it into a fully-featured Temporal workflow with retries, state
 management and deterministic execution. No Go, Java or TypeScript workflow
@@ -402,7 +402,7 @@ Bug reports, feedback and contributions are welcome.
 ## Related projects
 
 - [Temporal](https://temporal.io)
-- [CNCF Open Workflow Specification](https://serverlessworkflow.io)
+- [CNCF Open Workflow Specification](https://open-workflow-specification.org)
 - [Helm chart](./charts/zigflow)
 
 ---

--- a/docs/docs/concepts/comparing-zigflow-and-temporal-sdks.md
+++ b/docs/docs/concepts/comparing-zigflow-and-temporal-sdks.md
@@ -16,7 +16,7 @@ higher-level abstraction like Zigflow.
 
 Zigflow is a workflow worker that reads YAML, validates it and runs it on
 Temporal. You define a workflow as data using a structure inspired by the
-[CNCF Open Workflow Specification (formerly Serverless Workflow)](https://serverlessworkflow.io).
+[CNCF Open Workflow Specification (formerly Serverless Workflow)](https://open-workflow-specification.org).
 Zigflow compiles that definition into a Temporal workflow at startup and
 registers a worker against a task queue.
 

--- a/docs/docs/concepts/error-handling-and-retries.md
+++ b/docs/docs/concepts/error-handling-and-retries.md
@@ -188,7 +188,7 @@ Problem Details format.
 - rejectRequest:
     raise:
       error:
-        type: https://serverlessworkflow.io/spec/1.0.0/errors/authorization
+        type: https://zigflow.dev/spec/1.0.0/errors/authorization
         status: 403
         title: Forbidden
         detail: Only admin users can perform this action
@@ -198,14 +198,14 @@ Standard error types from the Open Workflow Specification (formerly Serverless W
 
 | Type | Status |
 | --- | --- |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/configuration` | 400 |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/validation` | 400 |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/expression` | 400 |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/authentication` | 401 |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/authorization` | 403 |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/timeout` | 408 |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/communication` | 500 |
-| `https://serverlessworkflow.io/spec/1.0.0/errors/runtime` | 500 |
+| `https://zigflow.dev/spec/1.0.0/errors/configuration` | 400 |
+| `https://zigflow.dev/spec/1.0.0/errors/validation` | 400 |
+| `https://zigflow.dev/spec/1.0.0/errors/expression` | 400 |
+| `https://zigflow.dev/spec/1.0.0/errors/authentication` | 401 |
+| `https://zigflow.dev/spec/1.0.0/errors/authorization` | 403 |
+| `https://zigflow.dev/spec/1.0.0/errors/timeout` | 408 |
+| `https://zigflow.dev/spec/1.0.0/errors/communication` | 500 |
+| `https://zigflow.dev/spec/1.0.0/errors/runtime` | 500 |
 
 The status shown is the recommended default. Use the HTTP status code that
 best describes the error.

--- a/docs/docs/concepts/glossary.md
+++ b/docs/docs/concepts/glossary.md
@@ -37,7 +37,7 @@ Domain-specific language. In this context, the YAML format that Zigflow uses
 to define workflows.
 
 Zigflow's DSL is based on the
-[CNCF Open Workflow Specification v1.0 (formerly Serverless Workflow)](https://serverlessworkflow.io).
+[CNCF Open Workflow Specification v1.0 (formerly Serverless Workflow)](https://open-workflow-specification.org).
 
 ---
 

--- a/docs/docs/dsl/intro.md
+++ b/docs/docs/dsl/intro.md
@@ -18,7 +18,7 @@ and the comparison with the
 [Temporal SDK](/docs/concepts/comparing-zigflow-and-temporal-sdks).
 :::
 
-Zigflow is built upon the [CNCF's Open Workflow Specification](https://serverlessworkflow.io)
+Zigflow is built upon the [CNCF's Open Workflow Specification](https://open-workflow-specification.org)
 project. This provides a solid foundation of a comprehensive and vendor-neutral
 framework. The [specification](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md)
 is well documented and acts as the inspiration behind this project.

--- a/docs/docs/dsl/tasks/raise.md
+++ b/docs/docs/dsl/tasks/raise.md
@@ -35,7 +35,7 @@ do:
   - bug:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/communication
+          type: https://zigflow.dev/spec/1.0.0/errors/communication
           status: 400
 ```
 
@@ -62,14 +62,14 @@ to another.
 
 | Type | Status[^1] | Description |
 | --- | :---: | --- |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/configuration](https://serverlessworkflow.io/spec/1.0.0/errors/configuration) | `400` | Errors resulting from incorrect or invalid configuration settings, such as missing or misconfigured environment variables, incorrect parameter values, or configuration file errors. |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/validation](https://serverlessworkflow.io/spec/1.0.0/errors/validation) | `400` | Errors arising from validation processes, such as validation of input data, schema validation failures, or validation constraints not being met. These errors indicate that the provided data or configuration does not adhere to the expected format or requirements specified by the workflow. |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/expression](https://serverlessworkflow.io/spec/1.0.0/errors/expression) | `400` | Errors occurring during the evaluation of runtime expressions, such as invalid syntax or unsupported operations. |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/authentication](https://serverlessworkflow.io/spec/1.0.0/errors/authentication) | `401` | Errors related to authentication failures. |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/authorization](https://serverlessworkflow.io/spec/1.0.0/errors/authorization) | `403` | Errors related to unauthorized access attempts or insufficient permissions to perform certain actions within the workflow. |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/timeout](https://serverlessworkflow.io/spec/1.0.0/errors/timeout) | `408` | Errors caused by timeouts during the execution of tasks or during interactions with external services. |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/communication](https://serverlessworkflow.io/spec/1.0.0/errors/communication) | `500` | Errors  encountered while communicating with external services, including network errors, service unavailable, or invalid responses. |
-| [https://serverlessworkflow.io/spec/1.0.0/errors/runtime](https://serverlessworkflow.io/spec/1.0.0/errors/runtime) | `500` | Errors occurring during the runtime execution of a workflow, including unexpected exceptions, errors related to resource allocation, or failures in handling workflow tasks. These errors typically occur during the actual execution of workflow components and may require runtime-specific handling and resolution strategies. |
+| [https://zigflow.dev/spec/1.0.0/errors/configuration](https://zigflow.dev/spec/1.0.0/errors/configuration) | `400` | Errors resulting from incorrect or invalid configuration settings, such as missing or misconfigured environment variables, incorrect parameter values, or configuration file errors. |
+| [https://zigflow.dev/spec/1.0.0/errors/validation](https://zigflow.dev/spec/1.0.0/errors/validation) | `400` | Errors arising from validation processes, such as validation of input data, schema validation failures, or validation constraints not being met. These errors indicate that the provided data or configuration does not adhere to the expected format or requirements specified by the workflow. |
+| [https://zigflow.dev/spec/1.0.0/errors/expression](https://zigflow.dev/spec/1.0.0/errors/expression) | `400` | Errors occurring during the evaluation of runtime expressions, such as invalid syntax or unsupported operations. |
+| [https://zigflow.dev/spec/1.0.0/errors/authentication](https://zigflow.dev/spec/1.0.0/errors/authentication) | `401` | Errors related to authentication failures. |
+| [https://zigflow.dev/spec/1.0.0/errors/authorization](https://zigflow.dev/spec/1.0.0/errors/authorization) | `403` | Errors related to unauthorized access attempts or insufficient permissions to perform certain actions within the workflow. |
+| [https://zigflow.dev/spec/1.0.0/errors/timeout](https://zigflow.dev/spec/1.0.0/errors/timeout) | `408` | Errors caused by timeouts during the execution of tasks or during interactions with external services. |
+| [https://zigflow.dev/spec/1.0.0/errors/communication](https://zigflow.dev/spec/1.0.0/errors/communication) | `500` | Errors  encountered while communicating with external services, including network errors, service unavailable, or invalid responses. |
+| [https://zigflow.dev/spec/1.0.0/errors/runtime](https://zigflow.dev/spec/1.0.0/errors/runtime) | `500` | Errors occurring during the runtime execution of a workflow, including unexpected exceptions, errors related to resource allocation, or failures in handling workflow tasks. These errors typically occur during the actual execution of workflow components and may require runtime-specific handling and resolution strategies. |
 
 [^1]: Default value. The `status code` that best describes the error should always be used.
 

--- a/docs/docs/dsl/tasks/switch.md
+++ b/docs/docs/dsl/tasks/switch.md
@@ -78,7 +78,7 @@ do:
   - handleUnknownType:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/validation
+          type: https://zigflow.dev/spec/1.0.0/errors/validation
           status: 400
           title: Unknown order type
           detail: ${ "Received order type: " + $input.orderType }

--- a/docs/docs/examples/error-handling.md
+++ b/docs/docs/examples/error-handling.md
@@ -64,7 +64,7 @@ Use the `raise` task to fail a workflow with a structured error:
     raise:
       error:
         type: >-
-          https://serverlessworkflow.io/spec/1.0.0/errors/validation
+          https://zigflow.dev/spec/1.0.0/errors/validation
         status: 400
         title: Missing required field
         detail: ${ "userId is required, got: " + ($input.userId | tostring) }

--- a/docs/docs/guides/extending-the-dsl.md
+++ b/docs/docs/guides/extending-the-dsl.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 # Extending the DSL
 
 Zigflow's DSL is based on the
-[Open Workflow Specification (formerly Serverless Workflow)](https://serverlessworkflow.io).
+[Open Workflow Specification (formerly Serverless Workflow)](https://open-workflow-specification.org).
 The mechanism on this page is the **only** sanctioned way to add
 semantics that the specification does not cover, and it exists for a
 narrow purpose: bridging the gap between an Open Workflow Specification task

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -333,7 +333,7 @@ const config = {
               },
               {
                 label: 'Open Workflow Specification',
-                href: 'https://serverlessworkflow.io',
+                href: 'https://open-workflow-specification.org',
               },
             ],
           },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -42,6 +42,15 @@ const vscodeLangserverTypesEsm = require
 /** @type {import('@docusaurus/types').PluginConfig[]} */
 const plugins = [
   loadExamplesPlugin,
+  [
+    '@docusaurus/plugin-content-docs',
+    {
+      id: 'spec',
+      path: 'spec',
+      routeBasePath: 'spec',
+      sidebarPath: false,
+    },
+  ],
   () => ({
     name: 'vscode-languageserver-types-esm-alias',
     configureWebpack() {

--- a/docs/spec/1.0.0/errors/authentication.mdx
+++ b/docs/spec/1.0.0/errors/authentication.mdx
@@ -1,0 +1,10 @@
+---
+title: Authentication
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/authentication"
+  description="Errors related to authentication failures."
+  status="401" />

--- a/docs/spec/1.0.0/errors/authorization.mdx
+++ b/docs/spec/1.0.0/errors/authorization.mdx
@@ -1,0 +1,10 @@
+---
+title: Authorization
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/authorization"
+  description="Errors related to unauthorized access attempts or insufficient permissions to perform certain actions within the workflow."
+  status="403" />

--- a/docs/spec/1.0.0/errors/communication.mdx
+++ b/docs/spec/1.0.0/errors/communication.mdx
@@ -1,0 +1,10 @@
+---
+title: Communication
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/communication"
+  description="Errors encountered while communicating with external services, including network errors, service unavailable, or invalid responses."
+  status="500" />

--- a/docs/spec/1.0.0/errors/configuration.mdx
+++ b/docs/spec/1.0.0/errors/configuration.mdx
@@ -1,0 +1,10 @@
+---
+title: Configuration
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/configuration"
+  description="Errors resulting from incorrect or invalid configuration settings, such as missing or misconfigured environment variables, incorrect parameter values, or configuration file errors."
+  status="400" />

--- a/docs/spec/1.0.0/errors/expression.mdx
+++ b/docs/spec/1.0.0/errors/expression.mdx
@@ -1,0 +1,10 @@
+---
+title: Expression
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/expression"
+  description="Errors occurring during the evaluation of runtime expressions, such as invalid syntax or unsupported operations."
+  status="400" />

--- a/docs/spec/1.0.0/errors/runtime.mdx
+++ b/docs/spec/1.0.0/errors/runtime.mdx
@@ -1,0 +1,10 @@
+---
+title: Runtime
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/runtime"
+  description="Errors occurring during the runtime execution of a workflow, including unexpected exceptions, errors related to resource allocation, or failures in handling workflow tasks. These errors typically occur during the actual execution of workflow components and may require runtime-specific handling and resolution strategies."
+  status="500" />

--- a/docs/spec/1.0.0/errors/timeout.mdx
+++ b/docs/spec/1.0.0/errors/timeout.mdx
@@ -1,0 +1,10 @@
+---
+title: Timeout
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/timeout"
+  description="Errors caused by timeouts during the execution of tasks or during interactions with external services."
+  status="408" />

--- a/docs/spec/1.0.0/errors/validation.mdx
+++ b/docs/spec/1.0.0/errors/validation.mdx
@@ -1,0 +1,10 @@
+---
+title: Validation
+---
+
+import ErrorSpec from '@site/src/components/ErrorSpec';
+
+<ErrorSpec
+  type="https://zigflow.dev/spec/1.0.0/errors/validation"
+  description="Errors arising from validation processes, such as validation of input data, schema validation failures, or validation constraints not being met. These errors indicate that the provided data or configuration does not adhere to the expected format or requirements specified by the workflow."
+  status="400" />

--- a/docs/src/components/ErrorSpec/index.tsx
+++ b/docs/src/components/ErrorSpec/index.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ErrorSpecProps = {
+  type: string;
+  description: string;
+  status: number;
+};
+
+export default function ErrorSpec(props: ErrorSpecProps) {
+  return (
+    <>
+      <h3>{props.type}</h3>
+      <p>Code: {props.status}</p>
+      <p>{props.description}</p>
+    </>
+  )
+}

--- a/examples/raise/workflow.yaml
+++ b/examples/raise/workflow.yaml
@@ -19,5 +19,5 @@ do:
   - error:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/communication
+          type: https://zigflow.dev/spec/1.0.0/errors/communication
           status: 400

--- a/pkg/zigflow/models/errors.go
+++ b/pkg/zigflow/models/errors.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import "github.com/open-workflow-specification/sdk-go/v4/model"
+
+const (
+	ErrorTypeConfiguration  = "https://zigflow.dev/spec/1.0.0/errors/configuration"
+	ErrorTypeValidation     = "https://zigflow.dev/spec/1.0.0/errors/validation"
+	ErrorTypeExpression     = "https://zigflow.dev/spec/1.0.0/errors/expression"
+	ErrorTypeAuthentication = "https://zigflow.dev/spec/1.0.0/errors/authentication"
+	ErrorTypeAuthorization  = "https://zigflow.dev/spec/1.0.0/errors/authorization"
+	ErrorTypeTimeout        = "https://zigflow.dev/spec/1.0.0/errors/timeout"
+	ErrorTypeCommunication  = "https://zigflow.dev/spec/1.0.0/errors/communication"
+	ErrorTypeRuntime        = "https://zigflow.dev/spec/1.0.0/errors/runtime"
+)
+
+func NewErrConfiguration(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeConfiguration,
+		400,
+		"Configuration Error",
+		detail,
+		instance,
+	)
+}
+
+func NewErrValidation(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeValidation,
+		400,
+		"Validation Error",
+		detail,
+		instance,
+	)
+}
+
+func NewErrExpression(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeExpression,
+		400,
+		"Expression Error",
+		detail,
+		instance,
+	)
+}
+
+func NewErrAuthentication(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeAuthentication,
+		401,
+		"Authentication Error",
+		detail,
+		instance,
+	)
+}
+
+func NewErrAuthorization(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeAuthorization,
+		403,
+		"Authorization Error",
+		detail,
+		instance,
+	)
+}
+
+func NewErrTimeout(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeTimeout,
+		408,
+		"Timeout Error",
+		detail,
+		instance,
+	)
+}
+
+func NewErrCommunication(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeCommunication,
+		500,
+		"Communication Error",
+		detail,
+		instance,
+	)
+}
+
+func NewErrRuntime(detail error, instance string) *model.Error {
+	return newError(
+		ErrorTypeRuntime,
+		500,
+		"Runtime Error",
+		detail,
+		instance,
+	)
+}
+
+// newError creates a new structured error
+func newError(errType string, status int, title string, detail error, instance string) *model.Error {
+	if detail != nil {
+		return &model.Error{
+			Type:   model.NewUriTemplate(errType),
+			Status: status,
+			Title:  model.NewStringOrRuntimeExpr(title),
+			Detail: model.NewStringOrRuntimeExpr(detail.Error()),
+			Instance: &model.JsonPointerOrRuntimeExpression{
+				Value: instance,
+			},
+		}
+	}
+
+	return &model.Error{
+		Type:   model.NewUriTemplate(errType),
+		Status: status,
+		Title:  model.NewStringOrRuntimeExpr(title),
+		Instance: &model.JsonPointerOrRuntimeExpression{
+			Value: instance,
+		},
+	}
+}

--- a/pkg/zigflow/tasks/task_builder_raise.go
+++ b/pkg/zigflow/tasks/task_builder_raise.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/zigflow/zigflow/pkg/cloudevents"
 	"github.com/zigflow/zigflow/pkg/utils"
+	"github.com/zigflow/zigflow/pkg/zigflow/models"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -60,14 +61,14 @@ const (
 
 // Open Workflow Specification native errors
 var raiseErrFuncMapping = map[string]func(error, string) *model.Error{
-	model.ErrorTypeAuthentication: model.NewErrAuthentication,
-	model.ErrorTypeValidation:     model.NewErrValidation,
-	model.ErrorTypeCommunication:  model.NewErrCommunication,
-	model.ErrorTypeAuthorization:  model.NewErrAuthorization,
-	model.ErrorTypeConfiguration:  model.NewErrConfiguration,
-	model.ErrorTypeExpression:     model.NewErrExpression,
-	model.ErrorTypeRuntime:        model.NewErrRuntime,
-	model.ErrorTypeTimeout:        model.NewErrTimeout,
+	models.ErrorTypeAuthentication: models.NewErrAuthentication,
+	models.ErrorTypeValidation:     models.NewErrValidation,
+	models.ErrorTypeCommunication:  models.NewErrCommunication,
+	models.ErrorTypeAuthorization:  models.NewErrAuthorization,
+	models.ErrorTypeConfiguration:  models.NewErrConfiguration,
+	models.ErrorTypeExpression:     models.NewErrExpression,
+	models.ErrorTypeRuntime:        models.NewErrRuntime,
+	models.ErrorTypeTimeout:        models.NewErrTimeout,
 }
 
 var temporalErrMapping = map[string]func(error, string) error{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes the error types with the URL `https://serverlessworkflow.io` and `https://open-workflow-specification.org` and replaces with `https://zigflow.dev`.

No functional changes beyond that, but the old errors won't retain their old HTTP types.

## Related issue
<!-- Most changes should be discussed in an issue before implementation. -->
<!-- Link the issue using Fixes #..., Closes #... or Relates to #... -->
<!-- If no issue exists, explain why. -->

Fixes #535

## How to test

<!-- Provide the steps used to verify this change -->

## Checklist

* [ ] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
* [ ] All tests pass
* [ ] Tests have been added or updated where behaviour changed
* [ ] Documentation has been updated where needed
