### PR TITLE
fix(try): remove the call to a child workflow

### DIFF
--- a/examples/try-catch/.air.toml
+++ b/examples/try-catch/.air.toml
@@ -5,7 +5,8 @@ tmp_dir = "tmp"
 [build]
   args_bin = [
     "run",
-    "--file ./workflow.yaml"
+    "--file ./workflow.yaml",
+    "--dir=''"
   ]
   bin = "./tmp/main"
   cmd = "go build -o ./tmp/main ../.."

--- a/examples/try-catch/e2e_test.go
+++ b/examples/try-catch/e2e_test.go
@@ -67,5 +67,6 @@ func TestTryCatchE2E(t *testing.T) {
 	require.NoError(t, we.Get(runCtx, &got), "get workflow result")
 	t.Logf("workflow output: %v", got)
 
-	assert.Equal(t, "some error", got["err"], "catch block should set err")
+	assert.Equal(t, "Get User error", got["title"], "catch block should set title")
+	assert.NotEmpty(t, got["error"], "catch block error should not be empty")
 }

--- a/examples/try-catch/workflow.yaml
+++ b/examples/try-catch/workflow.yaml
@@ -22,4 +22,5 @@ do:
         do:
           - setError:
               set:
-                err: some error
+                error: ${ $data.error }
+                title: Get User error

--- a/pkg/zigflow/tasks/task_builder_do.go
+++ b/pkg/zigflow/tasks/task_builder_do.go
@@ -37,10 +37,26 @@ import (
 
 type DoTaskOpts struct {
 	DisableRegisterWorkflow bool
-	Envvars                 map[string]any
-	MaxHistoryLength        int
-	Telemetry               *telemetry.Telemetry
-	Validator               *utils.Validator
+	// Nested marks this task list as executing inline inside an enclosing
+	// workflow's Temporal context rather than as a workflow of its own.
+	//
+	// It exists because the workflow context can no longer identify the
+	// logical root boundary on its own: an inline body (a try or catch
+	// task list) runs in the same Temporal context as the workflow that
+	// invoked it, so isRootWorkflow(ctx) reports true even though the
+	// builder is logically nested. Nested makes the distinction explicit
+	// so `then: end` inside an inline body ends the whole workflow instead
+	// of being consumed as a clean root completion.
+	//
+	// It is deliberately separate from DisableRegisterWorkflow: the
+	// for-task also disables registration for its inner body but then
+	// invokes it inside a registered child workflow, where the existing
+	// context-based root detection is still correct.
+	Nested           bool
+	Envvars          map[string]any
+	MaxHistoryLength int
+	Telemetry        *telemetry.Telemetry
+	Validator        *utils.Validator
 }
 
 func NewDoTaskBuilder(
@@ -230,24 +246,41 @@ func (t *DoTaskBuilder) workflowExecutor(tasks []workflowFunc) TemporalWorkflowF
 		})
 
 		// Iterate through the tasks to create the workflow. An `end` flow
-		// directive propagates outward as flow.ErrEnd. At the true root
-		// workflow boundary this is a clean termination, not a failure.
-		// At nested child workflow boundaries (e.g. redirect targets,
-		// for-loop iteration bodies) we re-emit ErrEnd as a serialisable
-		// Temporal ApplicationError so the parent workflow can detect it
-		// and continue propagating "end" upward until it reaches the
-		// root. Without this, ErrEnd would be silently swallowed by every
-		// child workflow boundary and `then: end` could only end the
-		// innermost scope rather than the overall workflow.
+		// directive propagates outward as flow.ErrEnd. There are three
+		// boundaries it can reach, and each handles it differently:
 		//
-		// state.Output is included in the end signal so the child's
-		// effective output survives the boundary; the parent's
+		//   true root workflow    consumes flow.ErrEnd as a successful
+		//                         workflow completion.
+		//   nested inline body    returns flow.ErrEnd unchanged with its
+		//                         effective output, so the invoking task
+		//                         (e.g. TryTaskBuilder.exec) keeps
+		//                         propagating end outward.
+		//   child workflow        re-emits ErrEnd as a serialisable
+		//                         Temporal ApplicationError so the parent
+		//                         can decode it and carry on propagating.
+		//
+		// The nested case must be explicit: an inline body shares the
+		// enclosing workflow's Temporal context, so isRootWorkflow(ctx)
+		// cannot tell it apart from the true root and would otherwise
+		// swallow the end directive, letting the catch body and every
+		// task after the containing try keep running.
+		//
+		// Without the child workflow re-emission, ErrEnd would be
+		// silently swallowed by every child workflow boundary and
+		// `then: end` could only end the innermost scope rather than the
+		// overall workflow.
+		//
+		// state.Output is included in the end signal so the nested
+		// scope's effective output survives the boundary; the parent's
 		// executeRedirect decodes it and applies the originating task's
 		// output/export directives to it before propagating end further
 		// upward.
 		if err := t.iterateTasks(ctx, tasks, input, state); err != nil {
 			if !errors.Is(err, flow.ErrEnd) {
 				return nil, err
+			}
+			if t.opts.Nested {
+				return state.Output, flow.ErrEnd
 			}
 			if !isRootWorkflow(ctx) {
 				return nil, flow.NewEndApplicationError(state.Output)
@@ -791,6 +824,14 @@ func (t *DoTaskBuilder) emitTaskCompleted(
 }
 
 func (t *DoTaskBuilder) shouldContinueAsNew(ctx workflow.Context) bool {
+	// A nested inline task list has no registered workflow type of its own
+	// (continueAsNew would be handed an empty workflow name) and shares the
+	// enclosing execution's history. Continue-As-New is the enclosing root
+	// workflow's decision; it takes it between its own tasks.
+	if t.opts.Nested {
+		return false
+	}
+
 	logger := workflow.GetLogger(ctx)
 	info := workflow.GetInfo(ctx)
 

--- a/pkg/zigflow/tasks/task_builder_try.go
+++ b/pkg/zigflow/tasks/task_builder_try.go
@@ -52,38 +52,29 @@ func NewTryTaskBuilder(
 
 type TryTaskBuilder struct {
 	builder[*model.TryTask]
-
-	tryChildWorkflowName   string
-	catchChildWorkflowName string
 }
 
 func (t *TryTaskBuilder) Build() (TemporalWorkflowFunc, error) {
-	for taskType, list := range t.getTasks() {
-		name, builder, err := t.createBuilder(taskType, list)
-		if err != nil {
-			return nil, fmt.Errorf("erroring registering %s tasks for %s: %w", taskType, t.GetTaskName(), err)
-		}
-
-		if _, err = builder.Build(); err != nil {
-			log.Error().Str("task", t.GetTaskName()).Str("taskType", taskType).Msg("Error building for workflow")
-			return nil, fmt.Errorf("error building for workflow: %w", err)
-		}
-
-		if taskType == tryBodyPathSegment {
-			t.tryChildWorkflowName = name
-		} else {
-			t.catchChildWorkflowName = name
-		}
+	tryFn, err := t.createTaskFn(t.task.Try)
+	if err != nil {
+		log.Error().Str("task", t.GetTaskName()).Str("taskType", "try").Msg("Error building for workflow")
+		return nil, err
 	}
 
-	return t.exec()
+	catchFn, err := t.createTaskFn(t.task.Catch.Do)
+	if err != nil {
+		log.Error().Str("task", t.GetTaskName()).Str("taskType", "catch").Msg("Error building for workflow")
+		return nil, err
+	}
+
+	return t.exec(tryFn, catchFn)
 }
 
 func (t *TryTaskBuilder) PostLoad() error {
-	for taskType, list := range t.getTasks() {
-		_, builder, err := t.createBuilder(taskType, list)
+	for taskType, taskList := range t.getTasks() {
+		builder, err := t.createBuilder(taskList)
 		if err != nil {
-			return fmt.Errorf("erroring registering %s post load tasks for %s: %w", taskType, t.GetTaskName(), err)
+			return fmt.Errorf("error registering %s post load tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
 
 		if err = builder.PostLoad(); err != nil {
@@ -96,30 +87,21 @@ func (t *TryTaskBuilder) PostLoad() error {
 }
 
 func (t *TryTaskBuilder) Validate() error {
-	for taskType, list := range t.getTasks() {
-		_, builder, err := t.createBuilder(taskType, list)
+	for taskType, taskList := range t.getTasks() {
+		builder, err := t.createBuilder(taskList)
 		if err != nil {
-			return fmt.Errorf("error registering %s validate tasks for %s: %w", taskType, t.GetTaskName(), err)
+			return err
 		}
 		if err := builder.Validate(); err != nil {
 			return fmt.Errorf("error validating %s tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
 	}
+
 	return nil
 }
 
 func (t *TryTaskBuilder) buildCatchError(err error) map[string]any {
 	out := map[string]any{}
-
-	if childErr, ok := errors.AsType[*temporal.ChildWorkflowExecutionError](err); ok {
-		out["childWorkflow"] = map[string]any{
-			"workflowType":     childErr.WorkflowType(),
-			"workflowID":       childErr.WorkflowID(),
-			"runID":            childErr.RunID(),
-			"initiatedEventID": childErr.InitiatedEventID(),
-			"startedEventID":   childErr.StartedEventID(),
-		}
-	}
 
 	if actErr, ok := errors.AsType[*temporal.ActivityError](err); ok {
 		retryStateName := actErr.RetryState().String()
@@ -178,34 +160,70 @@ func (t *TryTaskBuilder) buildCatchError(err error) map[string]any {
 		out["errorKind"] = "canceled"
 	}
 
+	// The try body now runs inline, so a plain Go error (one that is not a
+	// typed Temporal error) is a common shape. Rather than exposing an empty
+	// map to the catch tasks, fall back to surfacing at least the message so
+	// `$data.error` always carries something interrogable.
+	if len(out) == 0 && err != nil {
+		out["message"] = err.Error()
+	}
+
 	return out
 }
 
-func (t *TryTaskBuilder) exec() (TemporalWorkflowFunc, error) {
-	return func(ctx workflow.Context, input any, state *utils.State) (output any, err error) {
+func (t *TryTaskBuilder) createBuilder(task *model.TaskList) (*DoTaskBuilder, error) {
+	// Create the task builder, but without registering it
+	builder, err := NewDoTaskBuilder(t.temporalWorker, &model.DoTask{Do: task}, "", t.doc, t.eventEmitter, t.taskOpts, DoTaskOpts{
+		DisableRegisterWorkflow: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating do task builder: %w", err)
+	}
+
+	return builder, nil
+}
+
+func (t *TryTaskBuilder) createTaskFn(task *model.TaskList) (TemporalWorkflowFunc, error) {
+	builder, err := t.createBuilder(task)
+	if err != nil {
+		return nil, err
+	}
+
+	fn, err := builder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("error building task: %w", err)
+	}
+
+	return fn, nil
+}
+
+func (t *TryTaskBuilder) exec(tryFn, catchFn TemporalWorkflowFunc) (TemporalWorkflowFunc, error) {
+	return func(ctx workflow.Context, input any, state *utils.State) (any, error) {
 		logger := workflow.GetLogger(ctx)
+		logger.Info("Starting try task")
 
-		opts := workflow.ChildWorkflowOptions{
-			WorkflowID: fmt.Sprintf("%s_try", workflow.GetInfo(ctx).WorkflowExecution.ID),
-		}
-		childCtx := workflow.WithChildOptions(ctx, opts)
+		output, err := tryFn(ctx, input, state)
+		if err != nil {
+			logger.Warn("Try body failed, catching the error", "error", err)
 
-		var res map[string]any
-		if err := workflow.ExecuteChildWorkflow(childCtx, t.tryChildWorkflowName, state.Input, state).Get(ctx, &res); err != nil {
-			// A `then: end` directive inside the try body crosses the
-			// child workflow boundary as a typed Temporal ApplicationError.
-			// That is a deliberate workflow termination, not a failure to
-			// be caught: surface it as flow.ErrEnd so the do-task pipeline
-			// can keep propagating end upward, and preserve the carried
-			// output from the child so the root completion reflects it.
-			// Crucially, this skips the catch handler.
+			// A `then: end` directive inside the try body is a deliberate
+			// workflow termination, not a failure to be caught: surface it as
+			// flow.ErrEnd so the do-task pipeline can keep propagating end
+			// upward, preserving the carried output so the root completion
+			// reflects it. Crucially, this skips the catch handler.
+			//
+			// The try body runs inline, so it returns flow.ErrEnd directly
+			// alongside its output. The DecodeEndApplicationError branch is
+			// retained for backwards compatibility with an encoded end error
+			// that may still arrive from a Temporal boundary.
 			if endPayload, isEnd := flow.DecodeEndApplicationError(err); isEnd {
-				logger.Info("Try child workflow signalled end; propagating without running catch",
-					"tryWorkflow", t.tryChildWorkflowName, "carriedOutput", endPayload.Output)
+				logger.Info("Try body signalled end; propagating without running catch", "carriedOutput", endPayload.Output)
 				return endPayload.Output, flow.ErrEnd
 			}
-
-			logger.Warn("Workflow failed, catching the error", "tryWorkflow", t.tryChildWorkflowName, "catchWorkflow", t.catchChildWorkflowName)
+			if errors.Is(err, flow.ErrEnd) {
+				logger.Info("Try body signalled end; propagating without running catch", "carriedOutput", output)
+				return output, flow.ErrEnd
+			}
 
 			// Expose the caught error to the catch tasks so they can
 			// interrogate it. The Open Workflow Specification names this
@@ -225,29 +243,30 @@ func (t *TryTaskBuilder) exec() (TemporalWorkflowFunc, error) {
 				errKey: t.buildCatchError(err),
 			})
 
-			// The try workflow has failed - let's run the catch workflow
-			opts := workflow.ChildWorkflowOptions{
-				WorkflowID: fmt.Sprintf("%s_catch", workflow.GetInfo(ctx).WorkflowExecution.ID),
-			}
+			output, err = catchFn(ctx, catchState.Input, catchState)
+			if err != nil {
+				// Everything has failed
 
-			childCtx := workflow.WithChildOptions(ctx, opts)
-
-			if err := workflow.ExecuteChildWorkflow(childCtx, t.catchChildWorkflowName, catchState.Input, catchState).Get(ctx, &res); err != nil {
 				// The catch handler itself may emit `then: end`. Propagate
 				// that as flow.ErrEnd rather than wrapping it as a generic
-				// catch-workflow failure.
+				// catch failure. As with the try body, the inline catch
+				// returns flow.ErrEnd directly; the decode branch stays for
+				// backwards compatibility with an encoded end error.
 				if endPayload, isEnd := flow.DecodeEndApplicationError(err); isEnd {
-					logger.Info("Catch child workflow signalled end; propagating",
-						"catchWorkflow", t.catchChildWorkflowName, "carriedOutput", endPayload.Output)
+					logger.Info("Catch body signalled end; propagating", "carriedOutput", endPayload.Output)
 					return endPayload.Output, flow.ErrEnd
 				}
-				// Everything has failed
-				logger.Error("Error calling try workflow", "error", err)
-				return nil, fmt.Errorf("error calling catch workflow: %w", err)
+				if errors.Is(err, flow.ErrEnd) {
+					logger.Info("Catch body signalled end; propagating", "carriedOutput", output)
+					return output, flow.ErrEnd
+				}
+
+				logger.Error("Error running catch tasks", "error", err)
+				return nil, fmt.Errorf("error running catch tasks: %w", err)
 			}
 		}
 
-		return res, nil
+		return output, nil
 	}, nil
 }
 
@@ -256,32 +275,4 @@ func (t *TryTaskBuilder) getTasks() map[string]*model.TaskList {
 		tryBodyPathSegment:   t.task.Try,
 		catchBodyPathSegment: t.task.Catch.Do,
 	}
-}
-
-func (t *TryTaskBuilder) createBuilder(
-	taskType string, list *model.TaskList,
-) (childWorkflowName string, builder TaskBuilder, err error) {
-	l := log.With().Str("task", t.GetTaskName()).Str("taskType", taskType).Logger()
-
-	if len(*list) == 0 {
-		err = fmt.Errorf("no tasks detected for %s in %s", taskType, t.GetTaskName())
-		return
-	}
-
-	childWorkflowName = utils.GenerateChildWorkflowName(taskType, t.GetTaskName())
-
-	childPath := t.childTaskPath(taskType)
-	b, err := NewTaskBuilder(
-		childWorkflowName, &model.DoTask{Do: list},
-		t.temporalWorker, t.doc, t.eventEmitter, t.taskOpts, childPath,
-	)
-	if err != nil {
-		l.Error().Msg("Error creating the for task builder")
-		err = fmt.Errorf("error creating the for task builder: %w", err)
-		return
-	}
-
-	builder = b
-
-	return
 }

--- a/pkg/zigflow/tasks/task_builder_try.go
+++ b/pkg/zigflow/tasks/task_builder_try.go
@@ -55,15 +55,15 @@ type TryTaskBuilder struct {
 }
 
 func (t *TryTaskBuilder) Build() (TemporalWorkflowFunc, error) {
-	tryFn, err := t.createTaskFn(t.task.Try)
+	tryFn, err := t.createTaskFn(tryBodyPathSegment, t.task.Try)
 	if err != nil {
-		log.Error().Str("task", t.GetTaskName()).Str("taskType", "try").Msg("Error building for workflow")
+		log.Error().Str("task", t.GetTaskName()).Str("taskType", tryBodyPathSegment).Msg("Error building for workflow")
 		return nil, err
 	}
 
-	catchFn, err := t.createTaskFn(t.task.Catch.Do)
+	catchFn, err := t.createTaskFn(catchBodyPathSegment, t.task.Catch.Do)
 	if err != nil {
-		log.Error().Str("task", t.GetTaskName()).Str("taskType", "catch").Msg("Error building for workflow")
+		log.Error().Str("task", t.GetTaskName()).Str("taskType", catchBodyPathSegment).Msg("Error building for workflow")
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ func (t *TryTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 
 func (t *TryTaskBuilder) PostLoad() error {
 	for taskType, taskList := range t.getTasks() {
-		builder, err := t.createBuilder(taskList)
+		builder, err := t.createBuilder(taskType, taskList)
 		if err != nil {
 			return fmt.Errorf("error registering %s post load tasks for %s: %w", taskType, t.GetTaskName(), err)
 		}
@@ -88,7 +88,7 @@ func (t *TryTaskBuilder) PostLoad() error {
 
 func (t *TryTaskBuilder) Validate() error {
 	for taskType, taskList := range t.getTasks() {
-		builder, err := t.createBuilder(taskList)
+		builder, err := t.createBuilder(taskType, taskList)
 		if err != nil {
 			return err
 		}
@@ -171,20 +171,35 @@ func (t *TryTaskBuilder) buildCatchError(err error) map[string]any {
 	return out
 }
 
-func (t *TryTaskBuilder) createBuilder(task *model.TaskList) (*DoTaskBuilder, error) {
-	// Create the task builder, but without registering it
+// createBuilder builds the body of one branch (segment is
+// tryBodyPathSegment or catchBodyPathSegment) as an unregistered,
+// inline-executed DoTaskBuilder.
+func (t *TryTaskBuilder) createBuilder(segment string, task *model.TaskList) (*DoTaskBuilder, error) {
+	// Create the task builder, but without registering it. Nested marks it as
+	// running inline in this workflow's context so a `then: end` inside the
+	// body propagates outward instead of being mistaken for a clean root
+	// completion.
 	builder, err := NewDoTaskBuilder(t.temporalWorker, &model.DoTask{Do: task}, "", t.doc, t.eventEmitter, t.taskOpts, DoTaskOpts{
 		DisableRegisterWorkflow: true,
+		Nested:                  true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating do task builder: %w", err)
 	}
 
+	// Direct construction bypasses NewTaskBuilder's path setter, so thread the
+	// branch-specific path through here. Without it both bodies would build
+	// their tasks against an empty path and identical leaf names — the same
+	// name in try and catch, or in the try body and outside the try task —
+	// would collide on one per-task activity alias. childTaskPath allocates a
+	// fresh slice, so the two branches never share one.
+	builder.setTaskPath(t.childTaskPath(segment))
+
 	return builder, nil
 }
 
-func (t *TryTaskBuilder) createTaskFn(task *model.TaskList) (TemporalWorkflowFunc, error) {
-	builder, err := t.createBuilder(task)
+func (t *TryTaskBuilder) createTaskFn(segment string, task *model.TaskList) (TemporalWorkflowFunc, error) {
+	builder, err := t.createBuilder(segment, task)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zigflow/tasks/task_builder_try_integration_test.go
+++ b/pkg/zigflow/tasks/task_builder_try_integration_test.go
@@ -1,0 +1,565 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/open-workflow-specification/sdk-go/v4/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/cloudevents"
+	"github.com/zigflow/zigflow/pkg/utils"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"sigs.k8s.io/yaml"
+)
+
+// The tests in this file are deliberately integration-style: they drive real
+// task builders (DoTaskBuilder -> TryTaskBuilder -> nested DoTaskBuilder ->
+// leaf builders) and execute the resulting workflow function in Temporal's
+// test environment. The synthetic TemporalWorkflowFunc closures in
+// task_builder_try_test.go prove exec() propagates an error it is handed; they
+// cannot prove a *built* nested DoTaskBuilder hands one over in the first
+// place, which is exactly where inline `then: end` was being swallowed.
+
+const (
+	// testConstTryTask is the try task key used by the inline try/catch
+	// integration workflows.
+	testConstTryTask = "guarded"
+	// testConstMustNotRun is the key of the task placed after the try task; it
+	// must never run once a body has signalled `then: end`.
+	testConstMustNotRun = "mustNotRun"
+	// testConstTaskStartedEvent is the emitted cloudevent type used to work out
+	// which tasks actually executed.
+	testConstTaskStartedEvent = "dev.zigflow.task.started"
+	// testConstErrorKey is the default catch.as key the caught error is exposed
+	// under.
+	testConstErrorKey = "error"
+	// testConstAfterTry is the data key set by the task that follows the try
+	// task.
+	testConstAfterTry = "afterTry"
+	// testConstFailingTask is the key of the raise task used to fail a try body.
+	testConstFailingTask = "failing"
+	// testConstFinishTask is the key of the try-body task that emits `then: end`.
+	testConstFinishTask = "finish"
+)
+
+// newStartedTaskRecorder wires a cloudevents.Events instance to a temp
+// directory using the file protocol, and returns a reader that yields the
+// subjects of the emitted task.started events in order. Because every task —
+// at the root and inside the inline try/catch bodies — emits task.started
+// through the same emitter, the resulting slice is an exact record of which
+// tasks ran.
+func newStartedTaskRecorder(
+	t *testing.T, doc *model.Workflow,
+) (events *cloudevents.Events, readStarted func() []string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	eventsDir := filepath.Join(dir, "events")
+	require.NoError(t, os.MkdirAll(eventsDir, 0o755))
+
+	config := fmt.Sprintf("clients:\n  - name: recorder\n    protocol: file\n    target: %s\n", eventsDir)
+	configPath := filepath.Join(dir, "cloudevents.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+
+	validator, err := utils.NewValidator()
+	require.NoError(t, err)
+
+	events, err = cloudevents.Load(configPath, validator, doc)
+	require.NoError(t, err)
+
+	readStarted = func() []string {
+		entries, err := os.ReadDir(eventsDir)
+		require.NoError(t, err)
+
+		var subjects []string
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(eventsDir, entry.Name()))
+			require.NoError(t, err)
+			for doc := range bytes.SplitSeq(data, []byte("---\n")) {
+				doc = bytes.TrimSpace(doc)
+				if len(doc) == 0 {
+					continue
+				}
+				var ev struct {
+					Type    string `json:"type"`
+					Subject string `json:"subject"`
+				}
+				require.NoError(t, yaml.Unmarshal(doc, &ev))
+				if ev.Type == testConstTaskStartedEvent {
+					subjects = append(subjects, ev.Subject)
+				}
+			}
+		}
+		return subjects
+	}
+
+	return events, readStarted
+}
+
+// newTestWorkflowDoc returns a workflow document whose name namespaces the
+// per-task activity aliases the builders register.
+func newTestWorkflowDoc(name string) *model.Workflow {
+	return &model.Workflow{Document: model.Document{Name: name, DSL: "1.0.0"}}
+}
+
+// newRegistryMock returns a worker mock that accepts the root workflow
+// registration Build() performs. Tests that assert on activity aliases layer
+// their own strict expectations on top.
+func newRegistryMock() *WorkflowRegistryMock {
+	w := new(WorkflowRegistryMock)
+	w.On("RegisterWorkflowWithOptions", mock.Anything, mock.Anything).Maybe()
+	return w
+}
+
+// newPermissiveRegistryMock also accepts any activity registration, for tests
+// that assert on runtime dispatch rather than on the registered alias names.
+func newPermissiveRegistryMock() *WorkflowRegistryMock {
+	w := newRegistryMock()
+	w.On("RegisterActivityWithOptions", mock.Anything, mock.Anything).Maybe()
+	return w
+}
+
+// buildRootWorkflow runs the real load-time and build-time pipeline over do
+// and returns the root workflow function, exactly as NewWorkflow would.
+func buildRootWorkflow(
+	t *testing.T,
+	w worker.Worker,
+	doc *model.Workflow,
+	emitter *cloudevents.Events,
+	do *model.TaskList,
+) TemporalWorkflowFunc {
+	t.Helper()
+
+	b, err := NewDoTaskBuilder(w, &model.DoTask{Do: do}, doc.Document.Name, doc, emitter, nil)
+	require.NoError(t, err)
+	require.NoError(t, b.PostLoad())
+	require.NoError(t, b.Validate())
+
+	fn, err := b.Build()
+	require.NoError(t, err)
+	require.NotNil(t, fn)
+
+	return fn
+}
+
+// runRootWorkflow executes fn as the root workflow (state nil, so the real
+// root-boundary code path runs) and returns its result and error.
+func runRootWorkflow(
+	t *testing.T,
+	name string,
+	fn TemporalWorkflowFunc,
+	registerActivities func(env *testsuite.TestWorkflowEnvironment),
+) (any, error) {
+	t.Helper()
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	if registerActivities != nil {
+		registerActivities(env)
+	}
+
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		return fn(ctx, nil, nil)
+	}, workflow.RegisterOptions{Name: name})
+
+	env.ExecuteWorkflow(name)
+	require.True(t, env.IsWorkflowCompleted())
+
+	if err := env.GetWorkflowError(); err != nil {
+		return nil, err
+	}
+
+	var output any
+	require.NoError(t, env.GetWorkflowResult(&output))
+
+	return output, nil
+}
+
+// newEndingSetTask returns a set task carrying a `then: end` directive.
+func newEndingSetTask(set map[string]any) *model.SetTask {
+	return &model.SetTask{
+		TaskBase: model.TaskBase{
+			Then: &model.FlowDirective{Value: string(model.FlowDirectiveEnd)},
+		},
+		Set: model.NewObjectOrRuntimeExpr(set),
+	}
+}
+
+// newSetTask returns a plain set task with no flow directive.
+func newSetTask(set map[string]any) *model.SetTask {
+	return &model.SetTask{Set: model.NewObjectOrRuntimeExpr(set)}
+}
+
+// newFailingRaiseTask returns a raise task that always fails the surrounding
+// scope, which is how these tests drive the try body into the catch body
+// without depending on an external service.
+func newFailingRaiseTask() *model.RaiseTask {
+	return &model.RaiseTask{
+		Raise: model.RaiseTaskConfiguration{
+			Error: model.RaiseTaskError{
+				Definition: &model.Error{
+					Type:   model.NewUriTemplate(model.ErrorTypeValidation),
+					Status: 400,
+					Title:  model.NewStringOrRuntimeExpr("Boom"),
+					Detail: model.NewStringOrRuntimeExpr("try body failed"),
+				},
+			},
+		},
+	}
+}
+
+// TestBuiltTryBodyEndTerminatesWholeWorkflow is the regression test for the
+// swallowed `then: end`. The try body is a real, built nested DoTaskBuilder
+// running inline in the root workflow's Temporal context, so
+// isRootWorkflow(ctx) reports true for it. Before the explicit nested marker
+// the nested executor consumed flow.ErrEnd as a clean root completion, exec()
+// saw no error, and both the catch body and every task after the try kept
+// running.
+//
+// The DSL equivalent:
+//
+//	do:
+//	  - guarded:
+//	      try:
+//	        - finish:
+//	            set:
+//	              result: ended
+//	            then: end
+//	      catch:
+//	        as: error
+//	        do:
+//	          - caught:
+//	              set:
+//	                catchRan: true
+//	  - mustNotRun:
+//	      set:
+//	        afterTry: true
+func TestBuiltTryBodyEndTerminatesWholeWorkflow(t *testing.T) {
+	doc := newTestWorkflowDoc("wf-inline-try-end")
+	events, readStarted := newStartedTaskRecorder(t, doc)
+
+	do := &model.TaskList{
+		&model.TaskItem{Key: testConstTryTask, Task: &model.TryTask{
+			Try: &model.TaskList{
+				&model.TaskItem{Key: testConstFinishTask, Task: newEndingSetTask(map[string]any{
+					testConstResult: "ended",
+				})},
+			},
+			Catch: &model.TryTaskCatch{
+				As: testConstErrorKey,
+				Do: &model.TaskList{
+					&model.TaskItem{Key: "caught", Task: newSetTask(map[string]any{"catchRan": true})},
+				},
+			},
+		}},
+		&model.TaskItem{Key: testConstMustNotRun, Task: newSetTask(map[string]any{testConstAfterTry: true})},
+	}
+
+	fn := buildRootWorkflow(t, newRegistryMock(), doc, events, do)
+	output, err := runRootWorkflow(t, doc.Document.Name, fn, nil)
+
+	// At the true root boundary the propagated end is a clean completion.
+	require.NoError(t, err)
+
+	// The ending task's output survives: the nested body shares the root
+	// state, so state.Output still holds what `finish` set, and the try task
+	// (a control-directive task with no output directive of its own) leaves it
+	// untouched.
+	assert.Equal(t, map[string]any{testConstResult: "ended"}, output)
+
+	// Only the try task and the ending task inside it ran.
+	assert.Equal(t, []string{testConstTryTask, testConstFinishTask}, readStarted())
+}
+
+// TestBuiltCatchBodyEndTerminatesWholeWorkflow is the symmetric case: the try
+// body fails for a real reason, the catch body runs, and a real task inside
+// the catch body emits `then: end`. The end must terminate the whole workflow
+// and the task after the try must not run.
+//
+// The try task carries an output directive so the test can also prove the
+// carried output of the ended catch body reaches the enclosing task rather
+// than being discarded at the boundary.
+func TestBuiltCatchBodyEndTerminatesWholeWorkflow(t *testing.T) {
+	doc := newTestWorkflowDoc("wf-inline-catch-end")
+	events, readStarted := newStartedTaskRecorder(t, doc)
+
+	do := &model.TaskList{
+		&model.TaskItem{Key: testConstTryTask, Task: &model.TryTask{
+			TaskBase: model.TaskBase{
+				Output: &model.Output{
+					As: model.NewObjectOrRuntimeExpr(map[string]any{"carried": "${ . }"}),
+				},
+			},
+			Try: &model.TaskList{
+				&model.TaskItem{Key: testConstFailingTask, Task: newFailingRaiseTask()},
+			},
+			Catch: &model.TryTaskCatch{
+				As: testConstErrorKey,
+				Do: &model.TaskList{
+					&model.TaskItem{Key: testConstHandledKey, Task: newEndingSetTask(map[string]any{
+						testConstHandledKey: true,
+					})},
+				},
+			},
+		}},
+		&model.TaskItem{Key: testConstMustNotRun, Task: newSetTask(map[string]any{testConstAfterTry: true})},
+	}
+
+	fn := buildRootWorkflow(t, newRegistryMock(), doc, events, do)
+	output, err := runRootWorkflow(t, doc.Document.Name, fn, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t,
+		map[string]any{"carried": map[string]any{testConstHandledKey: true}},
+		output,
+		"the ended catch body's output must reach the try task's output directive")
+
+	// The failing try task ran, the catch handler ran, and nothing after the
+	// try task ran.
+	assert.Equal(t,
+		[]string{testConstTryTask, testConstFailingTask, testConstHandledKey},
+		readStarted())
+}
+
+// TestBuiltTryCatchOrdinaryFailureRegression guards the behaviour the end
+// propagation must not disturb: an ordinary try-body failure still enters the
+// catch body, the catch output becomes the try task's output, and tasks after
+// the try task keep running when the catch completes normally.
+func TestBuiltTryCatchOrdinaryFailureRegression(t *testing.T) {
+	newTryTask := func() *model.TryTask {
+		return &model.TryTask{
+			Try: &model.TaskList{
+				&model.TaskItem{Key: testConstFailingTask, Task: newFailingRaiseTask()},
+			},
+			Catch: &model.TryTaskCatch{
+				As: testConstErrorKey,
+				Do: &model.TaskList{
+					&model.TaskItem{Key: testConstHandledKey, Task: newSetTask(map[string]any{
+						testConstHandledKey: true,
+					})},
+				},
+			},
+		}
+	}
+
+	t.Run("catch output is returned", func(t *testing.T) {
+		doc := newTestWorkflowDoc("wf-inline-catch-output")
+		events, readStarted := newStartedTaskRecorder(t, doc)
+
+		do := &model.TaskList{
+			&model.TaskItem{Key: testConstTryTask, Task: newTryTask()},
+		}
+
+		fn := buildRootWorkflow(t, newRegistryMock(), doc, events, do)
+		output, err := runRootWorkflow(t, doc.Document.Name, fn, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{testConstHandledKey: true}, output)
+		assert.Equal(t,
+			[]string{testConstTryTask, testConstFailingTask, testConstHandledKey},
+			readStarted())
+	})
+
+	t.Run("subsequent tasks run", func(t *testing.T) {
+		doc := newTestWorkflowDoc("wf-inline-catch-continues")
+		events, readStarted := newStartedTaskRecorder(t, doc)
+
+		do := &model.TaskList{
+			&model.TaskItem{Key: testConstTryTask, Task: newTryTask()},
+			&model.TaskItem{Key: "after", Task: newSetTask(map[string]any{testConstAfterTry: true})},
+		}
+
+		fn := buildRootWorkflow(t, newRegistryMock(), doc, events, do)
+		output, err := runRootWorkflow(t, doc.Document.Name, fn, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{testConstAfterTry: true}, output)
+		assert.Equal(t,
+			[]string{testConstTryTask, testConstFailingTask, testConstHandledKey, "after"},
+			readStarted())
+	})
+}
+
+// newCollisionTaskList builds a workflow with the same activity-backed task
+// key ("step") in three places: outside the try task, inside the try body and
+// inside the catch body. Each location must resolve to its own per-task
+// activity alias.
+func newCollisionTaskList() *model.TaskList {
+	return &model.TaskList{
+		&model.TaskItem{Key: testConstStep, Task: newTestHTTPTask()},
+		&model.TaskItem{Key: testConstTryTask, Task: &model.TryTask{
+			Try: &model.TaskList{
+				&model.TaskItem{Key: testConstStep, Task: newTestHTTPTask()},
+			},
+			Catch: &model.TryTaskCatch{
+				As: testConstErrorKey,
+				Do: &model.TaskList{
+					&model.TaskItem{Key: testConstStep, Task: newTestHTTPTask()},
+				},
+			},
+		}},
+	}
+}
+
+// TestBuiltTryCatchRegistersDistinctActivityAliases proves the inline try and
+// catch bodies keep the parent try task's path plus their own branch segment.
+// Before the fix both bodies were built with an empty task path, so all three
+// "step" tasks collapsed onto one alias: registerActivityOnce would dedup the
+// second and third registrations and every location would dispatch to
+// whichever implementation registered first.
+func TestBuiltTryCatchRegistersDistinctActivityAliases(t *testing.T) {
+	doc := newTestWorkflowDoc("wf-alias")
+
+	w := newRegistryMock()
+	for _, name := range []string{
+		"wf-alias.step",
+		"wf-alias.guarded.try.step",
+		"wf-alias.guarded.catch.step",
+	} {
+		w.
+			On("RegisterActivityWithOptions", mock.Anything, activity.RegisterOptions{Name: name}).
+			Once()
+	}
+
+	buildRootWorkflow(t, w, doc, testEvents, newCollisionTaskList())
+
+	w.AssertExpectations(t)
+}
+
+// TestBuiltTryCatchInvokesBranchSpecificActivity closes the loop on the alias
+// fix by actually executing the workflow with three distinct implementations
+// registered under the three aliases. Each branch must invoke its own
+// implementation and no other.
+func TestBuiltTryCatchInvokesBranchSpecificActivity(t *testing.T) {
+	const (
+		outerAlias = "wf-dispatch.step"
+		tryAlias   = "wf-dispatch.guarded.try.step"
+		catchAlias = "wf-dispatch.guarded.catch.step"
+	)
+
+	cases := []struct {
+		name        string
+		tryFails    bool
+		wantInvoked []string
+		wantOutput  any
+	}{
+		{
+			name:        "try branch",
+			tryFails:    false,
+			wantInvoked: []string{outerAlias, tryAlias},
+			wantOutput:  tryAlias,
+		},
+		{
+			name:        "catch branch",
+			tryFails:    true,
+			wantInvoked: []string{outerAlias, tryAlias, catchAlias},
+			wantOutput:  catchAlias,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := newTestWorkflowDoc("wf-dispatch")
+
+			var (
+				mu       sync.Mutex
+				invoked  []string
+				recorder = func(alias string, fail bool) any {
+					return func(_ context.Context, _, _, _ any) (any, error) {
+						mu.Lock()
+						invoked = append(invoked, alias)
+						mu.Unlock()
+						if fail {
+							return nil, temporal.NewNonRetryableApplicationError(
+								"activity failed", "Boom", nil,
+							)
+						}
+						return alias, nil
+					}
+				}
+			)
+
+			fn := buildRootWorkflow(t, newPermissiveRegistryMock(), doc, testEvents, newCollisionTaskList())
+
+			output, err := runRootWorkflow(t, doc.Document.Name, fn, func(env *testsuite.TestWorkflowEnvironment) {
+				env.RegisterActivityWithOptions(recorder(outerAlias, false),
+					activity.RegisterOptions{Name: outerAlias})
+				env.RegisterActivityWithOptions(recorder(tryAlias, tc.tryFails),
+					activity.RegisterOptions{Name: tryAlias})
+				env.RegisterActivityWithOptions(recorder(catchAlias, false),
+					activity.RegisterOptions{Name: catchAlias})
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOutput, output)
+
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tc.wantInvoked, invoked,
+				"each task location must dispatch to its own per-task activity alias")
+		})
+	}
+}
+
+// TestNestedDoTaskBuilderNeverContinuesAsNew guards the other
+// workflow-boundary behaviour an inline body must not perform. A nested body
+// has no registered workflow type of its own (its name is empty), so calling
+// continueAsNew from inside it would ask Temporal to continue as an unnamed
+// workflow. Continue-As-New belongs to the enclosing root workflow, which
+// takes the decision between its own tasks.
+func TestNestedDoTaskBuilderNeverContinuesAsNew(t *testing.T) {
+	nested := newTestDoTaskBuilder("", DoTaskOpts{
+		DisableRegisterWorkflow: true,
+		Nested:                  true,
+	})
+	root := newTestDoTaskBuilder("root")
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	// Temporal suggesting Continue-As-New is the condition both builders see;
+	// only the non-nested one may act on it.
+	env.SetContinueAsNewSuggested(true)
+
+	var nestedWantsCAN, rootWantsCAN bool
+	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+		nestedWantsCAN = nested.shouldContinueAsNew(ctx)
+		rootWantsCAN = root.shouldContinueAsNew(ctx)
+		return nil, nil
+	}, workflow.RegisterOptions{Name: "nested-can"})
+
+	env.ExecuteWorkflow("nested-can")
+	require.NoError(t, env.GetWorkflowError())
+
+	assert.False(t, nestedWantsCAN, "a nested inline task list must never initiate Continue-As-New")
+	assert.True(t, rootWantsCAN, "the non-nested builder must still honour the history-length override")
+}

--- a/pkg/zigflow/tasks/task_builder_try_test.go
+++ b/pkg/zigflow/tasks/task_builder_try_test.go
@@ -53,164 +53,13 @@ func TestTryTaskBuilderGetTasks(t *testing.T) {
 	assert.Equal(t, task.Catch.Do, got["catch"])
 }
 
-func TestTryTaskBuilderExecRunsCatchOnError(t *testing.T) {
-	builder := &TryTaskBuilder{
+// newInlineTryBuilder builds a TryTaskBuilder wired for inline execution.
+// The try and catch bodies are supplied directly to exec as
+// TemporalWorkflowFunc closures, so no child workflows are registered.
+func newInlineTryBuilder(catchAs string) *TryTaskBuilder {
+	return &TryTaskBuilder{
 		builder: builder[*model.TryTask]{
 			name: "try-task",
-			task: &model.TryTask{
-				Try: &model.TaskList{},
-				Catch: &model.TryTaskCatch{
-					Do: &model.TaskList{},
-				},
-			},
-		},
-		tryChildWorkflowName:   "try-child",
-		catchChildWorkflowName: "catch-child",
-	}
-
-	fn, err := builder.exec()
-	assert.NoError(t, err)
-
-	state := utils.NewState()
-
-	var s testsuite.WorkflowTestSuite
-	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, errors.New("boom")
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return map[string]any{
-			testConstHandledKey: true,
-		}, nil
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return fn(ctx, nil, state)
-	}, workflow.RegisterOptions{Name: "try-exec"})
-
-	env.ExecuteWorkflow("try-exec")
-	assert.NoError(t, env.GetWorkflowError())
-
-	var result map[string]any
-	assert.NoError(t, env.GetWorkflowResult(&result))
-	assert.Equal(t, map[string]any{testConstHandledKey: true}, result)
-}
-
-// TestTryTaskBuilderExecPropagatesEndFromTryChild proves that a
-// `then: end` directive inside the try child workflow is NOT treated
-// as a catchable failure. The carried output must survive the boundary
-// and exec must surface flow.ErrEnd to the do-task pipeline so the
-// overall workflow ends cleanly, not run the catch handler.
-func TestTryTaskBuilderExecPropagatesEndFromTryChild(t *testing.T) {
-	builder := &TryTaskBuilder{
-		builder: builder[*model.TryTask]{
-			name: "try-task-end",
-			task: &model.TryTask{
-				Try: &model.TaskList{},
-				Catch: &model.TryTaskCatch{
-					Do: &model.TaskList{},
-				},
-			},
-		},
-		tryChildWorkflowName:   "try-child-end",
-		catchChildWorkflowName: "catch-child-end",
-	}
-
-	fn, err := builder.exec()
-	require.NoError(t, err)
-
-	state := utils.NewState()
-	childOutput := map[string]any{testConstValue: "end-time-output"}
-	catchRan := false
-
-	var s testsuite.WorkflowTestSuite
-	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, flow.NewEndApplicationError(childOutput)
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		catchRan = true
-		return map[string]any{testConstHandledKey: true}, nil
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return fn(ctx, nil, state)
-	}, workflow.RegisterOptions{Name: "try-exec-end"})
-
-	env.ExecuteWorkflow("try-exec-end")
-
-	// The try task surfaces flow.ErrEnd through the Temporal envelope.
-	wErr := env.GetWorkflowError()
-	require.Error(t, wErr)
-	assert.Contains(t, wErr.Error(), flow.ErrEnd.Error())
-	assert.False(t, catchRan, "catch handler must not run when the try child workflow signalled end")
-}
-
-// TestTryTaskBuilderExecPropagatesEndFromCatchChild is the symmetric
-// case: when the try child fails for a real reason and the catch
-// handler itself emits `then: end`, that end must propagate as
-// flow.ErrEnd rather than being wrapped as a generic catch-workflow
-// failure.
-func TestTryTaskBuilderExecPropagatesEndFromCatchChild(t *testing.T) {
-	builder := &TryTaskBuilder{
-		builder: builder[*model.TryTask]{
-			name: "try-task-catch-end",
-			task: &model.TryTask{
-				Try: &model.TaskList{},
-				Catch: &model.TryTaskCatch{
-					Do: &model.TaskList{},
-				},
-			},
-		},
-		tryChildWorkflowName:   "try-child-real-fail",
-		catchChildWorkflowName: "catch-child-end",
-	}
-
-	fn, err := builder.exec()
-	require.NoError(t, err)
-
-	state := utils.NewState()
-	catchOutput := map[string]any{testConstValue: "catch-end-output"}
-
-	var s testsuite.WorkflowTestSuite
-	env := s.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, errors.New("boom from try")
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, flow.NewEndApplicationError(catchOutput)
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return fn(ctx, nil, state)
-	}, workflow.RegisterOptions{Name: "try-exec-catch-end"})
-
-	env.ExecuteWorkflow("try-exec-catch-end")
-
-	wErr := env.GetWorkflowError()
-	require.Error(t, wErr)
-	assert.Contains(t, wErr.Error(), flow.ErrEnd.Error())
-	assert.NotContains(t, wErr.Error(), "error calling catch workflow",
-		"catch-emitted end must not be wrapped as a catch-workflow failure")
-}
-
-// runCatchAndCaptureState executes a try task whose try child fails, then
-// returns the $data the catch child workflow actually observed alongside the
-// parent state the exec function was handed. The catch child records the data
-// it receives into a closure-captured map so the test can assert on the exact
-// caught-error contract exposed under $data.
-func runCatchAndCaptureState(t *testing.T, catchAs string, tryErr error) (caughtData map[string]any, parentState *utils.State) {
-	t.Helper()
-
-	builder := &TryTaskBuilder{
-		builder: builder[*model.TryTask]{
-			name: "try-task-capture",
 			task: &model.TryTask{
 				Try: &model.TaskList{},
 				Catch: &model.TryTaskCatch{
@@ -219,66 +68,272 @@ func runCatchAndCaptureState(t *testing.T, catchAs string, tryErr error) (caught
 				},
 			},
 		},
-		tryChildWorkflowName:   "try-child-capture",
-		catchChildWorkflowName: "catch-child-capture",
 	}
+}
 
-	fn, err := builder.exec()
-	require.NoError(t, err)
-
-	parentState = utils.NewState()
+// runInlineTry executes fn inside Temporal's workflow test environment (exec
+// needs a real workflow.Context for its logger and state clone) and returns
+// the raw output and error the inline function produced, captured before they
+// cross the test-environment boundary. Capturing pre-boundary keeps the error
+// chain intact so callers can assert with errors.Is.
+func runInlineTry(t *testing.T, fn TemporalWorkflowFunc, input any, state *utils.State) (any, error) {
+	t.Helper()
 
 	var s testsuite.WorkflowTestSuite
 	env := s.NewTestWorkflowEnvironment()
 
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		return nil, tryErr
-	}, workflow.RegisterOptions{Name: builder.tryChildWorkflowName})
-
-	env.RegisterWorkflowWithOptions(func(ctx workflow.Context, input any, st *utils.State) (map[string]any, error) {
-		caughtData = st.Data
-		return map[string]any{testConstHandledKey: true}, nil
-	}, workflow.RegisterOptions{Name: builder.catchChildWorkflowName})
-
+	var (
+		gotOutput any
+		gotErr    error
+	)
 	env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
-		return fn(ctx, nil, parentState)
-	}, workflow.RegisterOptions{Name: "try-exec-capture"})
+		gotOutput, gotErr = fn(ctx, input, state)
+		return gotOutput, gotErr
+	}, workflow.RegisterOptions{Name: "try-exec"})
 
-	env.ExecuteWorkflow("try-exec-capture")
-	require.NoError(t, env.GetWorkflowError())
+	env.ExecuteWorkflow("try-exec")
 
-	return caughtData, parentState
+	return gotOutput, gotErr
 }
 
-// TestTryTaskBuilderExecExposesErrorUnderDefaultKey proves the catch child
-// workflow sees the caught error under $data.error when catch.as is unset.
+// TestTryTaskBuilderExecRunsCatchOnError proves the catch body runs when the
+// try body returns a genuine failure, that the try body receives the original
+// input and state, and that the catch output becomes the result.
+func TestTryTaskBuilderExecRunsCatchOnError(t *testing.T) {
+	builder := newInlineTryBuilder("")
+
+	state := utils.NewState()
+	state.Input = map[string]any{"in": "put"}
+
+	var (
+		tryInput any
+		tryState *utils.State
+		catchRan bool
+	)
+
+	tryFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		tryInput = input
+		tryState = st
+		return nil, errors.New("boom")
+	}
+	catchFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		catchRan = true
+		return map[string]any{testConstHandledKey: true}, nil
+	}
+
+	fn, err := builder.exec(tryFn, catchFn)
+	require.NoError(t, err)
+
+	output, execErr := runInlineTry(t, fn, state.Input, state)
+	require.NoError(t, execErr)
+
+	// The try body must receive the original input and the exact parent state.
+	assert.Equal(t, state.Input, tryInput)
+	assert.Same(t, state, tryState)
+
+	assert.True(t, catchRan, "catch body must run when the try body fails")
+	assert.Equal(t, map[string]any{testConstHandledKey: true}, output)
+}
+
+// TestTryTaskBuilderExecSuccessSkipsCatch proves a successful try body returns
+// its output unchanged and never invokes the catch body.
+func TestTryTaskBuilderExecSuccessSkipsCatch(t *testing.T) {
+	builder := newInlineTryBuilder("")
+
+	state := utils.NewState()
+	tryOutput := map[string]any{testConstValue: testConstOK}
+	catchRan := false
+
+	tryFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return tryOutput, nil
+	}
+	catchFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		catchRan = true
+		return nil, nil
+	}
+
+	fn, err := builder.exec(tryFn, catchFn)
+	require.NoError(t, err)
+
+	output, execErr := runInlineTry(t, fn, nil, state)
+	require.NoError(t, execErr)
+
+	assert.False(t, catchRan, "catch body must not run when the try body succeeds")
+	assert.Equal(t, tryOutput, output, "successful try output must be returned unchanged")
+}
+
+// TestTryTaskBuilderExecWrapsCatchFailure proves a genuine catch-body failure
+// is wrapped with the expected contextual error.
+func TestTryTaskBuilderExecWrapsCatchFailure(t *testing.T) {
+	builder := newInlineTryBuilder("")
+
+	tryFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return nil, errors.New("boom from try")
+	}
+	catchFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return nil, errors.New("boom from catch")
+	}
+
+	fn, err := builder.exec(tryFn, catchFn)
+	require.NoError(t, err)
+
+	output, execErr := runInlineTry(t, fn, nil, utils.NewState())
+	require.Error(t, execErr)
+	assert.Nil(t, output)
+	assert.Contains(t, execErr.Error(), "error running catch tasks")
+	assert.Contains(t, execErr.Error(), "boom from catch")
+}
+
+// TestTryTaskBuilderExecPropagatesEndFromTryBody proves a `then: end`
+// directive inside the try body (returned inline as flow.ErrEnd) is NOT
+// treated as a catchable failure: the carried output survives and exec
+// surfaces flow.ErrEnd without running the catch body.
+func TestTryTaskBuilderExecPropagatesEndFromTryBody(t *testing.T) {
+	builder := newInlineTryBuilder("")
+
+	tryOutput := map[string]any{testConstValue: "end-time-output"}
+	catchRan := false
+
+	tryFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return tryOutput, flow.ErrEnd
+	}
+	catchFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		catchRan = true
+		return nil, nil
+	}
+
+	fn, err := builder.exec(tryFn, catchFn)
+	require.NoError(t, err)
+
+	output, execErr := runInlineTry(t, fn, nil, utils.NewState())
+
+	require.Error(t, execErr)
+	assert.True(t, errors.Is(execErr, flow.ErrEnd), "try body end must surface as flow.ErrEnd")
+	assert.Equal(t, tryOutput, output, "carried output must be preserved")
+	assert.False(t, catchRan, "catch body must not run when the try body signalled end")
+}
+
+// TestTryTaskBuilderExecPropagatesEndFromCatchBody is the symmetric case:
+// when the try body fails for a real reason and the catch body itself emits
+// `then: end` (inline flow.ErrEnd), that end must propagate as flow.ErrEnd
+// rather than being wrapped as a generic catch failure.
+func TestTryTaskBuilderExecPropagatesEndFromCatchBody(t *testing.T) {
+	builder := newInlineTryBuilder("")
+
+	catchOutput := map[string]any{testConstValue: "catch-end-output"}
+
+	tryFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return nil, errors.New("boom from try")
+	}
+	catchFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return catchOutput, flow.ErrEnd
+	}
+
+	fn, err := builder.exec(tryFn, catchFn)
+	require.NoError(t, err)
+
+	output, execErr := runInlineTry(t, fn, nil, utils.NewState())
+
+	require.Error(t, execErr)
+	assert.True(t, errors.Is(execErr, flow.ErrEnd), "catch body end must surface as flow.ErrEnd")
+	assert.Equal(t, catchOutput, output, "carried output must be preserved")
+	assert.NotContains(t, execErr.Error(), "error running catch tasks",
+		"catch-emitted end must not be wrapped as a catch failure")
+}
+
+// TestTryTaskBuilderExecPropagatesEncodedEndCompat proves the retained
+// backwards-compatibility path: an encoded Temporal end error (as produced by
+// flow.NewEndApplicationError) is still recognised, its carried payload output
+// preserved, and the catch body skipped. This is not the primary inline path.
+func TestTryTaskBuilderExecPropagatesEncodedEndCompat(t *testing.T) {
+	builder := newInlineTryBuilder("")
+
+	encodedOutput := map[string]any{testConstValue: "encoded-end-output"}
+	catchRan := false
+
+	tryFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return nil, flow.NewEndApplicationError(encodedOutput)
+	}
+	catchFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		catchRan = true
+		return nil, nil
+	}
+
+	fn, err := builder.exec(tryFn, catchFn)
+	require.NoError(t, err)
+
+	output, execErr := runInlineTry(t, fn, nil, utils.NewState())
+
+	require.Error(t, execErr)
+	assert.True(t, errors.Is(execErr, flow.ErrEnd), "encoded end must surface as flow.ErrEnd")
+	assert.Equal(t, encodedOutput, output, "encoded end payload output must be preserved")
+	assert.False(t, catchRan, "catch body must not run when the try body signalled end")
+}
+
+// runCatchAndCaptureState executes a try task whose try body fails, then
+// returns the $data the catch body actually observed alongside the parent
+// state exec was handed and the input the catch body received. The catch body
+// records what it sees into closure-captured variables so tests can assert the
+// exact caught-error contract exposed under $data, all under inline execution.
+func runCatchAndCaptureState(t *testing.T, catchAs string, tryErr error) (
+	caughtData map[string]any, caughtInput any, parentState *utils.State,
+) {
+	t.Helper()
+
+	builder := newInlineTryBuilder(catchAs)
+
+	parentState = utils.NewState()
+	parentState.Input = map[string]any{"seed": "input"}
+
+	tryFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		return nil, tryErr
+	}
+	catchFn := func(ctx workflow.Context, input any, st *utils.State) (any, error) {
+		caughtData = st.Data
+		caughtInput = input
+		return map[string]any{testConstHandledKey: true}, nil
+	}
+
+	fn, err := builder.exec(tryFn, catchFn)
+	require.NoError(t, err)
+
+	_, execErr := runInlineTry(t, fn, parentState.Input, parentState)
+	require.NoError(t, execErr)
+
+	return caughtData, caughtInput, parentState
+}
+
+// TestTryTaskBuilderExecExposesErrorUnderDefaultKey proves the catch body sees
+// the caught error under $data.error when catch.as is unset, and that inline
+// execution no longer decorates it with childWorkflow metadata.
 func TestTryTaskBuilderExecExposesErrorUnderDefaultKey(t *testing.T) {
-	caughtData, _ := runCatchAndCaptureState(t, "", temporal.NewApplicationError("kaboom", "MyAppError"))
+	caughtData, caughtInput, _ := runCatchAndCaptureState(t, "", temporal.NewApplicationError("kaboom", "MyAppError"))
 
 	caughtErr, ok := caughtData["error"].(map[string]any)
-	require.True(t, ok, "catch child must see the caught error under $data.error")
+	require.True(t, ok, "catch body must see the caught error under $data.error")
 
-	// The error crosses a real child workflow boundary, so it carries both the
-	// child workflow metadata and the unwrapped ApplicationError fields.
 	assert.Equal(t, "MyAppError", caughtErr["type"])
 	assert.Equal(t, "kaboom", caughtErr["message"])
-	assert.Contains(t, caughtErr, "childWorkflow")
-	childMeta, ok := caughtErr["childWorkflow"].(map[string]any)
-	require.True(t, ok)
-	assert.NotEmpty(t, childMeta["workflowType"])
-	assert.NotEmpty(t, childMeta["workflowID"])
+
+	// Execution is now inline, so there is no child workflow boundary and no
+	// childWorkflow metadata to expose.
+	assert.NotContains(t, caughtErr, "childWorkflow",
+		"inline execution must not attach childWorkflow metadata")
+
+	// The catch body must receive the cloned catch state's input.
+	assert.Equal(t, map[string]any{"seed": "input"}, caughtInput)
 }
 
-// TestTryTaskBuilderExecExposesErrorUnderCustomKey proves the catch child
-// workflow sees the caught error under $data.<catch.as> when it is configured,
-// and that the default "error" key is not used in that case.
+// TestTryTaskBuilderExecExposesErrorUnderCustomKey proves the catch body sees
+// the caught error under $data.<catch.as> when configured, and that the
+// default "error" key is not used in that case.
 func TestTryTaskBuilderExecExposesErrorUnderCustomKey(t *testing.T) {
 	const customKey = "failure"
 
-	caughtData, _ := runCatchAndCaptureState(t, customKey, temporal.NewApplicationError("kaboom", "MyAppError"))
+	caughtData, _, _ := runCatchAndCaptureState(t, customKey, temporal.NewApplicationError("kaboom", "MyAppError"))
 
 	caughtErr, ok := caughtData[customKey].(map[string]any)
-	require.True(t, ok, "catch child must see the caught error under the custom $data key")
+	require.True(t, ok, "catch body must see the caught error under the custom $data key")
 	assert.Equal(t, "MyAppError", caughtErr["type"])
 	assert.Equal(t, "kaboom", caughtErr["message"])
 
@@ -291,7 +346,7 @@ func TestTryTaskBuilderExecExposesErrorUnderCustomKey(t *testing.T) {
 // propagation model: the error is only carried forward if the catch tasks
 // output it.
 func TestTryTaskBuilderExecDoesNotLeakErrorIntoParentState(t *testing.T) {
-	_, parentState := runCatchAndCaptureState(t, "", temporal.NewApplicationError("kaboom", "MyAppError"))
+	_, _, parentState := runCatchAndCaptureState(t, "", temporal.NewApplicationError("kaboom", "MyAppError"))
 
 	assert.NotContains(t, parentState.Data, "error",
 		"caught error must not leak back into the parent state after catch completes")
@@ -316,6 +371,9 @@ func TestBuildCatchError(t *testing.T) {
 		assert.Equal(t, true, out["nonRetryable"])
 		assert.Equal(t, "root cause", out["cause"])
 		assert.Equal(t, details, out["details"])
+
+		// Inline execution means no child workflow boundary is crossed.
+		assert.NotContains(t, out, "childWorkflow")
 	})
 
 	t.Run("retryable application error without details", func(t *testing.T) {
@@ -329,9 +387,12 @@ func TestBuildCatchError(t *testing.T) {
 		assert.NotContains(t, out, "details")
 	})
 
-	t.Run("non-application error yields empty map", func(t *testing.T) {
+	t.Run("plain Go error falls back to message", func(t *testing.T) {
 		out := tb.buildCatchError(errors.New("plain"))
 
-		assert.Empty(t, out)
+		// Inline execution surfaces plain Go errors more often; rather than an
+		// empty map, buildCatchError exposes at least the message so the catch
+		// tasks always have something interrogable under $data.
+		assert.Equal(t, "plain", out["message"])
 	})
 }

--- a/tests/e2e/tests/catch-end/test.go
+++ b/tests/e2e/tests/catch-end/test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package catchend
+
+import (
+	_ "embed"
+
+	"github.com/zigflow/zigflow/tests/e2e/utils"
+)
+
+// testCase is the symmetric counterpart to the try-end case: an ordinary
+// try-body failure still enters the catch body, and a `then: end` emitted by a
+// real task inside that inline catch body ends the whole workflow rather than
+// just the catch scope. The task after the try task must not run.
+var testCase = utils.TestCase{
+	Name:         "catch-end",
+	WorkflowPath: "workflow.yaml",
+	ExpectedOutput: map[string]any{
+		"result": map[string]any{
+			"handled": true,
+		},
+	},
+	Test: utils.RunToCompletion[map[string]any],
+}
+
+func init() {
+	utils.AddTestCase(&testCase)
+}

--- a/tests/e2e/tests/catch-end/workflow.yaml
+++ b/tests/e2e/tests/catch-end/workflow.yaml
@@ -1,0 +1,33 @@
+document:
+  dsl: 1.0.0
+  taskQueue: catch-end
+  workflowType: workflow
+  version: 0.0.1
+do:
+  - guarded:
+      # The try task's own output directive shapes whatever the executed body
+      # produced, so the ended catch body's carried output is observable at the
+      # workflow boundary.
+      output:
+        as:
+          result: ${ . }
+      try:
+        # /posts/9999 does not exist, so the mock returns a non-retryable 404.
+        # That is an ordinary failure and must enter the catch body.
+        - getMissingPost:
+            call: http
+            with:
+              method: get
+              endpoint: ${ "http://" + $env.HTTP_MOCK + "/posts/9999" }
+      catch:
+        as: caughtError
+        do:
+          # `then: end` inside the catch body must end the whole workflow, so
+          # the task after the try task must not run.
+          - handled:
+              set:
+                handled: true
+              then: end
+  - mustNotRun:
+      set:
+        afterTry: true

--- a/tests/e2e/tests/tests.go
+++ b/tests/e2e/tests/tests.go
@@ -19,6 +19,7 @@ package tests
 import (
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/callHTTP"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/catch-as"
+	_ "github.com/zigflow/zigflow/tests/e2e/tests/catch-end"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/complete"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/continue-as-new"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/fork"
@@ -26,6 +27,7 @@ import (
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/multi-file-diff-queues"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/multi-file-same-queue"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/set"
+	_ "github.com/zigflow/zigflow/tests/e2e/tests/try-end"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/wait-expression-duration"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/wait-until"
 	_ "github.com/zigflow/zigflow/tests/e2e/tests/wait-until-past"

--- a/tests/e2e/tests/try-end/test.go
+++ b/tests/e2e/tests/try-end/test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tryend
+
+import (
+	_ "embed"
+
+	"github.com/zigflow/zigflow/tests/e2e/utils"
+)
+
+// testCase proves `then: end` inside a try body ends the whole workflow. The
+// try and catch bodies execute inline in the workflow's own Temporal context,
+// so the nested task list cannot rely on that context to tell it apart from
+// the true root: without an explicit nested marker the end directive was
+// consumed as a clean completion of the try body, the catch handler ran, and
+// the task after the try task ran too.
+//
+// The expected output is the ending task's own output: nothing after it
+// contributed, so `catchRan` and `afterTry` must both be absent.
+var testCase = utils.TestCase{
+	Name:         "try-end",
+	WorkflowPath: "workflow.yaml",
+	ExpectedOutput: map[string]any{
+		"result": "ended",
+	},
+	Test: utils.RunToCompletion[map[string]any],
+}
+
+func init() {
+	utils.AddTestCase(&testCase)
+}

--- a/tests/e2e/tests/try-end/workflow.yaml
+++ b/tests/e2e/tests/try-end/workflow.yaml
@@ -1,0 +1,24 @@
+document:
+  dsl: 1.0.0
+  taskQueue: try-end
+  workflowType: workflow
+  version: 0.0.1
+do:
+  - guarded:
+      try:
+        # `then: end` inside the try body is a deliberate termination of the
+        # whole workflow, not a failure to be caught. The catch handler must
+        # not run, and neither must any task after the try task.
+        - finish:
+            set:
+              result: ended
+            then: end
+      catch:
+        as: error
+        do:
+          - caught:
+              set:
+                catchRan: true
+  - mustNotRun:
+      set:
+        afterTry: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is now a closure function in the same workflow. More Temporal idiomatic and improves capacity and memory usage.

## Related issue
<!-- Most changes should be discussed in an issue before implementation. -->
<!-- Link the issue using Fixes #..., Closes #... or Relates to #... -->
<!-- If no issue exists, explain why. -->

Fixes #525 

## How to test

<!-- Provide the steps used to verify this change -->

## Checklist

* [ ] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
* [ ] All tests pass
* [ ] Tests have been added or updated where behaviour changed
* [ ] Documentation has been updated where needed
