### PR TITLE
ci: lock gobwas/glob to v0.2.3

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Update Go dependencies
         run: |
-          go get -u ./...
+          go get -u ./... github.com/gobwas/glob@v0.2.3
           go mod tidy
           go generate ./...
 


### PR DESCRIPTION
The matthewmueller/glob repo has not been updated to v1

## Description
<!-- Describe your changes in detail -->

## Related issue
<!-- Most changes should be discussed in an issue before implementation. -->
<!-- Link the issue using Fixes #..., Closes #... or Relates to #... -->
<!-- If no issue exists, explain why. -->

Fixes #

## How to test

<!-- Provide the steps used to verify this change -->

## Checklist

* [ ] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
* [ ] All tests pass
* [ ] Tests have been added or updated where behaviour changed
* [ ] Documentation has been updated where needed
