### PR TITLE
fix(utils): honour io.Writer contract in LogWriter.Write

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,4 +11,5 @@ mrsimonemms <275848+mrsimonemms@users.noreply.github.com>
 Shlomit Manor <33759493+ShlomitSibony@users.noreply.github.com>
 Simon Emms <simon@simonemms.com>
 Sumit <sumit.seeftech@gmail.com>
+Yash B Joshi <68319416+YJ-928@users.noreply.github.com>
 Yorick Smeets <yorick@energyessentials.nl>

--- a/pkg/utils/log_writer.go
+++ b/pkg/utils/log_writer.go
@@ -36,12 +36,16 @@ func (w LogWriter) AddFields(args []any) LogWriter {
 }
 
 func (w LogWriter) Write(p []byte) (n int, err error) {
-	// This may include multiline strings
-	line := string(p)
+	// io.Writer requires n == len(p) whenever err is nil, including when there
+	// is nothing worth logging. io.MultiWriter enforces this and fails the
+	// whole copy otherwise, so a whitespace-only chunk must not report a short
+	// write.
+	n = len(p)
 
-	line = strings.TrimSpace(line)
+	// This may include multiline strings
+	line := strings.TrimSpace(string(p))
 	if line == "" {
-		return
+		return n, nil
 	}
 
 	msg := "New line"

--- a/pkg/utils/log_writer_contract_test.go
+++ b/pkg/utils/log_writer_contract_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"go.temporal.io/sdk/log"
+)
+
+type probeLogger struct{}
+
+func (probeLogger) Debug(string, ...any) {}
+func (probeLogger) Info(string, ...any)  {}
+func (probeLogger) Warn(string, ...any)  {}
+func (probeLogger) Error(string, ...any) {}
+
+var _ log.Logger = probeLogger{}
+
+// io.Writer: "Write must return a non-nil error if it returns n < len(p)."
+func TestLogWriterHonoursIoWriterContract(t *testing.T) {
+	w := LogWriter{Logger: probeLogger{}, Level: "info"}
+	for _, p := range [][]byte{[]byte("\n"), []byte("   "), []byte(" \t\n ")} {
+		n, err := w.Write(p)
+		if err == nil && n != len(p) {
+			t.Errorf("Write(%q) = (%d, nil); io.Writer requires n == len(p) (%d) when err is nil",
+				p, n, len(p))
+		}
+	}
+}
+
+// The real-world consequence: run:script pipes stdout/stderr through
+// io.MultiWriter, which fails the whole copy on a short write.
+func TestLogWriterUnderMultiWriter(t *testing.T) {
+	var buf bytes.Buffer
+	mw := io.MultiWriter(&buf, LogWriter{Logger: probeLogger{}, Level: "info"})
+	if _, err := mw.Write([]byte("\n")); err != nil {
+		t.Fatalf("MultiWriter rejected a whitespace-only chunk: %v "+
+			"(this is the intermittent 'short write' from run:script)", err)
+	}
+}


### PR DESCRIPTION
## Description

`LogWriter.Write` violates the [`io.Writer`](https://pkg.go.dev/io#Writer)
contract, which requires a non-nil error whenever `n < len(p)`.

- On a chunk with nothing worth logging, it returns **`n=0` with a nil error** —
  the named return `n` is never set before the early `return`.
- `io.MultiWriter` explicitly checks for this and converts it to
  `io.ErrShortWrite`, failing the **entire** copy.
- `runExecCommand` pipes a command's stdout and stderr through
  `io.MultiWriter(&buf, logWriter)`, so one such chunk aborts the whole command.

**Symptom:** an intermittent `error running command: short write` from
`run: script`, on the same script and input that succeeded moments earlier.

**Why intermittent:** the trigger is a whitespace-only chunk — typically a lone
trailing newline delivered as its own pipe `read()`. Whether that happens
depends on how the OS chunks the pipe, so it is timing-dependent rather than
input-dependent. I hit it three times independently across a batch of 11 files.

**Fix:** set `n = len(p)` before the early return. Logging output is unchanged.

`AUTHORS` is in the diff because the repo's `generate-authors` pre-commit hook
fails CI when the file is stale. The entry is produced by
`scripts/generate-authors.sh`, not hand-written.

## Related issue

None — submitted directly per CONTRIBUTING's *"for straightforward fixes, you
may open a pull request without asking to be assigned"*.

- The correct behaviour is defined by the `io.Writer` contract, not by Zigflow
  semantics, so there is nothing to decide.
- The added test demonstrates it, so there is nothing to triage separately.

Happy to open one if you'd prefer it tracked.

## How to test

`pkg/utils/log_writer_contract_test.go` is included. On `main` (`6df96e6cb`),
before the change:

```
=== RUN   TestLogWriterHonoursIoWriterContract
    Write("\n")     = (0, nil); io.Writer requires n == len(p) (1) when err is nil
    Write("   ")    = (0, nil); io.Writer requires n == len(p) (3) when err is nil
    Write(" \t\n ") = (0, nil); io.Writer requires n == len(p) (4) when err is nil
--- FAIL: TestLogWriterHonoursIoWriterContract
=== RUN   TestLogWriterUnderMultiWriter
    MultiWriter rejected a whitespace-only chunk: short write
--- FAIL: TestLogWriterUnderMultiWriter
```

Both pass with the change.

- No workflow file needed — this is a unit-level contract violation.
- `go build ./...`, `go vet` and `gofmt` clean; all 16 test packages pass.
- `tests/chart` fails in my environment because `helm` is not on `$PATH`. It
  fails identically on unmodified `main`, so it is unrelated to this change.

## Checklist

- [ ] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
- [x] All tests pass
- [x] Tests have been added or updated where behaviour changed
- [ ] Documentation has been updated where needed
