### PR TITLE
fix(http): encode the request body for the declared Content-Type

### DIFF
--- a/docs/docs/dsl/tasks/call.md
+++ b/docs/docs/dsl/tasks/call.md
@@ -107,7 +107,7 @@ Call an external resource via HTTP. To use this, the `call` property must equal
 | method | `string` | `yes` | The HTTP request method. |
 | endpoint | `string`\|[`endpoint`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#endpoint) | `yes` | An URI or an object that describes the HTTP endpoint to call. |
 | headers | `map` | `no` | A name/value mapping of the HTTP headers to use, if any. |
-| body | `any` | `no` | The HTTP request body, if any. |
+| body | `any` | `no` | The HTTP request body, if any. *Encoded to match the declared `Content-Type` — see [Gotchas](#gotchas).* |
 | query | `map[string, any]` | `no` | A name/value mapping of the query parameters to use, if any. |
 | output | `string` | `no` | The http call's output format.<br />*Supported values are:*<br />*- `raw`, which output's the base-64 encoded [http response](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#http-response) content, if any.*<br />*- `content`, which outputs the content of [http response](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#http-response), possibly deserialized.*<br />*- `response`, which outputs the [http response](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#http-response).*<br />*Defaults to `content`.* |
 | redirect | `boolean` | `no` | Specifies whether redirection status codes (`300–399`) should be treated as errors.<br />*If set to `false`, runtimes must raise an error for response status codes outside the `200–299` range.*<br />*If set to `true`, they must raise an error for status codes outside the `200–399` range.*<br />*Defaults to `false`.* |
@@ -129,6 +129,15 @@ do:
 ```
 
 ## Gotchas
+
+**The request body is encoded for the declared `Content-Type`.** A `body` given
+as a mapping is form-encoded when the headers declare
+`application/x-www-form-urlencoded`, and sent as JSON otherwise. A `body` given
+as a string is sent verbatim under any non-JSON media type, so pre-encoded and
+XML payloads are not JSON-quoted.
+
+Header lookup is case-insensitive, and form keys are sorted so the output is
+deterministic.
 
 **HTTP errors raise by default.** Responses outside the success range raise an error.
 

--- a/pkg/zigflow/activities/http.go
+++ b/pkg/zigflow/activities/http.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	neturl "net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -180,7 +181,18 @@ func (c *CallHTTP) callHTTPAction(ctx context.Context, task *model.CallHTTP, tim
 
 	method = strings.ToUpper(args.Method)
 	url = args.Endpoint.String()
-	body := args.Body
+
+	// Resolved before the body: the encoding depends on Content-Type
+	headers, err := objectOrRuntimeExprToMap("headers", args.Headers)
+	if err != nil {
+		return resp, method, url, reqHeaders, err
+	}
+	reqHeaders = map[string]string{}
+	for k, v := range headers {
+		reqHeaders[k] = fmt.Sprint(v)
+	}
+
+	body := encodeHTTPBody(args.Body, headerValue(reqHeaders, "Content-Type"))
 
 	logger.Debug("Making HTTP call", "method", method, "url", url)
 	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
@@ -189,16 +201,8 @@ func (c *CallHTTP) callHTTPAction(ctx context.Context, task *model.CallHTTP, tim
 		return resp, method, url, reqHeaders, err
 	}
 
-	// Add in headers
-	headers, err := objectOrRuntimeExprToMap("headers", args.Headers)
-	if err != nil {
-		return resp, method, url, reqHeaders, err
-	}
-	reqHeaders = map[string]string{}
-	for k, v := range headers {
-		val := fmt.Sprint(v)
-		req.Header.Add(k, val)
-		reqHeaders[k] = val
+	for k, v := range reqHeaders {
+		req.Header.Add(k, v)
 	}
 
 	// Add in query strings
@@ -348,4 +352,91 @@ func ParseOutput(outputType string, httpResp HTTPResponse, raw []byte) any {
 	}
 
 	return output
+}
+
+const formMediaType = "application/x-www-form-urlencoded"
+
+// headerValue looks up a header case-insensitively, as HTTP header names are
+// not case-sensitive but Go maps are.
+func headerValue(headers map[string]string, name string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v
+		}
+	}
+	return ""
+}
+
+func isJSONMediaType(mediaType string) bool {
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+// encodeHTTPBody encodes the request body for the declared Content-Type.
+// Bodies are held as JSON, so form endpoints need re-encoding; every other
+// media type is returned unchanged.
+func encodeHTTPBody(body json.RawMessage, contentType string) []byte {
+	if len(body) == 0 {
+		return body
+	}
+
+	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+
+	// UseNumber keeps numeric literals exact
+	var v any
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	if err := dec.Decode(&v); err != nil {
+		return body // not JSON: already raw bytes
+	}
+
+	// A string under a non-JSON media type is already encoded: send it verbatim
+	// rather than JSON-quoted
+	if s, ok := v.(string); ok && mediaType != "" && !isJSONMediaType(mediaType) {
+		return []byte(s)
+	}
+
+	if mediaType == formMediaType {
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return body
+		}
+		return []byte(formEncode(obj))
+	}
+
+	return body
+}
+
+// formEncode renders an object as application/x-www-form-urlencoded.
+// Values.Encode sorts keys, so the output is deterministic.
+func formEncode(obj map[string]any) string {
+	values := neturl.Values{}
+	for k, v := range obj {
+		if items, ok := v.([]any); ok {
+			for _, item := range items {
+				values.Add(k, formValue(item))
+			}
+			continue
+		}
+		values.Set(k, formValue(v))
+	}
+	return values.Encode()
+}
+
+func formValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case json.Number:
+		return t.String()
+	case bool:
+		return strconv.FormatBool(t)
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return fmt.Sprint(t)
+		}
+		return string(b)
+	}
 }

--- a/pkg/zigflow/activities/http_content_type_test.go
+++ b/pkg/zigflow/activities/http_content_type_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package activities
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The body is held as JSON regardless of the declared Content-Type, so an
+// endpoint expecting application/x-www-form-urlencoded receives a JSON object
+// under a header promising a form. encodeHTTPBody picks the wire encoding from
+// the declared Content-Type instead.
+func TestEncodeHTTPBodyFormURLEncoded(t *testing.T) {
+	body := json.RawMessage(`{"grant_type":"client_credentials","scope":"read write"}`)
+
+	got := string(encodeHTTPBody(body, "application/x-www-form-urlencoded"))
+
+	// url.Values.Encode sorts keys, so the expectation is stable.
+	want := "grant_type=client_credentials&scope=read+write"
+	if got != want {
+		t.Errorf("form encoding\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestEncodeHTTPBodyLeavesJSONUntouched(t *testing.T) {
+	body := json.RawMessage(`{"a":"b"}`)
+
+	for _, contentType := range []string{
+		"application/json",
+		"application/json; charset=utf-8",
+		"application/vnd.api+json",
+		"", // unset -- JSON remains the default
+	} {
+		if got := string(encodeHTTPBody(body, contentType)); got != string(body) {
+			t.Errorf("Content-Type %q: body changed\n got: %s\nwant: %s", contentType, got, body)
+		}
+	}
+}
+
+// Header lookup must be case-insensitive: workflows write `content-type` as
+// often as `Content-Type`, and Go maps are not case-folding.
+func TestHeaderValueIsCaseInsensitive(t *testing.T) {
+	for _, key := range []string{"Content-Type", "content-type", "CONTENT-TYPE"} {
+		headers := map[string]string{key: "application/x-www-form-urlencoded"}
+		if got := headerValue(headers, "Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("header %q not found, got %q", key, got)
+		}
+	}
+}
+
+// A pre-encoded or non-JSON payload must reach the wire as-is rather than
+// JSON-quoted, or an XML endpoint receives `"<x/>"` including the quotes.
+func TestEncodeHTTPBodyPassesThroughNonJSONPayloads(t *testing.T) {
+	body := json.RawMessage(`"<note><to>a</to></note>"`)
+
+	got := string(encodeHTTPBody(body, "application/xml"))
+
+	want := "<note><to>a</to></note>"
+	if got != want {
+		t.Errorf("XML passthrough\n got: %s\nwant: %s", got, want)
+	}
+}


### PR DESCRIPTION
## Description

`call: http` holds `with.body` as JSON and sends it verbatim, without consulting the declared `Content-Type`. A workflow that declares a form:

```yaml
document:
  dsl: 1.0.0
  taskQueue: zigflow
  workflowType: token-request
  version: 0.0.1
do:
  - getToken:
      call: http
      with:
        method: POST
        endpoint: https://api.example.com/oauth/token
        headers:
          Content-Type: application/x-www-form-urlencoded
        body:
          grant_type: client_credentials
          scope: read write
```

sends this on the wire:

```http
POST /oauth/token
Content-Type: application/x-www-form-urlencoded

{"grant_type":"client_credentials","scope":"read write"}
```

The endpoint receives a body that does not match the header it was promised and reports its parameters as missing. Nothing in the workflow explains why, and the `Content-Type` the author wrote is visibly correct, so the natural conclusion is that the endpoint is at fault. OAuth2 token endpoints are the common case; most require form encoding.

The cause is in `pkg/zigflow/activities/http.go` — the body is taken as-is and the headers are applied afterwards, so nothing is in a position to select an encoding:

```go
body := args.Body                                    // JSON, unconditionally
req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
// ...
// Add in headers                                    // too late to influence the body
```

`grep -i content-type pkg/zigflow/activities/http.go` returns nothing outside struct tags on `main` today.

**What changed**

- **Headers are resolved before the request is built**, so the encoding can be selected from `Content-Type`. Same values, same behaviour — only the order moves.
- **`application/x-www-form-urlencoded` is rendered with `url.Values`**, which sorts keys, so the output is deterministic and testable. Arrays become repeated keys; numbers keep their exact literal via `json.Number`.
- **A string body under any non-JSON media type is sent verbatim** rather than JSON-quoted. `text/plain` with body `"hello"` previously put `"hello"` on the wire, quotes included; it now sends `hello`. The same applies to XML, CSV and other text types.
- **JSON is byte-for-byte unchanged** — `application/json`, `charset` variants, `+json` suffixes, and an unset `Content-Type` all take the existing path untouched. Object bodies under non-JSON types are also unchanged.

**Behaviour change, stated plainly:** two cases send different bytes than before — form bodies, and string bodies under a non-JSON `Content-Type`. Both were previously sending a JSON encoding under a header that promised something else, so I believe both are corrections rather than regressions, but they are behaviour changes and worth a maintainer's judgement rather than being buried.

`net/url` is imported as `neturl` because the enclosing function already has a local `url` variable; aliasing keeps the diff to the body-encoding change rather than renaming an existing variable.

## Related issue

No issue was raised first. The behaviour is not a design question — if a request declares `application/x-www-form-urlencoded`, the body has to be form-encoded — so there is nothing to agree on before implementing, and the change is two files with a regression test.

Happy to open one and link it if you would prefer the discussion recorded separately.

## How to test

**Unit tests**

```bash
go test ./pkg/zigflow/activities/... -run 'TestEncodeHTTPBody|TestHeaderValue' -v
```

On `main` these fail to compile (the helpers do not exist); with this change they pass.

**End to end, against Postman Echo**

```yaml
document:
  dsl: 1.0.0
  taskQueue: zigflow
  workflowType: form-encoding-check
  version: 0.0.1
do:
  - post:
      call: http
      with:
        method: POST
        endpoint: https://postman-echo.com/post
        headers:
          Content-Type: application/x-www-form-urlencoded
        body:
          grant_type: client_credentials
          scope: read write
```

- **Before:** the echo shows the whole JSON string crammed into a single form key —
  `"form": {"{\"grant_type\":\"client_credentials\",\"scope\":\"read write\"}": ""}`
- **After:** the echo shows the fields parsed correctly —
  `"form": {"grant_type": "client_credentials", "scope": "read write"}`

Swapping the header to `application/json` shows an identical JSON body before and after, confirming the existing path is unaffected.

**Checks run locally**

- `go build ./...`
- `go test ./pkg/zigflow/activities/...`
- `golangci-lint run` using the pinned `v2.13.2` — 0 issues
- `pre-commit run` for `license-eye`, `golangci-lint` and `generate-authors` — all pass

## Checklist

* [ ] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...` — see **Related issue** above
* [x] All tests pass
* [x] Tests have been added or updated where behaviour changed
* [x] Documentation has been updated where needed — no documentation describes request body encoding, so nothing became inaccurate. Glad to add a note to `docs/docs/examples/http-call.md` if you would like it covered.