### PR TITLE
Implement context propagation

### DIFF
--- a/cmd/run/workers.go
+++ b/cmd/run/workers.go
@@ -26,12 +26,14 @@ import (
 	"github.com/rs/zerolog/log"
 	temporal "github.com/zigflow/helpers"
 	"github.com/zigflow/zigflow/pkg/codec"
+	"github.com/zigflow/zigflow/pkg/ctxpropagator"
 	"github.com/zigflow/zigflow/pkg/zigflow"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
 	"github.com/zigflow/zigflow/pkg/zigflow/tasks"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/contrib/sysinfo"
 	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 )
 
 // newTemporalConnection is the function used to establish a Temporal client. It
@@ -268,6 +270,7 @@ func initTemporalClient(opts *runOptions) (client.Client, error) {
 		},
 		temporal.WithZerolog(&log.Logger),
 		temporal.WithPrometheusMetrics(opts.temporal.MetricsListenAddress, opts.temporal.MetricsPrefix, nil),
+		temporal.WithContextPropagators([]workflow.ContextPropagator{ctxpropagator.NewContextPropagator()}),
 	)
 	if err != nil {
 		return nil, gh.FatalError{Cause: err, Msg: "Unable to create client"}

--- a/cmd/run/workers.go
+++ b/cmd/run/workers.go
@@ -27,11 +27,13 @@ import (
 	temporal "github.com/zigflow/helpers"
 	"github.com/zigflow/zigflow/pkg/codec"
 	"github.com/zigflow/zigflow/pkg/ctxpropagator"
+	"github.com/zigflow/zigflow/pkg/interceptors"
 	"github.com/zigflow/zigflow/pkg/zigflow"
 	"github.com/zigflow/zigflow/pkg/zigflow/activities"
 	"github.com/zigflow/zigflow/pkg/zigflow/tasks"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/contrib/sysinfo"
+	sdkinterceptor "go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -171,6 +173,9 @@ func buildWorkersByTaskQueue(
 				TaskQueueActivitiesPerSecond:           opts.TaskQueueActivitiesPerSecond,
 				DeploymentOptions:                      deploymentOptions,
 				SysInfoProvider:                        sysinfo.SysInfoProvider(),
+				Interceptors: []sdkinterceptor.WorkerInterceptor{
+					interceptors.NewLoggerInterceptor(),
+				},
 			})
 			workers[reg.TaskQueue] = w
 			log.Debug().Str("task-queue", reg.TaskQueue).Msg("Created worker for task queue")

--- a/docs/docs/concepts/common-mistakes.md
+++ b/docs/docs/concepts/common-mistakes.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 description: "The recurring mistakes that break Zigflow workflows: invalid task types, expression syntax, runtime variables, durations, determinism and document structure, with the correct construct for each."
 ---
 
@@ -124,9 +124,9 @@ set:
 
 ### Invented runtime variables
 
-Only five variables exist in an expression: `$context`, `$data`, `$env`,
-`$input` and `$output`. Names such as `$workflow`, `$task`, `$steps`, `$vars`
-or `$now` do not exist and fail at evaluation.
+Only six variables exist in an expression: `$context`, `$data`, `$env`,
+`$input`, `$output` and `$propagated`. Names such as `$workflow`, `$task`,
+`$steps`, `$vars` or `$now` do not exist and fail at evaluation.
 
 :::warning
 There is no `$now`. Use `${ timestamp }` or `${ timestamp_iso8601 }`, and only
@@ -359,6 +359,8 @@ taskQueue: my-queue-v2
   `output`
 - [Data and Expressions](/docs/concepts/data-and-expressions): expression
   syntax, variables and determinism
+- [Context Propagation](/docs/concepts/context-propagation): the read-only
+  `$propagated` object
 - [Tasks: introduction](/docs/dsl/tasks/intro): the eleven task types
 - [Call task](/docs/dsl/tasks/call): HTTP, gRPC and activity calls
 - [Wait task](/docs/dsl/tasks/wait): durations and the `until` form

--- a/docs/docs/concepts/comparing-zigflow-and-temporal-sdks.md
+++ b/docs/docs/concepts/comparing-zigflow-and-temporal-sdks.md
@@ -1,6 +1,6 @@
 ---
 title: "Zigflow vs Temporal SDK"
-sidebar_position: 9
+sidebar_position: 10
 description: "How Zigflow compares to a Temporal SDK, what each approach optimises for and when to choose declarative YAML workflows over SDK code."
 ---
 

--- a/docs/docs/concepts/context-propagation.md
+++ b/docs/docs/concepts/context-propagation.md
@@ -1,0 +1,212 @@
+---
+sidebar_position: 6
+description: "How Zigflow exposes Temporal context propagation to workflows through the read-only $propagated object, and how a client supplies the values."
+---
+
+# Context Propagation
+
+## What you will learn
+
+- What `$propagated` contains and where the values come from
+- How `$propagated` differs from `$context`
+- How a client supplies propagated values
+- What happens to propagated values across Temporal execution boundaries
+
+:::tip
+For the full list of runtime variables and the expression syntax, see
+[Data and Expressions](/docs/concepts/data-and-expressions).
+:::
+
+---
+
+## What context propagation is
+
+:::info
+For more information about context propagation in Temporal, see the
+[Temporal docs](https://docs.temporal.io/encyclopedia/context-propagation)
+:::
+
+Temporal can carry caller-supplied values alongside a workflow execution. The
+values travel in Temporal headers rather than in the workflow input, so they
+are available to the workflow without changing its input contract.
+
+Zigflow registers a Temporal context propagator and exposes whatever it
+receives as the read-only root-level `$propagated` object.
+
+This is useful for values that describe the caller rather than the work: a
+tenant identifier, a request correlation identifier, a locale, a region.
+
+---
+
+## Reading `$propagated`
+
+`$propagated` is an object of key and value pairs. Read a key with an ordinary
+runtime expression.
+
+```yaml title="workflow.yaml"
+document:
+  dsl: 1.0.0
+  taskQueue: zigflow
+  workflowType: propagated-example
+  version: 1.0.0
+do:
+  - recordCaller:
+      set:
+        tenantId: ${ $propagated.tenantId }
+        correlationId: ${ $propagated.correlationId }
+```
+
+Propagated values are ordinary workflow data. Use them anywhere an expression
+is valid, including conditions, task inputs, HTTP bodies and exports.
+
+```yaml
+- fetchTenantConfig:
+    call: http
+    with:
+      method: get
+      endpoint: ${ "https://api.example.com/tenants/" + $propagated.tenantId }
+```
+
+If nothing was propagated, `$propagated` is an empty object and reading a key
+returns `null`. Guard against a missing key the same way you would any other
+optional value:
+
+```yaml
+- recordTenant:
+    set:
+      tenantId: ${ $propagated.tenantId // "unknown" }
+```
+
+The propagated payload must decode to an object. If a client sends something
+else, such as a bare string, the workflow task fails and Temporal retries it,
+so the execution makes no progress until the client is corrected.
+
+---
+
+## `$propagated` is not `$context`
+
+The two are easy to confuse. They come from different places and behave
+differently.
+
+| | `$propagated` | `$context` |
+| --- | --- | --- |
+| Source | The caller, through Temporal context propagation | Tasks in the workflow, through `export.as` |
+| Written by | Nothing in the DSL. It is read-only | Each task's `export.as` |
+| Type | Always an object | Any value |
+| Changes during the run | No | Yes, each `export` replaces it |
+
+`$context` remains the user-controlled workflow context described in
+[Data Flow](/docs/concepts/data-flow). Context propagation does not change it.
+
+---
+
+## Lifecycle
+
+Propagated values are established once, when the workflow execution starts, and
+do not change for the rest of the run.
+
+- They are read from Temporal context propagation as the workflow begins.
+- They are retained in Zigflow's workflow state, so they survive
+  [Continue-As-New](/docs/dsl/metadata/continue-as-new).
+- They are carried across Temporal execution boundaries, such as activities and
+  child workflows, by the registered context propagator.
+- Nested `do` tasks share the parent workflow's state, so they see the same
+  values.
+
+There is no DSL mechanism to add to or modify `$propagated` during a run. To
+carry values you compute yourself, use `export.as` and `$context`.
+
+---
+
+## Supplying propagated values from a client
+
+Propagated values are supplied by the application that starts the workflow, not
+by Zigflow.
+
+Zigflow reads a single Temporal header field:
+
+```text
+zigflow.propagated
+```
+
+The field holds a payload encoding an object of key and value pairs, written
+with the Temporal SDK's default payload converter. Because the values become a
+Temporal payload, they must be portable, serialisable data. Strings, numbers,
+booleans, and objects and arrays of those, are all fine. Language-specific
+objects, open connections and handles are not.
+
+Zigflow does not expose a language-specific `context` object to the workflow.
+The portable contract is the propagated data itself.
+
+### SDK differences
+
+Temporal SDKs expose this in different ways:
+
+- Go and Java have a native context propagator concept. A Go client can
+  register Zigflow's propagator directly.
+- Other SDKs, including Python and TypeScript, use a client interceptor that
+  sets the `zigflow.propagated` header when starting a workflow.
+
+Either approach produces the same header, so the workflow sees the same
+`$propagated` object.
+
+The `examples/` directory in the Zigflow repository contains working clients for
+Go, Python and TypeScript.
+
+---
+
+## Choosing what to propagate
+
+:::warning
+Avoid propagating sensitive values such as access tokens, credentials or
+personal data. Propagated values are stored in Temporal history and, by
+default, use Temporal's standard payload conversion rather than Zigflow's
+configured payload codec.
+
+Context propagation is intended for small pieces of execution metadata such as
+correlation IDs, tenant identifiers, locale and region.
+:::
+
+Keep the set small and stable. Propagation is for identifiers and small
+descriptive values, not for workflow input. Anything the workflow operates on
+belongs in the workflow input, where it is schema-checked and explicit.
+
+Only `$propagated.correlationId` receives special treatment, and only in
+logging. See
+[Observability: correlation IDs in logs](/docs/deployment/observability#correlation-ids-in-logs).
+
+---
+
+## Common mistakes
+
+**Trying to write to `$propagated`.**
+It is read-only. No task writes to it. Use `set` to write `$data` or `export`
+to write `$context`.
+
+**Expecting `$propagated` to change during a run.**
+Values are fixed when the execution starts. A later caller cannot change them.
+
+**Confusing `$propagated` with `$context`.**
+`$propagated` comes from the caller and never changes. `$context` comes from
+your own tasks and is replaced by every `export`.
+
+**Assuming every propagated value is logged.**
+Only a string `correlationId` is added to log entries automatically. Everything
+else is readable through `$propagated` but is not logged.
+
+**Propagating non-serialisable data.**
+The values must survive conversion to a Temporal payload.
+
+---
+
+## Related pages
+
+- [Data and Expressions](/docs/concepts/data-and-expressions): the runtime
+  variables and expression syntax
+- [Data Flow](/docs/concepts/data-flow): how `$output` and `$context` move data
+  between tasks
+- [Observability](/docs/deployment/observability#correlation-ids-in-logs):
+  automatic `correlationId` logging
+- [Continue-As-New](/docs/dsl/metadata/continue-as-new): long-running workflows
+  and history size
+- [How Zigflow runs](/docs/concepts/how-zigflow-runs): the execution model

--- a/docs/docs/concepts/data-and-expressions.md
+++ b/docs/docs/concepts/data-and-expressions.md
@@ -54,6 +54,7 @@ endpoint: ${ "https://api.example.com/users/" + ($data.userId | tostring) }
 | `$env` | Environment variables available to the worker |
 | `$input` | The original workflow input supplied by the caller. This value does not change as tasks execute. |
 | `$output` | The output of the most recent task |
+| `$propagated` | Read-only values received through Temporal context propagation |
 
 ### `$input`
 
@@ -133,6 +134,29 @@ Set `--env-prefix` to change the prefix (default is `ZIGGY`).
 
 The output of the most recently completed task. Use it to chain task results
 without storing them explicitly.
+
+### `$propagated`
+
+:::tip
+For the caller-side contract and how values are supplied, see
+[Context Propagation](/docs/concepts/context-propagation).
+:::
+
+Values received through Temporal context propagation, supplied by the
+application that started the workflow. It is read-only and is fixed for the
+whole run.
+
+```yaml
+- recordCaller:
+    set:
+      tenantId: ${ $propagated.tenantId }
+```
+
+`$propagated` is always an object. If nothing was propagated it is empty, and
+reading a key returns `null`.
+
+Do not confuse it with `$context`. `$propagated` comes from the caller and never
+changes. `$context` is written by your own tasks through `export`.
 
 ---
 
@@ -217,6 +241,10 @@ A `$data` key is only available after the task that wrote it has run. A `set`
 task merges its keys directly, and an activity-backed task such as an HTTP call
 stores its result under the task name. Access them in a later task.
 
+**Trying to write to `$propagated`.**
+`$propagated` is read-only. Use `set` to write `$data`, or `export` to write
+`$context`.
+
 **Confusing `$output` with `$data`.**
 `$output` is the output of the last task only. `$data` accumulates workflow data
 from task execution, keyed by name, and unlike `$context` is never replaced by
@@ -227,6 +255,8 @@ from task execution, keyed by name, and unlike `$context` is never replaced by
 ## Related pages
 
 - [Data Flow](/docs/concepts/data-flow): how data moves between tasks
+- [Context Propagation](/docs/concepts/context-propagation): the `$propagated`
+  object and where its values come from
 - [Set task](/docs/dsl/tasks/set): storing data
 - [DSL reference](/docs/dsl/intro): full expression context
 - [How Zigflow runs](/docs/concepts/how-zigflow-runs): determinism and replay

--- a/docs/docs/concepts/data-flow.md
+++ b/docs/docs/concepts/data-flow.md
@@ -38,6 +38,11 @@ whiteboard unless you explicitly merge the existing contents.
 The workflow returns the baton. The whiteboard is for passing values between
 tasks along the way.
 
+A third variable, `$propagated`, is read-only and is not a channel. It carries
+values supplied by the caller through Temporal context propagation and never
+changes during the run. See
+[Context Propagation](/docs/concepts/context-propagation).
+
 ---
 
 ## How a task processes data
@@ -272,5 +277,7 @@ it.
 ## Related pages
 
 - [Data and Expressions](/docs/concepts/data-and-expressions): jq expressions
+- [Context Propagation](/docs/concepts/context-propagation): the read-only
+  `$propagated` object
 - [Set task](/docs/dsl/tasks/set): storing data in `$data`
 - [DSL reference](/docs/dsl/intro): `input`, `output` and `export` properties

--- a/docs/docs/concepts/durable-execution-in-yaml.md
+++ b/docs/docs/concepts/durable-execution-in-yaml.md
@@ -1,6 +1,6 @@
 ---
 title: "Durable execution in YAML"
-sidebar_position: 10
+sidebar_position: 11
 description: "How Zigflow expresses durable execution in YAML by compiling declarative workflow definitions onto Temporal."
 ---
 

--- a/docs/docs/concepts/error-handling-and-retries.md
+++ b/docs/docs/concepts/error-handling-and-retries.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Error Handling and Retries

--- a/docs/docs/concepts/glossary.md
+++ b/docs/docs/concepts/glossary.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Glossary
@@ -28,6 +28,17 @@ can be awaited by the parent. Used internally by `fork`, `try` and certain
 `run` modes.
 
 See also: [Temporal docs: child workflows](https://docs.temporal.io/child-workflows)
+
+---
+
+## Context propagation
+
+A Temporal mechanism for carrying caller-supplied values alongside a workflow
+execution, in Temporal headers rather than in the workflow input. Zigflow
+exposes the values it receives to the workflow as the read-only `$propagated`
+object.
+
+See also: [Context Propagation](/docs/concepts/context-propagation)
 
 ---
 

--- a/docs/docs/deployment/observability.md
+++ b/docs/docs/deployment/observability.md
@@ -10,6 +10,7 @@ sidebar_position: 5
 - How to scrape Prometheus metrics from a running worker
 - How to emit CloudEvents during workflow execution
 - How to control log verbosity
+- How `correlationId` is added to logs automatically
 
 ## Health checks
 
@@ -159,6 +160,66 @@ takes precedence.
 
 Logs are structured JSON, written to stderr.
 
+### Correlation IDs in logs
+
+:::tip
+For how propagated values reach the workflow in the first place, see
+[Context Propagation](/docs/concepts/context-propagation).
+:::
+
+Zigflow gives one propagated value special treatment. If the caller propagates
+a key named `correlationId` and its value is a string, Zigflow adds it as a
+structured `correlationId` field to every workflow and activity log entry.
+
+You do not need to add it to individual log statements.
+
+Given a caller that propagates:
+
+```json
+{
+  "correlationId": "abc-123",
+  "tenantId": "acme"
+}
+```
+
+Log entries from that workflow execution carry `correlationId=abc-123`
+automatically. The `tenantId` value is still available to the workflow as
+`${ $propagated.tenantId }`, but it is not added to log entries. Read it like
+any other value:
+
+```yaml
+- recordTenant:
+    set:
+      tenantId: ${ $propagated.tenantId }
+```
+
+#### Rules
+
+| Condition | Result |
+| --- | --- |
+| `correlationId` is present and is a string | Added to every log entry as `correlationId` |
+| `correlationId` is absent | No correlation field is added |
+| `correlationId` is present but is not a string | No correlation field is added |
+
+`correlationId` is optional. A workflow runs normally without it.
+
+Zigflow does not convert a non-string `correlationId` to a string. If you want
+the automatic field, propagate a string. If you propagate a number, the value
+remains readable as `${ $propagated.correlationId }` but is not logged
+automatically.
+
+#### Why only `correlationId`
+
+Only `correlationId` is auto-logged because it is the one value whose purpose
+is to be correlated across log lines. Logging arbitrary propagated data by
+default would risk writing sensitive values into logs and adding high
+cardinality fields to every entry.
+
+All propagated values remain available through `$propagated` whether or not
+they are logged. To surface another one, read it into the workflow with `set`
+or `export`, where it becomes visible in Temporal history and in
+[CloudEvents](/docs/dsl/debugging).
+
 ---
 
 ## Related pages
@@ -167,3 +228,5 @@ Logs are structured JSON, written to stderr.
 - [Docker](/docs/deployment/docker): Docker and Compose configuration
 - [Kubernetes](/docs/deployment/kubernetes): Helm chart deployment
 - [Debugging workflows](/docs/dsl/debugging): CloudEvents in detail
+- [Context Propagation](/docs/concepts/context-propagation): the `$propagated`
+  object and how callers supply it

--- a/docs/docs/dsl/tasks/intro.md
+++ b/docs/docs/dsl/tasks/intro.md
@@ -70,6 +70,7 @@ Variables able to be referenced within runtime expressions.
 | `$env` | Any environment variable prefixed with `ZIGGY_`. The prefix is _NOT_ used in this object. This can be set with the [`--env-prefix` flag](/docs/cli/commands/zigflow#options) | `${ $env.EXAMPLE_ENVVAR }` |
 | `$input` | Any input received when the workflow was triggered | `${ $input.val1 }` |
 | `$output` | Any output exported from a task - see [output](/docs/dsl/intro#output) | `${ $output }` |
+| `$propagated` | Read-only values received through [context propagation](/docs/concepts/context-propagation). Empty if the caller propagated nothing | `${ $propagated.tenantId }` |
 
 ### Functions
 

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -22,7 +22,7 @@ import globals from 'globals';
 
 export default defineConfig([
   {
-    ignores: ['.docusaurus'],
+    ignores: ['.docusaurus', 'build'],
   },
   eslintPluginPrettierRecommended,
   {

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -149,7 +149,7 @@ task-level `timeout` field.
 
 ## Runtime variables
 
-Inside `${ ... }`, exactly five workflow-state variables are available. No
+Inside `${ ... }`, exactly six workflow-state variables are available. No
 others exist, and referencing any other `$`-variable fails to compile:
 
 | Variable   | Contents                                                                                                                                                     |
@@ -159,9 +159,17 @@ others exist, and referencing any other `$`-variable fails to compile:
 | `$env`     | Environment variables (see below).                                                                                                                           |
 | `$input`   | The input given by the caller. This value does not change as tasks execute.                                                                                  |
 | `$output`  | The current output value.                                                                                                                                    |
+| `$propagated` | Read-only values received through Temporal context propagation. An empty object if the caller propagated nothing. |
 
 Variables such as `$workflow`, `$task`, `$secret`, `$secrets`, `$vars`, `$self`,
 `$now` or `$steps` do not exist.
+
+`$propagated` is read-only. Nothing in the DSL writes to it. Its values are
+supplied by the client that starts the workflow, in the Temporal header field
+`zigflow.propagated`, and are fixed for the whole run. If the client propagates
+a string under the key `correlationId`, Zigflow adds it automatically as a
+`correlationId` field on workflow and activity log entries. No other propagated
+value is logged automatically.
 
 `$env` exposes only environment variables that start with a configured prefix,
 which is `ZIGGY_` by default, with the prefix stripped. For example,

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -22,16 +22,20 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
 	gh "github.com/mrsimonemms/golang-helpers"
 	"github.com/rs/zerolog/log"
 	temporal "github.com/zigflow/helpers"
+	"github.com/zigflow/zigflow/pkg/ctxpropagator"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
 )
 
 func exec() error {
 	// The client is a heavyweight object that should be created once per process.
 	c, err := temporal.NewConnectionWithEnvvars(
 		temporal.WithZerolog(&log.Logger),
+		temporal.WithContextPropagators([]workflow.ContextPropagator{ctxpropagator.NewContextPropagator()}),
 	)
 	if err != nil {
 		return gh.FatalError{
@@ -46,6 +50,13 @@ func exec() error {
 	}
 
 	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxpropagator.PropagateKey, map[string]any{
+		"key":                       "value",
+		"number":                    123,
+		"hello":                     "world",
+		ctxpropagator.CorrelationID: uuid.NewString(),
+	})
+
 	we, err := c.ExecuteWorkflow(ctx, workflowOptions, "basic", map[string]any{
 		"userId": 3,
 	})

--- a/examples/basic/workflow.yaml
+++ b/examples/basic/workflow.yaml
@@ -33,6 +33,8 @@ do:
         as:
           baseData: ${ . }
       set:
+        # $propagated comes from context propagator set in client
+        correlationId: ${ $propagated.correlationId }
         # Set a variable from an envvar
         envvar: ${ $env.EXAMPLE_ENVVAR }
         uuid: ${ uuid }

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -23,7 +23,38 @@ import sys
 import uuid
 from typing import Any, Dict
 
-from temporalio.client import Client
+from temporalio.client import (
+    Client,
+    Interceptor,
+    OutboundInterceptor,
+    StartWorkflowInput,
+)
+from temporalio.converter import PayloadConverter
+
+
+class PropagationOutboundInterceptor(OutboundInterceptor):
+    async def start_workflow(self, input: StartWorkflowInput):
+        headers = dict(input.headers)
+        headers["zigflow.propagated"] = PayloadConverter.default.to_payload(
+            {
+                "key":    "value",
+                "number": 123,
+                "hello":  "world",
+                "correlationId": str(uuid.uuid4()),
+            }
+        )
+
+        input.headers = headers
+
+        return await self.next.start_workflow(input)
+
+
+class PropagationInterceptor(Interceptor):
+    def intercept_client(
+        self,
+        next: OutboundInterceptor,
+    ) -> OutboundInterceptor:
+        return PropagationOutboundInterceptor(next)
 
 
 async def main() -> None:
@@ -32,7 +63,10 @@ async def main() -> None:
     api_key = os.getenv("TEMPORAL_API_KEY")
     tls_enabled = os.getenv("TEMPORAL_TLS", "false").lower() == "true"
 
-    connect_kwargs: Dict[str, Any] = {"namespace": namespace}
+    connect_kwargs: Dict[str, Any] = {
+        "namespace": namespace,
+        "interceptors": [PropagationInterceptor()],
+      }
     if tls_enabled:
         # Passing True enables TLS using the platform defaults (e.g. system CAs).
         connect_kwargs["tls"] = True

--- a/examples/python/workflow.yaml
+++ b/examples/python/workflow.yaml
@@ -27,6 +27,8 @@ do:
         as:
           baseData: ${ . }
       set:
+        # $propagated comes from injectors set in client
+        correlationId: ${ $propagated.correlationId }
         # Set a variable from an envvar
         envvar: ${ $env.EXAMPLE_ENVVAR }
         uuid: ${ uuid }

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -14,8 +14,35 @@
  * limitations under the License.
  */
 
-import { Connection, Client } from '@temporalio/client';
+import {
+  Connection,
+  Client,
+  WorkflowStartInput,
+  Next,
+  WorkflowClientInterceptor,
+  defaultPayloadConverter,
+} from '@temporalio/client';
 import { nanoid } from 'nanoid';
+
+class PropagationInterceptor implements WorkflowClientInterceptor {
+  async start(
+    input: WorkflowStartInput,
+    next: Next<WorkflowClientInterceptor, 'start'>,
+  ): Promise<string> {
+    return next({
+      ...input,
+      headers: {
+        ...input.headers,
+        'zigflow.propagated': defaultPayloadConverter.toPayload({
+          correlationId: nanoid(),
+          key: 'value',
+          number: 123,
+          hello: 'world',
+        })!,
+      },
+    });
+  }
+}
 
 async function bootstrap() {
   const connection = await Connection.connect({
@@ -27,6 +54,9 @@ async function bootstrap() {
   const client = new Client({
     connection,
     namespace: process.env.TEMPORAL_NAMESPACE ?? 'default',
+    interceptors: {
+      workflow: [new PropagationInterceptor()],
+    },
   });
 
   const handle = await client.workflow.start('basic-typescript', {

--- a/examples/typescript/workflow.yaml
+++ b/examples/typescript/workflow.yaml
@@ -26,6 +26,8 @@ do:
         as:
           baseData: ${ . }
       set:
+        # $propagated comes from injectors set in client
+        correlationId: ${ $propagated.correlationId }
         # Set a variable from an envvar
         envvar: ${ $env.EXAMPLE_ENVVAR }
         uuid: ${ uuid }

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.44.0
-	github.com/zigflow/helpers v0.1.0
+	github.com/zigflow/helpers v0.1.1
 	github.com/zigflow/schema v0.0.0-20260701135855-e79c2b6217b1
 	go.temporal.io/sdk v1.48.0
 	go.temporal.io/sdk/contrib/sysinfo v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -556,8 +556,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zigflow/helpers v0.1.0 h1:eA/gwrK+4Jda2pOn24wa4YCIww6cDcxqBd+buPfYUS8=
-github.com/zigflow/helpers v0.1.0/go.mod h1:l46aOXFqQNLkvWCK4DM4Po0sIc1E0pYBBHYqNAY0olk=
+github.com/zigflow/helpers v0.1.1 h1:eyTyFdnzhP+5fccKCk84nVb5KYSCtOT1SZc/VrzV3hk=
+github.com/zigflow/helpers v0.1.1/go.mod h1:rRBAZ3K0IZbr8jYOaFAJf0FOgnNsDcFX1q3U9KkmMDs=
 github.com/zigflow/schema v0.0.0-20260701135855-e79c2b6217b1 h1:UDaWPmoVrrHFnhiq4KPOyePJR5DzFdShfDIuT4lO/k0=
 github.com/zigflow/schema v0.0.0-20260701135855-e79c2b6217b1/go.mod h1:O/9DLbXLFYLSoByQbeI4hhr9qXXdk/isH51EYQiqSkw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
@@ -606,6 +606,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
 go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
+go.uber.org/zap/exp v0.3.0 h1:6JYzdifzYkGmTdRR59oYH+Ng7k49H9qVpWwNSsGJj3U=
+go.uber.org/zap/exp v0.3.0/go.mod h1:5I384qq7XGxYyByIhHm6jg5CHkGY0nsTfbDLgDDlgJQ=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=

--- a/pkg/ctxpropagator/propagator.go
+++ b/pkg/ctxpropagator/propagator.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ctxpropagator
+
+import (
+	"context"
+
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/workflow"
+)
+
+type contextKey struct{}
+
+type propagator struct{}
+
+const (
+	CorrelationID = "correlationId" // Special key added to logger output
+	HeaderKey     = "zigflow.propagated"
+)
+
+var PropagateKey = contextKey{}
+
+func (s *propagator) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
+	if value, ok := reader.Get(HeaderKey); ok {
+		var values map[string]any
+		if err := converter.GetDefaultDataConverter().FromPayload(value, &values); err != nil {
+			return ctx, err
+		}
+		ctx = context.WithValue(ctx, PropagateKey, values)
+	}
+
+	return ctx, nil
+}
+
+func (s *propagator) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
+	if value, ok := reader.Get(HeaderKey); ok {
+		var values map[string]any
+		if err := converter.GetDefaultDataConverter().FromPayload(value, &values); err != nil {
+			return ctx, err
+		}
+		ctx = workflow.WithValue(ctx, PropagateKey, values)
+	}
+
+	return ctx, nil
+}
+
+func (s *propagator) Inject(ctx context.Context, writer workflow.HeaderWriter) error {
+	value := ctx.Value(PropagateKey)
+	if value == nil {
+		return nil
+	}
+
+	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
+	if err != nil {
+		return err
+	}
+
+	writer.Set(HeaderKey, payload)
+
+	return nil
+}
+
+func (s *propagator) InjectFromWorkflow(ctx workflow.Context, writer workflow.HeaderWriter) error {
+	value := ctx.Value(PropagateKey)
+	if value == nil {
+		return nil
+	}
+
+	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
+	if err != nil {
+		return err
+	}
+
+	writer.Set(HeaderKey, payload)
+
+	return nil
+}
+
+func NewContextPropagator() workflow.ContextPropagator {
+	return &propagator{}
+}

--- a/pkg/ctxpropagator/propagator_test.go
+++ b/pkg/ctxpropagator/propagator_test.go
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ctxpropagator
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+// testHeader is an in-memory stand-in for the Temporal header. The SDK only
+// exposes the reader/writer interfaces, so tests supply their own.
+type testHeader struct {
+	fields map[string]*commonpb.Payload
+}
+
+func newTestHeader() *testHeader {
+	return &testHeader{fields: map[string]*commonpb.Payload{}}
+}
+
+func (h *testHeader) Set(key string, value *commonpb.Payload) {
+	h.fields[key] = value
+}
+
+func (h *testHeader) Get(key string) (*commonpb.Payload, bool) {
+	value, ok := h.fields[key]
+
+	return value, ok
+}
+
+// ForEachKey walks the keys in sorted order so tests never depend on Go's
+// randomised map iteration.
+func (h *testHeader) ForEachKey(handler func(string, *commonpb.Payload) error) error {
+	keys := make([]string, 0, len(h.fields))
+	for key := range h.fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if err := handler(key, h.fields[key]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var (
+	_ workflow.HeaderReader = (*testHeader)(nil)
+	_ workflow.HeaderWriter = (*testHeader)(nil)
+)
+
+// malformedPayload claims to be JSON but is not decodable.
+func malformedPayload() *commonpb.Payload {
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{"encoding": []byte("json/plain")},
+		Data:     []byte("{ this is not json"),
+	}
+}
+
+func TestPropagator_InjectExtractRoundTrip(t *testing.T) {
+	values := map[string]any{
+		CorrelationID: "corr-123",
+		"tenant":      "acme",
+	}
+
+	p := NewContextPropagator()
+	header := newTestHeader()
+
+	require.NoError(t, p.Inject(context.WithValue(context.Background(), PropagateKey, values), header))
+
+	_, ok := header.Get(HeaderKey)
+	require.True(t, ok, "Inject should write the propagated values to the header")
+
+	ctx, err := p.Extract(context.Background(), header)
+	require.NoError(t, err)
+
+	assert.Equal(t, values, ctx.Value(PropagateKey))
+}
+
+func TestPropagator_InjectWithoutValues(t *testing.T) {
+	p := NewContextPropagator()
+	header := newTestHeader()
+
+	require.NoError(t, p.Inject(context.Background(), header))
+
+	_, ok := header.Get(HeaderKey)
+	assert.False(t, ok, "nothing should be written when there is nothing to propagate")
+}
+
+func TestPropagator_ExtractWithoutHeader(t *testing.T) {
+	p := NewContextPropagator()
+
+	ctx, err := p.Extract(context.Background(), newTestHeader())
+	require.NoError(t, err)
+
+	assert.Nil(t, ctx.Value(PropagateKey), "no header means no propagated values")
+}
+
+func TestPropagator_ExtractIgnoresUnrelatedHeaderKeys(t *testing.T) {
+	p := NewContextPropagator()
+	header := newTestHeader()
+	header.Set("some.other.key", malformedPayload())
+
+	ctx, err := p.Extract(context.Background(), header)
+	require.NoError(t, err)
+
+	assert.Nil(t, ctx.Value(PropagateKey))
+}
+
+func TestPropagator_ExtractMalformedPayload(t *testing.T) {
+	p := NewContextPropagator()
+	header := newTestHeader()
+	header.Set(HeaderKey, malformedPayload())
+
+	ctx, err := p.Extract(context.Background(), header)
+
+	require.Error(t, err, "an undecodable payload must be reported, not silently dropped")
+	assert.Nil(t, ctx.Value(PropagateKey))
+}
+
+func TestPropagator_InjectFromWorkflow(t *testing.T) {
+	tests := []struct {
+		name      string
+		values    map[string]any
+		setValues bool
+		wantKey   bool
+	}{
+		{
+			name:      "writes propagated values",
+			values:    map[string]any{CorrelationID: "corr-456"},
+			setValues: true,
+			wantKey:   true,
+		},
+		{
+			name:      "writes nothing when there is nothing to propagate",
+			setValues: false,
+			wantKey:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewContextPropagator()
+			header := newTestHeader()
+
+			workflowFn := func(ctx workflow.Context) error {
+				if tc.setValues {
+					ctx = workflow.WithValue(ctx, PropagateKey, tc.values)
+				}
+
+				return p.InjectFromWorkflow(ctx, header)
+			}
+
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.ExecuteWorkflow(workflowFn)
+
+			require.True(t, env.IsWorkflowCompleted())
+			require.NoError(t, env.GetWorkflowError())
+
+			_, ok := header.Get(HeaderKey)
+			require.Equal(t, tc.wantKey, ok)
+
+			if !tc.wantKey {
+				return
+			}
+
+			// The injected payload must be readable by the non-workflow side.
+			ctx, err := p.Extract(context.Background(), header)
+			require.NoError(t, err)
+			assert.Equal(t, tc.values, ctx.Value(PropagateKey))
+		})
+	}
+}
+
+func TestPropagator_ExtractToWorkflow(t *testing.T) {
+	values := map[string]any{
+		CorrelationID: "corr-789",
+		"tenant":      "acme",
+	}
+
+	populated := newTestHeader()
+	require.NoError(t, NewContextPropagator().Inject(
+		context.WithValue(context.Background(), PropagateKey, values), populated,
+	))
+
+	malformed := newTestHeader()
+	malformed.Set(HeaderKey, malformedPayload())
+
+	tests := []struct {
+		name    string
+		header  *testHeader
+		want    map[string]any
+		wantErr bool
+	}{
+		{name: "propagated values are readable from the workflow context", header: populated, want: values},
+		{name: "no header leaves the workflow context untouched", header: newTestHeader()},
+		{name: "malformed payload is reported", header: malformed, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewContextPropagator()
+
+			workflowFn := func(ctx workflow.Context) (map[string]any, error) {
+				ctx, err := p.ExtractToWorkflow(ctx, tc.header)
+				if err != nil {
+					return nil, err
+				}
+
+				values, _ := ctx.Value(PropagateKey).(map[string]any)
+
+				return values, nil
+			}
+
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.ExecuteWorkflow(workflowFn)
+
+			require.True(t, env.IsWorkflowCompleted())
+
+			if tc.wantErr {
+				assert.Error(t, env.GetWorkflowError())
+
+				return
+			}
+
+			require.NoError(t, env.GetWorkflowError())
+
+			var got map[string]any
+			require.NoError(t, env.GetWorkflowResult(&got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestPropagator_WorkflowContextIsPopulatedByTemporal exercises the propagator
+// through the SDK itself rather than by calling it directly.
+func TestPropagator_WorkflowContextIsPopulatedByTemporal(t *testing.T) {
+	values := map[string]any{CorrelationID: "corr-sdk"}
+
+	written := newTestHeader()
+	require.NoError(t, NewContextPropagator().Inject(
+		context.WithValue(context.Background(), PropagateKey, values), written,
+	))
+
+	workflowFn := func(ctx workflow.Context) (map[string]any, error) {
+		propagated, _ := ctx.Value(PropagateKey).(map[string]any)
+
+		return propagated, nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetContextPropagators([]workflow.ContextPropagator{NewContextPropagator()})
+	env.SetHeader(&commonpb.Header{Fields: written.fields})
+	env.ExecuteWorkflow(workflowFn)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var got map[string]any
+	require.NoError(t, env.GetWorkflowResult(&got))
+	assert.Equal(t, values, got)
+}

--- a/pkg/interceptors/activity.go
+++ b/pkg/interceptors/activity.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interceptors
+
+import (
+	"go.temporal.io/sdk/interceptor"
+)
+
+type activityInboundInterceptor struct {
+	interceptor.ActivityInboundInterceptorBase
+}
+
+type activityOutboundInterceptor struct {
+	interceptor.ActivityOutboundInterceptorBase
+}
+
+func (a *activityInboundInterceptor) Init(outbound interceptor.ActivityOutboundInterceptor) error {
+	return a.Next.Init(&activityOutboundInterceptor{
+		ActivityOutboundInterceptorBase: interceptor.ActivityOutboundInterceptorBase{
+			Next: outbound,
+		},
+	})
+}

--- a/pkg/interceptors/logger.go
+++ b/pkg/interceptors/logger.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interceptors
+
+import (
+	"context"
+
+	"github.com/zigflow/zigflow/pkg/ctxpropagator"
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+)
+
+// Hook into the activity interceptor
+func (a *activityOutboundInterceptor) GetLogger(ctx context.Context) log.Logger {
+	base := a.Next.GetLogger(ctx)
+
+	return newLogger(ctx, base)
+}
+
+// Hook into the workflow interceptor
+func (w *workflowOutboundInterceptor) GetLogger(
+	ctx workflow.Context,
+) log.Logger {
+	base := w.Next.GetLogger(ctx)
+
+	return newLogger(ctx, base)
+}
+
+type logContext interface {
+	Value(any) any
+}
+
+type loggerInterceptor struct {
+	interceptor.WorkerInterceptorBase
+}
+
+func (w *loggerInterceptor) InterceptActivity(
+	ctx context.Context, next interceptor.ActivityInboundInterceptor,
+) interceptor.ActivityInboundInterceptor {
+	return &activityInboundInterceptor{
+		ActivityInboundInterceptorBase: interceptor.ActivityInboundInterceptorBase{
+			Next: next,
+		},
+	}
+}
+
+func (w *loggerInterceptor) InterceptWorkflow(
+	ctx workflow.Context, next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	return &workflowInboundInterceptor{
+		WorkflowInboundInterceptorBase: interceptor.WorkflowInboundInterceptorBase{
+			Next: next,
+		},
+	}
+}
+
+func newLogger(ctx logContext, base log.Logger) log.Logger {
+	// Search for context propagator data
+	values, ok := ctx.Value(ctxpropagator.PropagateKey).(map[string]any)
+	if !ok {
+		return base
+	}
+
+	// Search for correlation ID
+	correlationIDAny, ok := values[ctxpropagator.CorrelationID]
+	if !ok {
+		return base
+	}
+
+	// Check it's a string
+	correlationID, ok := correlationIDAny.(string)
+	if !ok {
+		return base
+	}
+
+	// Return our custom logger
+	return &logger{
+		base:          base,
+		correlationID: correlationID,
+	}
+}
+
+type logger struct {
+	base          log.Logger
+	correlationID string
+}
+
+func (l *logger) toLoggerKeyvals(keyvals []any) []any {
+	return append([]any{
+		ctxpropagator.CorrelationID,
+		l.correlationID,
+	}, keyvals...)
+}
+
+func (l *logger) Debug(msg string, keyvals ...any) {
+	l.base.Debug(msg, l.toLoggerKeyvals(keyvals)...)
+}
+
+func (l *logger) Error(msg string, keyvals ...any) {
+	l.base.Error(msg, l.toLoggerKeyvals(keyvals)...)
+}
+
+func (l *logger) Info(msg string, keyvals ...any) {
+	l.base.Info(msg, l.toLoggerKeyvals(keyvals)...)
+}
+
+func (l *logger) Warn(msg string, keyvals ...any) {
+	l.base.Warn(msg, l.toLoggerKeyvals(keyvals)...)
+}
+
+var _ log.Logger = &logger{}
+
+func NewLoggerInterceptor() interceptor.WorkerInterceptor {
+	return &loggerInterceptor{}
+}

--- a/pkg/interceptors/logger_test.go
+++ b/pkg/interceptors/logger_test.go
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interceptors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/ctxpropagator"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	sdkinterceptor "go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	testCorrelationID = "corr-123"
+	testMessage       = "a log message"
+	testTenantKey     = "tenant"
+	testTenant        = "acme"
+)
+
+type logCall struct {
+	level   string
+	msg     string
+	keyvals []any
+}
+
+// recordingLogger captures everything written to it so tests can assert on the
+// key/value pairs the interceptor adds.
+type recordingLogger struct {
+	calls []logCall
+}
+
+func (l *recordingLogger) record(level, msg string, keyvals []any) {
+	l.calls = append(l.calls, logCall{level: level, msg: msg, keyvals: keyvals})
+}
+
+func (l *recordingLogger) Debug(msg string, keyvals ...any) { l.record("debug", msg, keyvals) }
+func (l *recordingLogger) Error(msg string, keyvals ...any) { l.record("error", msg, keyvals) }
+func (l *recordingLogger) Info(msg string, keyvals ...any)  { l.record("info", msg, keyvals) }
+func (l *recordingLogger) Warn(msg string, keyvals ...any)  { l.record("warn", msg, keyvals) }
+
+var _ log.Logger = (*recordingLogger)(nil)
+
+// keyval returns the value logged against key, and whether it was present.
+func keyval(keyvals []any, key string) (any, bool) {
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if k, ok := keyvals[i].(string); ok && k == key {
+			return keyvals[i+1], true
+		}
+	}
+
+	return nil, false
+}
+
+func TestNewLogger_CorrelationID(t *testing.T) {
+	tests := []struct {
+		name       string
+		propagated any
+		setValue   bool
+		want       bool
+	}{
+		{
+			name:     "no propagated values",
+			setValue: false,
+		},
+		{
+			name:       "propagated values are not a map",
+			propagated: "not-a-map",
+			setValue:   true,
+		},
+		{
+			name:       "propagated values without a correlation ID",
+			propagated: map[string]any{testTenantKey: testTenant},
+			setValue:   true,
+		},
+		{
+			name:       "correlation ID is not a string",
+			propagated: map[string]any{ctxpropagator.CorrelationID: 42},
+			setValue:   true,
+		},
+		{
+			name:       "correlation ID is present",
+			propagated: map[string]any{ctxpropagator.CorrelationID: testCorrelationID},
+			setValue:   true,
+			want:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.setValue {
+				ctx = context.WithValue(ctx, ctxpropagator.PropagateKey, tc.propagated)
+			}
+
+			base := &recordingLogger{}
+			newLogger(ctx, base).Info(testMessage, "extra", "value")
+
+			require.Len(t, base.calls, 1)
+			call := base.calls[0]
+			assert.Equal(t, testMessage, call.msg)
+
+			// Caller-supplied key/value pairs must always survive.
+			extra, ok := keyval(call.keyvals, "extra")
+			assert.True(t, ok, "caller key/value pairs must be preserved")
+			assert.Equal(t, "value", extra)
+
+			correlationID, ok := keyval(call.keyvals, ctxpropagator.CorrelationID)
+			require.Equal(t, tc.want, ok)
+
+			if tc.want {
+				assert.Equal(t, testCorrelationID, correlationID)
+			}
+		})
+	}
+}
+
+func TestNewLogger_ForwardsEveryLevel(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxpropagator.PropagateKey, map[string]any{
+		ctxpropagator.CorrelationID: testCorrelationID,
+	})
+
+	tests := []struct {
+		name  string
+		level string
+		logFn func(log.Logger, string, ...any)
+	}{
+		{"debug", "debug", log.Logger.Debug},
+		{"info", "info", log.Logger.Info},
+		{"warn", "warn", log.Logger.Warn},
+		{"error", "error", log.Logger.Error},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := &recordingLogger{}
+			tc.logFn(newLogger(ctx, base), testMessage, "extra", "value")
+
+			require.Len(t, base.calls, 1)
+			call := base.calls[0]
+
+			assert.Equal(t, tc.level, call.level)
+			assert.Equal(t, testMessage, call.msg)
+			assert.Equal(t, []any{
+				ctxpropagator.CorrelationID, testCorrelationID,
+				"extra", "value",
+			}, call.keyvals)
+		})
+	}
+}
+
+func TestNewLogger_WithoutKeyvals(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxpropagator.PropagateKey, map[string]any{
+		ctxpropagator.CorrelationID: testCorrelationID,
+	})
+
+	base := &recordingLogger{}
+	newLogger(ctx, base).Warn(testMessage)
+
+	require.Len(t, base.calls, 1)
+	assert.Equal(t, []any{ctxpropagator.CorrelationID, testCorrelationID}, base.calls[0].keyvals)
+}
+
+// headerWithCorrelationID builds a Temporal header carrying propagated values,
+// as an upstream caller would.
+func headerWithCorrelationID(t *testing.T, values map[string]any) *commonpb.Header {
+	t.Helper()
+
+	payload, err := converter.GetDefaultDataConverter().ToPayload(values)
+	require.NoError(t, err)
+
+	return &commonpb.Header{
+		Fields: map[string]*commonpb.Payload{ctxpropagator.HeaderKey: payload},
+	}
+}
+
+func loggingWorkflow(ctx workflow.Context) error {
+	workflow.GetLogger(ctx).Info(testMessage, "extra", "value")
+
+	return nil
+}
+
+func TestLoggerInterceptor_WorkflowLogger(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]any
+		want   bool
+	}{
+		{
+			name:   "correlation ID is added when propagated",
+			values: map[string]any{ctxpropagator.CorrelationID: testCorrelationID},
+			want:   true,
+		},
+		{
+			name:   "correlation ID is omitted when not propagated",
+			values: map[string]any{testTenantKey: testTenant},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := &recordingLogger{}
+
+			var suite testsuite.WorkflowTestSuite
+			suite.SetLogger(base)
+
+			env := suite.NewTestWorkflowEnvironment()
+			env.SetWorkerOptions(worker.Options{
+				Interceptors: []sdkinterceptor.WorkerInterceptor{NewLoggerInterceptor()},
+			})
+			env.SetContextPropagators([]workflow.ContextPropagator{ctxpropagator.NewContextPropagator()})
+			env.SetHeader(headerWithCorrelationID(t, tc.values))
+
+			env.ExecuteWorkflow(loggingWorkflow)
+
+			require.True(t, env.IsWorkflowCompleted())
+			require.NoError(t, env.GetWorkflowError())
+
+			var call *logCall
+			for i := range base.calls {
+				if base.calls[i].msg == testMessage {
+					call = &base.calls[i]
+				}
+			}
+			require.NotNil(t, call, "the workflow's log call should reach the underlying logger")
+
+			extra, ok := keyval(call.keyvals, "extra")
+			assert.True(t, ok, "caller key/value pairs must be preserved")
+			assert.Equal(t, "value", extra)
+
+			correlationID, ok := keyval(call.keyvals, ctxpropagator.CorrelationID)
+			require.Equal(t, tc.want, ok)
+
+			if tc.want {
+				assert.Equal(t, testCorrelationID, correlationID)
+			}
+		})
+	}
+}
+
+func loggingActivity(ctx context.Context) error {
+	activity.GetLogger(ctx).Info(testMessage, "extra", "value")
+
+	return nil
+}
+
+func TestLoggerInterceptor_ActivityLogger(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]any
+		want   bool
+	}{
+		{
+			name:   "correlation ID is added when propagated",
+			values: map[string]any{ctxpropagator.CorrelationID: testCorrelationID},
+			want:   true,
+		},
+		{
+			name:   "correlation ID is omitted when not propagated",
+			values: map[string]any{testTenantKey: testTenant},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := &recordingLogger{}
+
+			var suite testsuite.WorkflowTestSuite
+			suite.SetLogger(base)
+
+			env := suite.NewTestActivityEnvironment()
+			env.SetWorkerOptions(worker.Options{
+				Interceptors: []sdkinterceptor.WorkerInterceptor{NewLoggerInterceptor()},
+			})
+			env.SetContextPropagators([]workflow.ContextPropagator{ctxpropagator.NewContextPropagator()})
+			env.SetHeader(headerWithCorrelationID(t, tc.values))
+			env.RegisterActivity(loggingActivity)
+
+			_, err := env.ExecuteActivity(loggingActivity)
+			require.NoError(t, err)
+
+			var call *logCall
+			for i := range base.calls {
+				if base.calls[i].msg == testMessage {
+					call = &base.calls[i]
+				}
+			}
+			require.NotNil(t, call, "the activity's log call should reach the underlying logger")
+
+			extra, ok := keyval(call.keyvals, "extra")
+			assert.True(t, ok, "caller key/value pairs must be preserved")
+			assert.Equal(t, "value", extra)
+
+			correlationID, ok := keyval(call.keyvals, ctxpropagator.CorrelationID)
+			require.Equal(t, tc.want, ok)
+
+			if tc.want {
+				assert.Equal(t, testCorrelationID, correlationID)
+			}
+		})
+	}
+}

--- a/pkg/interceptors/workflow.go
+++ b/pkg/interceptors/workflow.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interceptors
+
+import (
+	"go.temporal.io/sdk/interceptor"
+)
+
+type workflowInboundInterceptor struct {
+	interceptor.WorkflowInboundInterceptorBase
+}
+
+type workflowOutboundInterceptor struct {
+	interceptor.WorkflowOutboundInterceptorBase
+}
+
+func (w *workflowInboundInterceptor) Init(
+	outbound interceptor.WorkflowOutboundInterceptor,
+) error {
+	return w.Next.Init(&workflowOutboundInterceptor{
+		WorkflowOutboundInterceptorBase: interceptor.WorkflowOutboundInterceptorBase{
+			Next: outbound,
+		},
+	})
+}

--- a/pkg/utils/expression_determinism.go
+++ b/pkg/utils/expression_determinism.go
@@ -87,11 +87,12 @@ func IsExpressionDeterministic(expr string) bool {
 // evaluation from workflow State. Reading these values is always replay-safe
 // because they come from workflow history.
 var stateVars = map[string]struct{}{
-	"$context": {},
-	"$data":    {},
-	"$env":     {},
-	"$input":   {},
-	"$output":  {},
+	"$context":    {},
+	"$data":       {},
+	"$env":        {},
+	"$input":      {},
+	"$output":     {},
+	"$propagated": {},
 }
 
 // nonDeterministicReasons lists symbols that are explicitly non-deterministic

--- a/pkg/utils/expression_determinism_test.go
+++ b/pkg/utils/expression_determinism_test.go
@@ -43,6 +43,7 @@ func TestAnalyseExpressionDeterminism_Deterministic(t *testing.T) {
 		{"identity", "${ . }"},
 		{"context access", "${ $context.user.id }"},
 		{"input access", "${ $input.name }"},
+		{"propagated access", "${ $propagated.correlationId }"},
 		{"map over state", "${ $data.items | map(. * 2) }"},
 		{"select over state", "${ $data.items[] | select(.active) }"},
 		{"object literal from state", `${ {name: $data.name, age: $data.age} }`},

--- a/pkg/utils/state.go
+++ b/pkg/utils/state.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	swUtils "github.com/open-workflow-specification/sdk-go/v4/impl/utils"
+	"github.com/zigflow/zigflow/pkg/ctxpropagator"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/workflow"
 )
@@ -32,12 +33,13 @@ const (
 )
 
 type State struct {
-	CANStartFrom *string        `json:"canStartFrom,omitempty"` // Continue-as-new from here
-	Context      any            `json:"context"`                // Output data exported to later tasks output
-	Data         map[string]any `json:"data"`                   // Data stored along the way
-	Env          map[string]any `json:"env"`                    // Available environment variables
-	Input        any            `json:"input,omitempty"`        // The input given by the caller
-	Output       any            `json:"output"`                 // What will be output to the caller
+	CANStartFrom      *string        `json:"canStartFrom,omitempty"` // Continue-as-new from here
+	Context           any            `json:"context"`                // Output data exported to later tasks output
+	ContextPropagator map[string]any `json:"contextPropagator"`      // Data sent via the context propagator
+	Data              map[string]any `json:"data"`                   // Data stored along the way
+	Env               map[string]any `json:"env"`                    // Available environment variables
+	Input             any            `json:"input,omitempty"`        // The input given by the caller
+	Output            any            `json:"output"`                 // What will be output to the caller
 }
 
 func (s *State) init() *State {
@@ -47,7 +49,15 @@ func (s *State) init() *State {
 	if s.Data == nil {
 		s.Data = map[string]any{}
 	}
+	s.ContextPropagator = map[string]any{}
 
+	return s
+}
+
+func (s *State) AddContextPropagator(ctx workflow.Context) *State {
+	if val, ok := ctx.Value(ctxpropagator.PropagateKey).(map[string]any); ok {
+		s.ContextPropagator = val
+	}
 	return s
 }
 
@@ -150,6 +160,7 @@ func (s *State) Clone() *State {
 	s1 := NewState()
 
 	s1.Context = swUtils.DeepCloneValue(s.Context)
+	s1.ContextPropagator = swUtils.DeepClone(s.ContextPropagator)
 	s1.Data = swUtils.DeepClone(s.Data)
 	s1.Env = swUtils.DeepClone(s.Env)
 	s1.Input = swUtils.DeepCloneValue(s.Input)
@@ -163,11 +174,12 @@ func (s *State) GetAsMap() map[string]any {
 	s1 := s.Clone()
 
 	return map[string]any{
-		"$context": s1.Context,
-		"$data":    s1.Data,
-		"$env":     s1.Env,
-		"$input":   s1.Input,
-		"$output":  s1.Output,
+		"$context":    s1.Context,
+		"$data":       s1.Data,
+		"$env":        s1.Env,
+		"$input":      s1.Input,
+		"$output":     s1.Output,
+		"$propagated": s1.ContextPropagator,
 	}
 }
 

--- a/pkg/utils/state_test.go
+++ b/pkg/utils/state_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/ctxpropagator"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
@@ -171,4 +172,113 @@ func TestAddActivityInfo_SetsRFC3339Now(t *testing.T) {
 
 	_, err = time.Parse(time.RFC3339, now)
 	assert.NoError(t, err, "$data.activity.now must be RFC3339-formatted")
+}
+
+const testCorrelationID = "corr-123"
+
+func TestAddContextPropagator(t *testing.T) {
+	tests := []struct {
+		name       string
+		propagated any
+		setValue   bool
+		want       map[string]any
+	}{
+		{
+			name:       "copies propagated values onto the state",
+			propagated: map[string]any{ctxpropagator.CorrelationID: testCorrelationID, "tenant": "acme"},
+			setValue:   true,
+			want:       map[string]any{ctxpropagator.CorrelationID: testCorrelationID, "tenant": "acme"},
+		},
+		{
+			name:     "leaves an empty map when nothing was propagated",
+			setValue: false,
+			want:     map[string]any{},
+		},
+		{
+			name:       "ignores a propagated value that is not a map",
+			propagated: "not-a-map",
+			setValue:   true,
+			want:       map[string]any{},
+		},
+		{
+			name:       "ignores a propagated map of the wrong type",
+			propagated: map[string]string{ctxpropagator.CorrelationID: testCorrelationID},
+			setValue:   true,
+			want:       map[string]any{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workflowFn := func(ctx workflow.Context) (map[string]any, error) {
+				if tc.setValue {
+					ctx = workflow.WithValue(ctx, ctxpropagator.PropagateKey, tc.propagated)
+				}
+
+				// An unexpected value must neither panic nor leave the
+				// state unusable, so read it back through GetAsMap.
+				return NewState().AddContextPropagator(ctx).GetAsMap(), nil
+			}
+
+			testSuite := &testsuite.WorkflowTestSuite{}
+			env := testSuite.NewTestWorkflowEnvironment()
+			env.ExecuteWorkflow(workflowFn)
+
+			require.True(t, env.IsWorkflowCompleted())
+			require.NoError(t, env.GetWorkflowError())
+
+			got := map[string]any{}
+			require.NoError(t, env.GetWorkflowResult(&got))
+
+			assert.Equal(t, tc.want, got["$propagated"])
+			assert.Equal(t, map[string]any{}, got["$data"])
+			assert.Equal(t, map[string]any{}, got["$env"])
+		})
+	}
+}
+
+func TestNewState_ContextPropagatorDefaultsToEmptyMap(t *testing.T) {
+	assert.Equal(t, map[string]any{}, NewState().ContextPropagator)
+}
+
+func TestState_GetAsMap_ExposesPropagated(t *testing.T) {
+	// Runtime expressions read propagated values as $propagated.
+	workflowFn := func(ctx workflow.Context) (map[string]any, error) {
+		ctx = workflow.WithValue(ctx, ctxpropagator.PropagateKey, map[string]any{
+			ctxpropagator.CorrelationID: testCorrelationID,
+		})
+
+		return NewState().AddContextPropagator(ctx).GetAsMap(), nil
+	}
+
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var asMap map[string]any
+	require.NoError(t, env.GetWorkflowResult(&asMap))
+
+	assert.Equal(t, map[string]any{ctxpropagator.CorrelationID: testCorrelationID}, asMap["$propagated"])
+}
+
+func TestState_GetAsMap_PropagatedIsEmptyWhenUnset(t *testing.T) {
+	assert.Equal(t, map[string]any{}, NewState().GetAsMap()["$propagated"])
+}
+
+func TestState_Clone_PreservesContextPropagator(t *testing.T) {
+	s := NewState()
+	s.ContextPropagator = map[string]any{ctxpropagator.CorrelationID: testCorrelationID}
+
+	clone := s.Clone()
+	require.Equal(t, s.ContextPropagator, clone.ContextPropagator)
+
+	// The clone owns its propagated values: mutating them must not reach
+	// back into the state it was cloned from.
+	clone.ContextPropagator[ctxpropagator.CorrelationID] = "corr-mutated"
+	clone.ContextPropagator["added"] = true
+
+	assert.Equal(t, map[string]any{ctxpropagator.CorrelationID: testCorrelationID}, s.ContextPropagator)
 }

--- a/pkg/zigflow/tasks/task_builder_do.go
+++ b/pkg/zigflow/tasks/task_builder_do.go
@@ -209,7 +209,9 @@ func (t *DoTaskBuilder) workflowExecutor(tasks []workflowFunc) TemporalWorkflowF
 
 		if state == nil {
 			logger.Debug("Creating new state instance")
-			state = utils.NewState().AddWorkflowInfo(ctx)
+			state = utils.NewState().
+				AddWorkflowInfo(ctx).
+				AddContextPropagator(ctx)
 			state.Env = t.opts.Envvars
 			state.Input = input
 

--- a/pkg/zigflow/tasks/task_builder_do_test.go
+++ b/pkg/zigflow/tasks/task_builder_do_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/ctxpropagator"
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/flow"
 	"go.temporal.io/sdk/activity"
@@ -727,4 +729,64 @@ func (m *WorkflowRegistryMock) Stop() {
 
 func (m *WorkflowRegistryMock) RegisterWorkflowWithOptions(w any, opts workflow.RegisterOptions) {
 	m.Called(w, opts)
+}
+
+// The do-task seeds new state from the workflow context, so values carried by
+// the context propagator must be visible to tasks as $propagated.
+func TestDoTaskBuilderWorkflowExecutorAddsContextPropagator(t *testing.T) {
+	tests := []struct {
+		name       string
+		propagated map[string]any
+		setValue   bool
+		want       map[string]any
+	}{
+		{
+			name:       "propagated values reach the task state",
+			propagated: map[string]any{ctxpropagator.CorrelationID: "corr-123"},
+			setValue:   true,
+			want:       map[string]any{ctxpropagator.CorrelationID: "corr-123"},
+		},
+		{
+			name:     "no propagated values leaves an empty map",
+			setValue: false,
+			want:     map[string]any{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := &DoTaskBuilder{
+				builder: builder[*model.DoTask]{
+					doc:          testWorkflow,
+					eventEmitter: testEvents,
+					name:         "test-workflow",
+					task:         &model.DoTask{},
+				},
+			}
+
+			var capturedState *utils.State
+			runOrder := make([]string, 0, 2)
+			wf := builder.workflowExecutor(newOutputWorkflowFuncs(&runOrder, &capturedState))
+
+			var s testsuite.WorkflowTestSuite
+			env := s.NewTestWorkflowEnvironment()
+
+			workflowName := "propagated-" + tc.name
+			env.RegisterWorkflowWithOptions(func(ctx workflow.Context) (any, error) {
+				if tc.setValue {
+					ctx = workflow.WithValue(ctx, ctxpropagator.PropagateKey, tc.propagated)
+				}
+
+				return wf(ctx, map[string]any{}, nil)
+			}, workflow.RegisterOptions{Name: workflowName})
+
+			env.ExecuteWorkflow(workflowName)
+
+			require.NoError(t, env.GetWorkflowError())
+			require.NotNil(t, capturedState)
+
+			assert.Equal(t, tc.want, capturedState.ContextPropagator)
+			assert.Equal(t, tc.want, capturedState.GetAsMap()["$propagated"])
+		})
+	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds support for [context propagation](https://docs.temporal.io/develop/go/best-practices/context-propagation) and examples for Go, Python and TypeScript.

If it includes a key called `correlationId`, this will be added to all log calls. This allows Temporal calls to be correlated to the wider distributed system calls.

## Related issue
<!-- Most changes should be discussed in an issue before implementation. -->
<!-- Link the issue using Fixes #..., Closes #... or Relates to #... -->
<!-- If no issue exists, explain why. -->

Fixes #558 

## How to test

<!-- Provide the steps used to verify this change -->

## Checklist

* [x] This PR links to an issue using `Fixes #...`, `Closes #...` or `Relates to #...`
* [x] All tests pass
* [x] Tests have been added or updated where behaviour changed
* [x] Documentation has been updated where needed
